### PR TITLE
feat(pop-api): further implementation of nfts api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9033,6 +9033,7 @@ dependencies = [
 name = "pop-api"
 version = "0.0.0"
 dependencies = [
+ "enumflags2",
  "ink",
  "parity-scale-codec",
  "pop-api-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9046,6 +9046,7 @@ dependencies = [
 name = "pop-api-primitives"
 version = "0.0.0"
 dependencies = [
+ "bounded-collections 0.1.9",
  "parity-scale-codec",
  "scale-info",
 ]

--- a/contracts/pop-api-examples/nfts/lib.rs
+++ b/contracts/pop-api-examples/nfts/lib.rs
@@ -5,63 +5,63 @@ use pop_api::nfts;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub enum ContractError {
-    NftsError(nfts::Error),
+	NftsError(nfts::Error),
 }
 
 impl From<nfts::Error> for ContractError {
-    fn from(value: nfts::Error) -> Self {
-        ContractError::NftsError(value)
-    }
+	fn from(value: nfts::Error) -> Self {
+		ContractError::NftsError(value)
+	}
 }
 
 #[ink::contract(env = pop_api::Environment)]
 mod pop_api_extension_demo {
-    use super::ContractError;
+	use super::ContractError;
 
-    #[ink(storage)]
-    #[derive(Default)]
-    pub struct PopApiExtensionDemo;
+	#[ink(storage)]
+	#[derive(Default)]
+	pub struct PopApiExtensionDemo;
 
-    impl PopApiExtensionDemo {
-        #[ink(constructor, payable)]
-        pub fn new() -> Self {
-            ink::env::debug_println!("PopApiExtensionDemo::new");
-            Default::default()
-        }
+	impl PopApiExtensionDemo {
+		#[ink(constructor, payable)]
+		pub fn new() -> Self {
+			ink::env::debug_println!("PopApiExtensionDemo::new");
+			Default::default()
+		}
 
-        #[ink(message)]
-        pub fn mint_through_runtime(
-            &mut self,
-            collection_id: u32,
-            item_id: u32,
-            receiver: AccountId,
-        ) -> Result<(), ContractError> {
-            ink::env::debug_println!("PopApiExtensionDemo::mint_through_runtime: collection_id: {:?} \nitem_id {:?} \nreceiver: {:?}, ", collection_id, item_id, receiver);
+		#[ink(message)]
+		pub fn mint_through_runtime(
+			&mut self,
+			collection_id: u32,
+			item_id: u32,
+			receiver: AccountId,
+		) -> Result<(), ContractError> {
+			ink::env::debug_println!("PopApiExtensionDemo::mint_through_runtime: collection_id: {:?} \nitem_id {:?} \nreceiver: {:?}, ", collection_id, item_id, receiver);
 
-            // simplified API call
-            let result = pop_api::nfts::mint(collection_id, item_id, receiver);
-            ink::env::debug_println!(
-                "PopApiExtensionDemo::mint_through_runtime result: {result:?}"
-            );
-            if let Err(pop_api::nfts::Error::NoConfig) = result {
-                ink::env::debug_println!(
-                    "PopApiExtensionDemo::mint_through_runtime expected error received"
-                );
-            }
-            result?;
+			// simplified API call
+			let result = pop_api::nfts::mint(collection_id, item_id, receiver);
+			ink::env::debug_println!(
+				"PopApiExtensionDemo::mint_through_runtime result: {result:?}"
+			);
+			if let Err(pop_api::nfts::Error::NoConfig) = result {
+				ink::env::debug_println!(
+					"PopApiExtensionDemo::mint_through_runtime expected error received"
+				);
+			}
+			result?;
 
-            ink::env::debug_println!("PopApiExtensionDemo::mint_through_runtime end");
-            Ok(())
-        }
-    }
+			ink::env::debug_println!("PopApiExtensionDemo::mint_through_runtime end");
+			Ok(())
+		}
+	}
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
+	#[cfg(test)]
+	mod tests {
+		use super::*;
 
-        #[ink::test]
-        fn default_works() {
-            PopApiExtensionDemo::new();
-        }
-    }
+		#[ink::test]
+		fn default_works() {
+			PopApiExtensionDemo::new();
+		}
+	}
 }

--- a/pop-api/Cargo.toml
+++ b/pop-api/Cargo.toml
@@ -6,9 +6,10 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+enumflags2 = { version = "0.7.7" }
 ink = { version = "4.3.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.6", default-features = false, features = ["derive"] }
 sp-io = { version = "23.0.0", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
 sp-runtime = { version = "24.0", default-features = false }
 
@@ -22,6 +23,7 @@ crate-type = ["rlib"]
 [features]
 default = ["std"]
 std = [
+    "enumflags2/std",
     "ink/std",
     "pop-api-primitives/std",
     "scale/std",

--- a/pop-api/primitives/Cargo.toml
+++ b/pop-api/primitives/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+bounded-collections = { version = "0.1", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 
@@ -17,6 +18,7 @@ crate-type = ["rlib"]
 [features]
 default = ["std"]
 std = [
+    "bounded-collections/std",
     "scale/std",
     "scale-info/std",
 ]

--- a/pop-api/primitives/src/lib.rs
+++ b/pop-api/primitives/src/lib.rs
@@ -1,3 +1,18 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
+pub use bounded_collections::{BoundedBTreeMap, BoundedBTreeSet, BoundedVec, ConstU32};
+//use scale::{Decode, Encode, MaxEncodedLen};
+
 pub mod storage_keys;
+
+// /// Some way of identifying an account on the chain.
+// #[derive(Encode, Decode, Debug, MaxEncodedLen)]
+// pub struct AccountId([u8; 32]);
+// Id used for identifying non-fungible collections.
+pub type CollectionId = u32;
+// Id used for identifying non-fungible items.
+pub type ItemId = u32;
+/// The maximum length of an attribute key.
+pub type KeyLimit = ConstU32<64>;
+/// The maximum approvals an item could have.
+pub type ApprovalsLimit = ConstU32<20>;

--- a/pop-api/primitives/src/storage_keys.rs
+++ b/pop-api/primitives/src/storage_keys.rs
@@ -1,3 +1,4 @@
+use super::*;
 use scale::{Decode, Encode, MaxEncodedLen};
 
 #[derive(Encode, Decode, Debug, MaxEncodedLen)]
@@ -14,10 +15,20 @@ pub enum ParachainSystemKeys {
 // https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/nfts/src/impl_nonfungibles.rs
 #[derive(Encode, Decode, Debug, MaxEncodedLen)]
 pub enum NftsKeys {
-	Owner,
-	CollectionOwner,
-	Attribute,
-	CustomAttribute,
-	SystemAttribute,
-	CollectionAttribute,
+	// Get the details of a collection.
+	Collection(CollectionId),
+	/// Get the owner of the collection, if the collection exists.
+	CollectionOwner(CollectionId),
+	// Get the details of an item.
+	Item(CollectionId, ItemId),
+	/// Get the owner of the item, if the item exists.
+	Owner(CollectionId, ItemId),
+	/// Get the attribute value of `item` of `collection` corresponding to `key`.
+	Attribute(CollectionId, ItemId, BoundedVec<u8, KeyLimit>),
+	// /// Get the custom attribute value of `item` of `collection` corresponding to `key`.
+	// CustomAttribute(AccountId, CollectionId, ItemId, BoundedVec<u8, KeyLimit>),
+	/// Get the system attribute value of `item` of `collection` corresponding to `key`
+	SystemAttribute(CollectionId, Option<ItemId>, BoundedVec<u8, KeyLimit>),
+	/// Get the attribute value of `item` of `collection` corresponding to `key`.
+	CollectionAttribute(CollectionId, BoundedVec<u8, KeyLimit>),
 }

--- a/pop-api/primitives/src/storage_keys.rs
+++ b/pop-api/primitives/src/storage_keys.rs
@@ -2,10 +2,22 @@ use scale::{Decode, Encode, MaxEncodedLen};
 
 #[derive(Encode, Decode, Debug, MaxEncodedLen)]
 pub enum RuntimeStateKeys {
+	Nfts(NftsKeys),
 	ParachainSystem(ParachainSystemKeys),
 }
 
 #[derive(Encode, Decode, Debug, MaxEncodedLen)]
 pub enum ParachainSystemKeys {
 	LastRelayChainBlockNumber,
+}
+
+// https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/nfts/src/impl_nonfungibles.rs
+#[derive(Encode, Decode, Debug, MaxEncodedLen)]
+pub enum NftsKeys {
+	Owner,
+	CollectionOwner,
+	Attribute,
+	CustomAttribute,
+	SystemAttribute,
+	CollectionAttribute,
 }

--- a/pop-api/src/lib.rs
+++ b/pop-api/src/lib.rs
@@ -6,7 +6,6 @@ pub mod v0;
 use crate::PopApiError::{Balances, Nfts, UnknownStatusCode};
 use ink::{prelude::vec::Vec, ChainExtensionInstance};
 use primitives::storage_keys::*;
-use scale;
 pub use sp_runtime::{BoundedVec, MultiAddress, MultiSignature};
 use v0::RuntimeCall;
 pub use v0::{balances, nfts, relay_chain_block_number, state};

--- a/pop-api/src/lib.rs
+++ b/pop-api/src/lib.rs
@@ -11,17 +11,10 @@ pub use sp_runtime::{BoundedVec, MultiAddress, MultiSignature};
 use v0::RuntimeCall;
 pub use v0::{balances, nfts, state};
 
-// Id used for identifying non-fungible collections.
-pub type CollectionId = u32;
-
-// Id used for identifying non-fungible items.
-pub type ItemId = u32;
-
 type AccountId = <Environment as ink::env::Environment>::AccountId;
 type Balance = <Environment as ink::env::Environment>::Balance;
 type BlockNumber = <Environment as ink::env::Environment>::BlockNumber;
 type StringLimit = u32;
-type KeyLimit = u32;
 type MaxTips = u32;
 
 pub type Result<T> = core::result::Result<T, PopApiError>;

--- a/pop-api/src/lib.rs
+++ b/pop-api/src/lib.rs
@@ -17,9 +17,9 @@ pub type CollectionId = u32;
 // Id used for identifying non-fungible items.
 pub type ItemId = u32;
 
-type AccountId = <ink::env::DefaultEnvironment as ink::env::Environment>::AccountId;
-type Balance = <ink::env::DefaultEnvironment as ink::env::Environment>::Balance;
-type BlockNumber = <ink::env::DefaultEnvironment as ink::env::Environment>::BlockNumber;
+type AccountId = <Environment as ink::env::Environment>::AccountId;
+type Balance = <Environment as ink::env::Environment>::Balance;
+type BlockNumber = <Environment as ink::env::Environment>::BlockNumber;
 type StringLimit = u32;
 type KeyLimit = u32;
 type MaxTips = u32;

--- a/pop-api/src/lib.rs
+++ b/pop-api/src/lib.rs
@@ -9,7 +9,7 @@ use primitives::storage_keys::*;
 use scale;
 pub use sp_runtime::{BoundedVec, MultiAddress, MultiSignature};
 use v0::RuntimeCall;
-pub use v0::{balances, nfts, state};
+pub use v0::{balances, nfts, relay_chain_block_number, state};
 
 type AccountId = <Environment as ink::env::Environment>::AccountId;
 type Balance = <Environment as ink::env::Environment>::Balance;

--- a/pop-api/src/v0/mod.rs
+++ b/pop-api/src/v0/mod.rs
@@ -1,6 +1,17 @@
+use crate::{
+	primitives::storage_keys::{ParachainSystemKeys, RuntimeStateKeys},
+	BlockNumber, PopApiError,
+};
+
 pub mod balances;
 pub mod nfts;
 pub mod state;
+
+pub fn relay_chain_block_number() -> Result<BlockNumber, PopApiError> {
+	Ok(state::read(RuntimeStateKeys::ParachainSystem(
+		ParachainSystemKeys::LastRelayChainBlockNumber,
+	))?)
+}
 
 #[derive(scale::Encode)]
 pub(crate) enum RuntimeCall {

--- a/pop-api/src/v0/mod.rs
+++ b/pop-api/src/v0/mod.rs
@@ -8,9 +8,7 @@ pub mod nfts;
 pub mod state;
 
 pub fn relay_chain_block_number() -> Result<BlockNumber, PopApiError> {
-	Ok(state::read(RuntimeStateKeys::ParachainSystem(
-		ParachainSystemKeys::LastRelayChainBlockNumber,
-	))?)
+	state::read(RuntimeStateKeys::ParachainSystem(ParachainSystemKeys::LastRelayChainBlockNumber))
 }
 
 #[derive(scale::Encode)]

--- a/pop-api/src/v0/nfts.rs
+++ b/pop-api/src/v0/nfts.rs
@@ -1,7 +1,8 @@
 use super::RuntimeCall;
 use crate::{PopApiError::UnknownStatusCode, *};
 use ink::prelude::vec::Vec;
-use primitives::{ApprovalsLimit, BoundedBTreeMap, CollectionId, ItemId, KeyLimit, MultiAddress};
+use primitives::{ApprovalsLimit, BoundedBTreeMap, KeyLimit, MultiAddress};
+pub use primitives::{CollectionId, ItemId};
 use scale::Encode;
 pub use types::*;
 
@@ -675,7 +676,7 @@ mod types {
 	}
 
 	/// Information about a collection.
-	#[derive(Decode)]
+	#[derive(Decode, Debug, Encode, Eq, PartialEq)]
 	pub struct CollectionDetails {
 		/// Collection's owner.
 		pub owner: AccountId,
@@ -715,7 +716,7 @@ mod types {
 	}
 
 	/// Information concerning the ownership of a single unique item.
-	#[derive(Decode)]
+	#[derive(Decode, Debug, Encode, Eq, PartialEq)]
 	pub struct ItemDetails {
 		/// The owner of this item.
 		pub owner: AccountId,

--- a/pop-api/src/v0/nfts.rs
+++ b/pop-api/src/v0/nfts.rs
@@ -3,7 +3,7 @@ use crate::{PopApiError::UnknownStatusCode, *};
 use ink::prelude::vec::Vec;
 use primitives::{ApprovalsLimit, BoundedBTreeMap, CollectionId, ItemId, KeyLimit, MultiAddress};
 use scale::Encode;
-use types::*;
+pub use types::*;
 
 type Result<T> = core::result::Result<T, Error>;
 

--- a/pop-api/src/v0/nfts.rs
+++ b/pop-api/src/v0/nfts.rs
@@ -54,21 +54,6 @@ pub fn redeposit(collection: CollectionId, items: Vec<ItemId>) -> Result<()> {
 	Ok(dispatch(RuntimeCall::Nfts(NftCalls::Redeposit { collection, items }))?)
 }
 
-/// Disallow further unprivileged transfer of an item.
-pub fn lock_item_transfer(collection: CollectionId, item: ItemId) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::LockItemTransfer { collection, item }))?)
-}
-
-/// Re-allow unprivileged transfer of an item.
-pub fn unlock_item_transfer(collection: CollectionId, item: ItemId) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::UnlockItemTransfer { collection, item }))?)
-}
-
-/// Disallows specified settings for the whole collection.
-pub fn lock_colelction(collection: CollectionId, lock_settings: CollectionSettings) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::LockCollection { collection, lock_settings }))?)
-}
-
 /// Change the Owner of a collection.
 pub fn transfer_ownership(
 	collection: CollectionId,
@@ -78,154 +63,6 @@ pub fn transfer_ownership(
 		collection,
 		new_owner: new_owner.into(),
 	}))?)
-}
-
-/// Change the Issuer, Admin and Freezer of a collection.
-pub fn set_team(
-	collection: CollectionId,
-	issuer: Option<impl Into<MultiAddress<AccountId, ()>>>,
-	admin: Option<impl Into<MultiAddress<AccountId, ()>>>,
-	freezer: Option<impl Into<MultiAddress<AccountId, ()>>>,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::SetTeam {
-		collection,
-		issuer: issuer.map(|i| i.into()),
-		admin: admin.map(|i| i.into()),
-		freezer: freezer.map(|i| i.into()),
-	}))?)
-}
-
-/// Approve an item to be transferred by a delegated third-party account.
-pub fn approve_transfer(
-	collection: CollectionId,
-	item: ItemId,
-	delegate: impl Into<MultiAddress<AccountId, ()>>,
-	maybe_deadline: Option<BlockNumber>,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::ApproveTransfer {
-		collection,
-		item,
-		delegate: delegate.into(),
-		maybe_deadline,
-	}))?)
-}
-
-/// Cancel one of the transfer approvals for a specific item.
-pub fn cancel_approval(
-	collection: CollectionId,
-	item: ItemId,
-	delegate: impl Into<MultiAddress<AccountId, ()>>,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::CancelApproval {
-		collection,
-		item,
-		delegate: delegate.into(),
-	}))?)
-}
-
-/// Cancel all the approvals of a specific item.
-pub fn clear_all_transfer_approvals(collection: CollectionId, item: ItemId) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::ClearAllTransferApprovals { collection, item }))?)
-}
-
-/// Disallows changing the metadata or attributes of the item.
-pub fn lock_item_properties(
-	collection: CollectionId,
-	item: ItemId,
-	lock_metadata: bool,
-	lock_attributes: bool,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::LockItemProperties {
-		collection,
-		item,
-		lock_metadata,
-		lock_attributes,
-	}))?)
-}
-
-/// Set an attribute for a collection or item.
-pub fn set_attribute(
-	collection: CollectionId,
-	maybe_item: Option<ItemId>,
-	namespace: AttributeNamespace<AccountId>,
-	key: BoundedVec<u8, KeyLimit>,
-	value: BoundedVec<u8, KeyLimit>,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::SetAttribute {
-		collection,
-		maybe_item,
-		namespace,
-		key,
-		value,
-	}))?)
-}
-
-/// Clear an attribute for a collection or item.
-pub fn clear_attribute(
-	collection: CollectionId,
-	maybe_item: Option<ItemId>,
-	namespace: AttributeNamespace<AccountId>,
-	key: BoundedVec<u8, KeyLimit>,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::ClearAttribute {
-		collection,
-		maybe_item,
-		namespace,
-		key,
-	}))?)
-}
-
-/// Approve item's attributes to be changed by a delegated third-party account.
-pub fn approve_item_attribute(
-	collection: CollectionId,
-	item: ItemId,
-	delegate: impl Into<MultiAddress<AccountId, ()>>,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::ApproveItemAttribute {
-		collection,
-		item,
-		delegate: delegate.into(),
-	}))?)
-}
-
-/// Cancel the previously provided approval to change item's attributes.
-pub fn cancel_item_attributes_approval(
-	collection: CollectionId,
-	item: ItemId,
-	delegate: impl Into<MultiAddress<AccountId, ()>>,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::CancelItemAttributesApproval {
-		collection,
-		item,
-		delegate: delegate.into(),
-	}))?)
-}
-
-/// Set the metadata for an item.
-pub fn set_metadata(
-	collection: CollectionId,
-	item: ItemId,
-	data: BoundedVec<u8, StringLimit>,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::SetMetadata { collection, item, data }))?)
-}
-
-/// Clear the metadata for an item.
-pub fn clear_metadata(collection: CollectionId, item: ItemId) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::ClearMetadata { collection, item }))?)
-}
-
-/// Set the metadata for a collection.
-pub fn set_collection_metadata(
-	collection: CollectionId,
-	data: BoundedVec<u8, StringLimit>,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::SetCollectionMetadata { collection, data }))?)
-}
-
-/// Clear the metadata for a collection.
-pub fn clear_collection_metadata(collection: CollectionId) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::ClearCollectionMetadata { collection }))?)
 }
 
 /// Set (or reset) the acceptance of ownership for a particular account.
@@ -246,61 +83,6 @@ pub fn update_mint_settings(collection: CollectionId, mint_settings: MintSetting
 	Ok(dispatch(RuntimeCall::Nfts(NftCalls::UpdateMintSettings { collection, mint_settings }))?)
 }
 
-/// Set (or reset) the price for an item.
-pub fn price(collection: CollectionId, item: ItemId, price: Option<Balance>) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::Price { collection, item, price }))?)
-}
-
-/// Allows to buy an item if it's up for sale.
-pub fn buy_item(collection: CollectionId, item: ItemId, bid_price: Balance) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::BuyItem { collection, item, bid_price }))?)
-}
-
-/// Allows to pay the tips.
-pub fn pay_tips(tips: BoundedVec<ItemTip, MaxTips>) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::PayTips { tips }))?)
-}
-
-/// Register a new atomic swap, declaring an intention to send an `item` in exchange for
-/// `desired_item` from origin to target on the current chain.
-pub fn create_swap(
-	offered_collection: CollectionId,
-	offered_item: ItemId,
-	desired_collection: CollectionId,
-	maybe_desired_item: Option<ItemId>,
-	maybe_price: Option<PriceWithDirection>,
-	duration: BlockNumber,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::CreateSwap {
-		offered_collection,
-		offered_item,
-		desired_collection,
-		maybe_desired_item,
-		maybe_price,
-		duration,
-	}))?)
-}
-
-/// Cancel an atomic swap.
-pub fn cancel_swap(offered_collection: CollectionId, offered_item: ItemId) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::CancelSwap { offered_collection, offered_item }))?)
-}
-
-/// Claim an atomic swap.
-pub fn claim_swap(
-	send_collection: CollectionId,
-	send_item: ItemId,
-	receive_collection: CollectionId,
-	receive_item: ItemId,
-) -> Result<()> {
-	Ok(dispatch(RuntimeCall::Nfts(NftCalls::ClaimSwap {
-		send_collection,
-		send_item,
-		receive_collection,
-		receive_item,
-	}))?)
-}
-
 /// Get the owner of the item, if the item exists.
 pub fn owner(collection: CollectionId, item: ItemId) -> Result<Option<AccountId>> {
 	Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::Owner(collection, item)))?)
@@ -311,46 +93,6 @@ pub fn collection_owner(collection: CollectionId) -> Result<Option<AccountId>> {
 	Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::CollectionOwner(collection)))?)
 }
 
-/// Get the attribute value of `item` of `collection` corresponding to `key`.
-pub fn attribute(
-	collection: CollectionId,
-	item: ItemId,
-	key: BoundedVec<u8, KeyLimit>,
-) -> Result<Option<Vec<u8>>> {
-	Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::Attribute(collection, item, key)))?)
-}
-
-// /// Get the custom attribute value of `item` of `collection` corresponding to `key`.
-// pub fn custom_attribute(
-// 	account: AccountId,
-// 	collection: CollectionId,
-// 	item: ItemId,
-// 	key: BoundedVec<u8, KeyLimit>,
-// ) -> Result<Option<Vec<u8>>> {
-// 	Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::CustomAttribute(
-// 		account, collection, item, key,
-// 	)))?)
-// }
-
-/// Get the system attribute value of `item` of `collection` corresponding to `key` if
-/// `item` is `Some`. Otherwise, returns the system attribute value of `collection`
-/// corresponding to `key`.
-pub fn system_attribute(
-	collection: CollectionId,
-	item: Option<ItemId>,
-	key: BoundedVec<u8, KeyLimit>,
-) -> Result<Option<Vec<u8>>> {
-	Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::SystemAttribute(collection, item, key)))?)
-}
-
-/// Get the attribute value of `item` of `collection` corresponding to `key`.
-pub fn collection_attribute(
-	collection: CollectionId,
-	key: BoundedVec<u8, KeyLimit>,
-) -> Result<Option<Vec<u8>>> {
-	Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::CollectionAttribute(collection, key)))?)
-}
-
 /// Get the details of a collection.
 pub fn collection(collection: CollectionId) -> Result<Option<CollectionDetails>> {
 	Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::Collection(collection)))?)
@@ -359,6 +101,298 @@ pub fn collection(collection: CollectionId) -> Result<Option<CollectionDetails>>
 /// Get the details of an item.
 pub fn item(collection: CollectionId, item: ItemId) -> Result<Option<ItemDetails>> {
 	Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::Item(collection, item)))?)
+}
+
+pub mod approvals {
+	use super::*;
+
+	/// Approve an item to be transferred by a delegated third-party account.
+	pub fn approve_transfer(
+		collection: CollectionId,
+		item: ItemId,
+		delegate: impl Into<MultiAddress<AccountId, ()>>,
+		maybe_deadline: Option<BlockNumber>,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::ApproveTransfer {
+			collection,
+			item,
+			delegate: delegate.into(),
+			maybe_deadline,
+		}))?)
+	}
+
+	/// Cancel one of the transfer approvals for a specific item.
+	pub fn cancel_approval(
+		collection: CollectionId,
+		item: ItemId,
+		delegate: impl Into<MultiAddress<AccountId, ()>>,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::CancelApproval {
+			collection,
+			item,
+			delegate: delegate.into(),
+		}))?)
+	}
+
+	/// Cancel all the approvals of a specific item.
+	pub fn clear_all_transfer_approvals(collection: CollectionId, item: ItemId) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::ClearAllTransferApprovals { collection, item }))?)
+	}
+}
+
+pub mod attributes {
+	use super::*;
+
+	/// Approve item's attributes to be changed by a delegated third-party account.
+	pub fn approve_item_attribute(
+		collection: CollectionId,
+		item: ItemId,
+		delegate: impl Into<MultiAddress<AccountId, ()>>,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::ApproveItemAttribute {
+			collection,
+			item,
+			delegate: delegate.into(),
+		}))?)
+	}
+
+	/// Cancel the previously provided approval to change item's attributes.
+	pub fn cancel_item_attributes_approval(
+		collection: CollectionId,
+		item: ItemId,
+		delegate: impl Into<MultiAddress<AccountId, ()>>,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::CancelItemAttributesApproval {
+			collection,
+			item,
+			delegate: delegate.into(),
+		}))?)
+	}
+
+	/// Set an attribute for a collection or item.
+	pub fn set_attribute(
+		collection: CollectionId,
+		maybe_item: Option<ItemId>,
+		namespace: AttributeNamespace<AccountId>,
+		key: BoundedVec<u8, KeyLimit>,
+		value: BoundedVec<u8, KeyLimit>,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::SetAttribute {
+			collection,
+			maybe_item,
+			namespace,
+			key,
+			value,
+		}))?)
+	}
+
+	/// Clear an attribute for a collection or item.
+	pub fn clear_attribute(
+		collection: CollectionId,
+		maybe_item: Option<ItemId>,
+		namespace: AttributeNamespace<AccountId>,
+		key: BoundedVec<u8, KeyLimit>,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::ClearAttribute {
+			collection,
+			maybe_item,
+			namespace,
+			key,
+		}))?)
+	}
+
+	/// Get the attribute value of `item` of `collection` corresponding to `key`.
+	pub fn attribute(
+		collection: CollectionId,
+		item: ItemId,
+		key: BoundedVec<u8, KeyLimit>,
+	) -> Result<Option<Vec<u8>>> {
+		Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::Attribute(collection, item, key)))?)
+	}
+
+	// /// Get the custom attribute value of `item` of `collection` corresponding to `key`.
+	// pub fn custom_attribute(
+	// 	account: AccountId,
+	// 	collection: CollectionId,
+	// 	item: ItemId,
+	// 	key: BoundedVec<u8, KeyLimit>,
+	// ) -> Result<Option<Vec<u8>>> {
+	// 	Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::CustomAttribute(
+	// 		account, collection, item, key,
+	// 	)))?)
+	// }
+
+	/// Get the system attribute value of `item` of `collection` corresponding to `key` if
+	/// `item` is `Some`. Otherwise, returns the system attribute value of `collection`
+	/// corresponding to `key`.
+	pub fn system_attribute(
+		collection: CollectionId,
+		item: Option<ItemId>,
+		key: BoundedVec<u8, KeyLimit>,
+	) -> Result<Option<Vec<u8>>> {
+		Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::SystemAttribute(collection, item, key)))?)
+	}
+
+	/// Get the attribute value of `item` of `collection` corresponding to `key`.
+	pub fn collection_attribute(
+		collection: CollectionId,
+		key: BoundedVec<u8, KeyLimit>,
+	) -> Result<Option<Vec<u8>>> {
+		Ok(state::read(RuntimeStateKeys::Nfts(NftsKeys::CollectionAttribute(collection, key)))?)
+	}
+}
+
+pub mod locking {
+	use super::*;
+
+	/// Disallows changing the metadata or attributes of the item.
+	pub fn lock_item_properties(
+		collection: CollectionId,
+		item: ItemId,
+		lock_metadata: bool,
+		lock_attributes: bool,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::LockItemProperties {
+			collection,
+			item,
+			lock_metadata,
+			lock_attributes,
+		}))?)
+	}
+
+	/// Disallow further unprivileged transfer of an item.
+	pub fn lock_item_transfer(collection: CollectionId, item: ItemId) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::LockItemTransfer { collection, item }))?)
+	}
+
+	/// Re-allow unprivileged transfer of an item.
+	pub fn unlock_item_transfer(collection: CollectionId, item: ItemId) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::UnlockItemTransfer { collection, item }))?)
+	}
+
+	/// Disallows specified settings for the whole collection.
+	pub fn lock_collection(
+		collection: CollectionId,
+		lock_settings: CollectionSettings,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::LockCollection { collection, lock_settings }))?)
+	}
+}
+
+pub mod metadata {
+	use super::*;
+
+	/// Set the metadata for an item.
+	pub fn set_metadata(
+		collection: CollectionId,
+		item: ItemId,
+		data: BoundedVec<u8, StringLimit>,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::SetMetadata { collection, item, data }))?)
+	}
+
+	/// Clear the metadata for an item.
+	pub fn clear_metadata(collection: CollectionId, item: ItemId) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::ClearMetadata { collection, item }))?)
+	}
+
+	/// Set the metadata for a collection.
+	pub fn set_collection_metadata(
+		collection: CollectionId,
+		data: BoundedVec<u8, StringLimit>,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::SetCollectionMetadata { collection, data }))?)
+	}
+
+	/// Clear the metadata for a collection.
+	pub fn clear_collection_metadata(collection: CollectionId) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::ClearCollectionMetadata { collection }))?)
+	}
+}
+
+pub mod roles {
+	use super::*;
+
+	/// Change the Issuer, Admin and Freezer of a collection.
+	pub fn set_team(
+		collection: CollectionId,
+		issuer: Option<impl Into<MultiAddress<AccountId, ()>>>,
+		admin: Option<impl Into<MultiAddress<AccountId, ()>>>,
+		freezer: Option<impl Into<MultiAddress<AccountId, ()>>>,
+	) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::SetTeam {
+			collection,
+			issuer: issuer.map(|i| i.into()),
+			admin: admin.map(|i| i.into()),
+			freezer: freezer.map(|i| i.into()),
+		}))?)
+	}
+}
+
+pub mod trading {
+	use super::*;
+
+	/// Allows to pay the tips.
+	pub fn pay_tips(tips: BoundedVec<ItemTip, MaxTips>) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::PayTips { tips }))?)
+	}
+
+	/// Set (or reset) the price for an item.
+	pub fn price(collection: CollectionId, item: ItemId, price: Option<Balance>) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::Price { collection, item, price }))?)
+	}
+
+	/// Allows to buy an item if it's up for sale.
+	pub fn buy_item(collection: CollectionId, item: ItemId, bid_price: Balance) -> Result<()> {
+		Ok(dispatch(RuntimeCall::Nfts(NftCalls::BuyItem { collection, item, bid_price }))?)
+	}
+
+	pub mod swaps {
+		use super::*;
+
+		/// Register a new atomic swap, declaring an intention to send an `item` in exchange for
+		/// `desired_item` from origin to target on the current chain.
+		pub fn create_swap(
+			offered_collection: CollectionId,
+			offered_item: ItemId,
+			desired_collection: CollectionId,
+			maybe_desired_item: Option<ItemId>,
+			maybe_price: Option<PriceWithDirection>,
+			duration: BlockNumber,
+		) -> Result<()> {
+			Ok(dispatch(RuntimeCall::Nfts(NftCalls::CreateSwap {
+				offered_collection,
+				offered_item,
+				desired_collection,
+				maybe_desired_item,
+				maybe_price,
+				duration,
+			}))?)
+		}
+
+		/// Cancel an atomic swap.
+		pub fn cancel_swap(offered_collection: CollectionId, offered_item: ItemId) -> Result<()> {
+			Ok(dispatch(RuntimeCall::Nfts(NftCalls::CancelSwap {
+				offered_collection,
+				offered_item,
+			}))?)
+		}
+
+		/// Claim an atomic swap.
+		pub fn claim_swap(
+			send_collection: CollectionId,
+			send_item: ItemId,
+			receive_collection: CollectionId,
+			receive_item: ItemId,
+		) -> Result<()> {
+			Ok(dispatch(RuntimeCall::Nfts(NftCalls::ClaimSwap {
+				send_collection,
+				send_item,
+				receive_collection,
+				receive_item,
+			}))?)
+		}
+	}
 }
 
 #[derive(Encode)]

--- a/runtime/src/assets_config.rs
+++ b/runtime/src/assets_config.rs
@@ -38,7 +38,9 @@ parameter_types! {
 
 impl pallet_nfts::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	// TODO: source from primitives
 	type CollectionId = CollectionId;
+	// TODO: source from primitives
 	type ItemId = ItemId;
 	type Currency = Balances;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
@@ -50,8 +52,10 @@ impl pallet_nfts::Config for Runtime {
 	type AttributeDepositBase = NftsAttributeDepositBase;
 	type DepositPerByte = NftsDepositPerByte;
 	type StringLimit = ConstU32<256>;
+	// TODO: source from primitives
 	type KeyLimit = ConstU32<64>;
 	type ValueLimit = ConstU32<256>;
+	// TODO: source from primitives
 	type ApprovalsLimit = ConstU32<20>;
 	type ItemAttributesApprovalsLimit = ConstU32<30>;
 	type MaxTips = ConstU32<10>;

--- a/runtime/src/extensions.rs
+++ b/runtime/src/extensions.rs
@@ -4,7 +4,6 @@ use frame_support::{
 	pallet_prelude::*,
 	traits::nonfungibles_v2::Inspect,
 };
-use log;
 use pallet_contracts::chain_extension::{
 	BufInBufOutState, ChainExtension, Environment, Ext, InitState, RetVal, SysConfig,
 };

--- a/runtime/src/extensions.rs
+++ b/runtime/src/extensions.rs
@@ -14,6 +14,7 @@ use pop_api_primitives::{
 };
 use sp_core::crypto::UncheckedFrom;
 use sp_runtime::{traits::Dispatchable, DispatchError};
+use sp_std::vec::Vec;
 
 const LOG_TARGET: &str = "pop-api::extension";
 


### PR DESCRIPTION
Implements the remaining runtime calls that were listed, along with a few queries.

Notes: 
- Removes the offchain signing calls for now.
- Have not implemented those which require AccountId to be added to primitives (e.g. custom attribute). It results in a dependency mismatch between the runtime and that required by ink. Need to find a solution for this.
- Suggest moving `pop-api-primitives` to `pop-primitives` in a separate PR