### PR TITLE
chore: improve zombienet config

### DIFF
--- a/networks/rococo.toml
+++ b/networks/rococo.toml
@@ -16,7 +16,7 @@ default_command = "./bin/polkadot"
 
 [[parachains]]
 id = 909
+default_command = "./target/release/pop-node"
 
     [[parachains.collators]]
     name = "pop"
-    command = "./target/release/pop-node"


### PR DESCRIPTION
Simply moves the `command` to launch a parachain to the `default_command` setting for the parachain. 

Note: This is primarily motivated by pop cli support and has not been tested with legacy zombienet.