### PR TITLE
ci: grant write permission to actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,8 @@ jobs:
   clippy:
     needs: lint
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     env:
       SKIP_WASM_BUILD: 1
     steps:


### PR DESCRIPTION
Grants permission to the workflow to annotate the checks with any clippy warnings.