### PR TITLE
test(pop-api): read_state chain extension test

### DIFF
--- a/pop-api/primitives/src/storage_keys.rs
+++ b/pop-api/primitives/src/storage_keys.rs
@@ -1,11 +1,11 @@
-use scale::{Decode, Encode};
+use scale::{Decode, Encode, MaxEncodedLen};
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encode, Decode, Debug, MaxEncodedLen)]
 pub enum RuntimeStateKeys {
 	ParachainSystem(ParachainSystemKeys),
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encode, Decode, Debug, MaxEncodedLen)]
 pub enum ParachainSystemKeys {
 	LastRelayChainBlockNumber,
 }


### PR DESCRIPTION
Adds test to ensure that read_state chain extension works.

Notes:
- added `MaxEncodedLen` to key types to use `env.read_as()`
- charges a db read for reading the specified key from contract memory, to be replaced once benchmarked
- charges a db read for obtaining the last relay block
- removed unnecessary `pub` modifiers