### PR TITLE
build(deps): fix pop-runtime default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", b
 substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.1" }
 
 # Local
-pop-runtime = { path = "./runtime", default-features = false }
+pop-runtime = { path = "./runtime", default-features = true } # default-features=true required for `-p pop-node` builds
 pop-primitives = { path = "./primitives", default-features = false }
 
 # Substrate


### PR DESCRIPTION
Fixes an issue when building via `-p pop-node` specifically.