### PR TITLE
fix(pop-api): read_state uses RelayChainDataProvider

### DIFF
--- a/runtime/src/extensions.rs
+++ b/runtime/src/extensions.rs
@@ -1,5 +1,5 @@
-use cumulus_primitives_core::relay_chain::BlockNumber;
 use cumulus_pallet_parachain_system::RelaychainDataProvider;
+use cumulus_primitives_core::relay_chain::BlockNumber;
 use frame_support::{
 	dispatch::{GetDispatchInfo, RawOrigin},
 	pallet_prelude::*,
@@ -14,7 +14,10 @@ use pop_api_primitives::{
 	CollectionId, ItemId,
 };
 use sp_core::crypto::UncheckedFrom;
-use sp_runtime::{traits::{BlockNumberProvider, Dispatchable}, DispatchError};
+use sp_runtime::{
+	traits::{BlockNumberProvider, Dispatchable},
+	DispatchError,
+};
 use sp_std::{boxed::Box, vec::Vec};
 use xcm::{
 	latest::{prelude::*, OriginKind::SovereignAccount},
@@ -210,7 +213,8 @@ where
 		RuntimeStateKeys::ParachainSystem(key) => match key {
 			ParachainSystemKeys::LastRelayChainBlockNumber => {
 				env.charge_weight(T::DbWeight::get().reads(1_u64))?;
-				let relay_block_num: BlockNumber = RelaychainDataProvider::<T>::current_block_number();
+				let relay_block_num: BlockNumber =
+					RelaychainDataProvider::<T>::current_block_number();
 				log::debug!(
 					target:LOG_TARGET,
 					"{} last relay chain block number is: {:?}.", LOG_PREFIX, relay_block_num

--- a/runtime/src/extensions.rs
+++ b/runtime/src/extensions.rs
@@ -1,4 +1,5 @@
 use cumulus_primitives_core::relay_chain::BlockNumber;
+use cumulus_pallet_parachain_system::RelaychainDataProvider;
 use frame_support::{
 	dispatch::{GetDispatchInfo, RawOrigin},
 	pallet_prelude::*,
@@ -13,7 +14,7 @@ use pop_api_primitives::{
 	CollectionId, ItemId,
 };
 use sp_core::crypto::UncheckedFrom;
-use sp_runtime::{traits::Dispatchable, DispatchError};
+use sp_runtime::{traits::{BlockNumberProvider, Dispatchable}, DispatchError};
 use sp_std::{boxed::Box, vec::Vec};
 use xcm::{
 	latest::{prelude::*, OriginKind::SovereignAccount},
@@ -209,8 +210,7 @@ where
 		RuntimeStateKeys::ParachainSystem(key) => match key {
 			ParachainSystemKeys::LastRelayChainBlockNumber => {
 				env.charge_weight(T::DbWeight::get().reads(1_u64))?;
-				let relay_block_num: BlockNumber =
-					cumulus_pallet_parachain_system::Pallet::<T>::last_relay_block_number();
+				let relay_block_num: BlockNumber = RelaychainDataProvider::<T>::current_block_number();
 				log::debug!(
 					target:LOG_TARGET,
 					"{} last relay chain block number is: {:?}.", LOG_PREFIX, relay_block_num
@@ -608,7 +608,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let _ = env_logger::try_init();
 
-			let (wasm_binary, _) = load_wasm_module::<Runtime>("../contracts/pop-api-examples/read-runtime-state/target/ink/pop_api_extension_demo.wasm").unwrap();
+			let (wasm_binary, _) = load_wasm_module::<Runtime>("../contracts/pop-api-examples/read-runtime-state/target/ink/pop_api_read_state_example.wasm").unwrap();
 
 			let init_value = 100;
 


### PR DESCRIPTION
Use [`RelaychainDataProvider`](https://github.com/paritytech/polkadot-sdk/blob/ea458d0b95d819d31683a8a09ca7973ae10b49be/cumulus/pallets/parachain-system/src/lib.rs#L1715) to retrieve the relay chain block number instead.