### PR TITLE
feat: network token enforcement

### DIFF
--- a/integration-tests/src/chains/pop_network/genesis.rs
+++ b/integration-tests/src/chains/pop_network/genesis.rs
@@ -1,4 +1,4 @@
-use emulated_integration_tests_common::{accounts, build_genesis_storage, collators};
+use emulated_integration_tests_common::{build_genesis_storage, collators};
 use pop_runtime::Balance;
 use sp_core::storage::Storage;
 
@@ -9,13 +9,7 @@ const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 pub(crate) fn genesis() -> Storage {
 	let genesis_config = pop_runtime::RuntimeGenesisConfig {
 		system: pop_runtime::SystemConfig::default(),
-		balances: pop_runtime::BalancesConfig {
-			balances: accounts::init_balances()
-				.iter()
-				.cloned()
-				.map(|k| (k, ED * 4096 * 4096))
-				.collect(),
-		},
+		balances: pop_runtime::BalancesConfig { ..Default::default() },
 		parachain_info: pop_runtime::ParachainInfoConfig {
 			parachain_id: PARA_ID.into(),
 			..Default::default()

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -239,7 +239,7 @@ fn para_to_relay_reserve_transfer_assets(t: ParaToRelayTest) -> DispatchResult {
 }
 
 // Funds Pop with relay tokens
-fn fund_pop_network(
+fn fund_pop_from_relay(
 	sender: sp_runtime::AccountId32,
 	amount_to_send: Balance,
 	beneficiary: sp_runtime::AccountId32,
@@ -253,6 +253,25 @@ fn fund_pop_network(
 
 	let mut test = RelayToParaTest::new(test_args);
 	test.set_dispatchable::<RococoRelay>(relay_to_para_reserve_transfer_assets);
+	test.assert();
+}
+
+// Funds Pop with relay tokens from system para
+fn fund_pop_from_system_para(
+	sender: sp_runtime::AccountId32,
+	amount_to_send: Balance,
+	beneficiary: sp_runtime::AccountId32,
+	assets: Assets,
+) {
+	let destination = AssetHubRococoPara::sibling_location_of(PopNetworkPara::para_id());
+	let test_args = TestContext {
+		sender,
+		receiver: beneficiary.clone(),
+		args: TestArgs::new_para(destination, beneficiary, amount_to_send, assets, None, 0),
+	};
+
+	let mut test = SystemParaToParaTest::new(test_args);
+	test.set_dispatchable::<AssetHubRococoPara>(system_para_to_para_reserve_transfer_assets);
 	test.assert();
 }
 
@@ -308,17 +327,18 @@ fn reserve_transfer_native_asset_from_para_to_relay() {
 
 	// Setup: reserve transfer from relay to Pop, so that sovereign account accurate for return
 	// transfer
-	let amount_to_send: Balance = ROCOCO_ED * 1000;
-	fund_pop_network(RococoRelaySender::get(), amount_to_send, PopNetworkParaReceiver::get());
+	let amount_to_send: Balance = ROCOCO_ED * 1_000;
+	fund_pop_from_relay(RococoRelaySender::get(), amount_to_send, PopNetworkParaReceiver::get()); // alice on relay > bob on pop
 
 	// Init values for Pop Network Parachain
-	let destination = PopNetworkPara::parent_location();
-	let beneficiary_id = RococoRelayReceiver::get();
+	let destination = PopNetworkPara::parent_location(); // relay
+	let beneficiary_id = RococoRelayReceiver::get(); // bob on relay
+	let amount_to_send = PopNetworkPara::account_data_of(PopNetworkParaReceiver::get()).free; // bob on pop balance
 	let assets = (Parent, amount_to_send).into();
 
 	let test_args = TestContext {
-		sender: PopNetworkParaSender::get(),
-		receiver: RococoRelayReceiver::get(),
+		sender: PopNetworkParaReceiver::get(), // bob on pop
+		receiver: RococoRelayReceiver::get(),  // bob on relay
 		args: TestArgs::new_para(destination, beneficiary_id, amount_to_send, assets, None, 0),
 	};
 
@@ -402,15 +422,24 @@ fn reserve_transfer_native_asset_from_system_para_to_para() {
 fn reserve_transfer_native_asset_from_para_to_system_para() {
 	init_tracing();
 
+	// Setup: reserve transfer from AH to Pop, so that sovereign account accurate for return transfer
+	let amount_to_send: Balance = ASSET_HUB_ROCOCO_ED * 1000;
+	fund_pop_from_system_para(
+		AssetHubRococoParaSender::get(),
+		amount_to_send,
+		PopNetworkParaReceiver::get(),
+		(Parent, amount_to_send).into(),
+	); // alice on asset hub > bob on pop
+
 	// Init values for Pop Network Parachain
 	let destination = PopNetworkPara::sibling_location_of(AssetHubRococoPara::para_id());
-	let beneficiary_id = AssetHubRococoParaReceiver::get();
-	let amount_to_send: Balance = ASSET_HUB_ROCOCO_ED * 1000;
+	let beneficiary_id = AssetHubRococoParaReceiver::get(); // bob on asset hub
+	let amount_to_send = PopNetworkPara::account_data_of(PopNetworkParaReceiver::get()).free; // bob on pop balance
 	let assets = (Parent, amount_to_send).into();
 
 	let test_args = TestContext {
-		sender: PopNetworkParaSender::get(),
-		receiver: AssetHubRococoParaReceiver::get(),
+		sender: PopNetworkParaReceiver::get(),       // bob on pop
+		receiver: AssetHubRococoParaReceiver::get(), // bob on asset hub
 		args: TestArgs::new_para(destination, beneficiary_id, amount_to_send, assets, None, 0),
 	};
 
@@ -424,7 +453,7 @@ fn reserve_transfer_native_asset_from_para_to_system_para() {
 	let sov_pop_net_on_ahr =
 		AssetHubRococoPara::sovereign_account_id_of(pop_net_location_as_seen_by_ahr);
 
-	// fund the Pop Network's SA on AHR with the native tokens held in reserve
+	// fund Pop Network's SA on AHR with the native tokens held in reserve
 	AssetHubRococoPara::fund_accounts(vec![(sov_pop_net_on_ahr.into(), amount_to_send * 2)]);
 
 	test.set_assertion::<PopNetworkPara>(para_to_system_para_sender_assertions);
@@ -459,7 +488,7 @@ fn place_coretime_spot_order_from_para_to_relay() {
 
 	// Setup: reserve transfer from relay to Pop, so that sovereign account accurate for return transfer
 	let amount_to_send: Balance = pop_runtime::UNIT * 1000;
-	fund_pop_network(RococoRelaySender::get(), amount_to_send, beneficiary.clone());
+	fund_pop_from_relay(RococoRelaySender::get(), amount_to_send, beneficiary.clone());
 
 	let message = {
 		let assets: Asset = (Here, 10 * pop_runtime::UNIT).into();

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -93,20 +93,6 @@ pub fn development_config() -> ChainSpec {
 				get_collator_keys_from_seed("Bob"),
 			),
 		],
-		vec![
-			get_account_id_from_seed::<sr25519::Public>("Alice"),
-			get_account_id_from_seed::<sr25519::Public>("Bob"),
-			get_account_id_from_seed::<sr25519::Public>("Charlie"),
-			get_account_id_from_seed::<sr25519::Public>("Dave"),
-			get_account_id_from_seed::<sr25519::Public>("Eve"),
-			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-			get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-		],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		PARA_ID.into(),
 	))
@@ -144,20 +130,6 @@ pub fn local_testnet_config() -> ChainSpec {
 				get_collator_keys_from_seed("Bob"),
 			),
 		],
-		vec![
-			get_account_id_from_seed::<sr25519::Public>("Alice"),
-			get_account_id_from_seed::<sr25519::Public>("Bob"),
-			get_account_id_from_seed::<sr25519::Public>("Charlie"),
-			get_account_id_from_seed::<sr25519::Public>("Dave"),
-			get_account_id_from_seed::<sr25519::Public>("Eve"),
-			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-			get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-		],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		PARA_ID.into(),
 	))
@@ -168,14 +140,10 @@ pub fn local_testnet_config() -> ChainSpec {
 
 fn testnet_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
-	endowed_accounts: Vec<AccountId>,
 	root: AccountId,
 	id: ParaId,
 ) -> serde_json::Value {
 	serde_json::json!({
-		"balances": {
-			"balances": endowed_accounts.iter().cloned().map(|k| (k, 1u64 << 60)).collect::<Vec<_>>(),
-		},
 		"parachainInfo": {
 			"parachainId": id,
 		},

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -37,8 +37,8 @@ use frame_support::{
 	parameter_types,
 	traits::{
 		fungible::HoldConsideration, tokens::nonfungibles_v2::Inspect, ConstBool, ConstU32,
-		ConstU64, ConstU8, EitherOfDiverse, EqualPrivilegeOnly, LinearStoragePrice,
-		TransformOrigin,
+		ConstU64, ConstU8, Contains, EitherOfDiverse, EqualPrivilegeOnly, EverythingBut,
+		LinearStoragePrice, TransformOrigin,
 	},
 	weights::{
 		constants::WEIGHT_REF_TIME_PER_SECOND, ConstantMultiplier, Weight, WeightToFeeCoefficient,
@@ -298,6 +298,23 @@ parameter_types! {
 	pub const SS58Prefix: u16 = 42;
 }
 
+/// A type to identify filtered calls.
+pub struct FilteredCalls;
+impl Contains<RuntimeCall> for FilteredCalls {
+	fn contains(c: &RuntimeCall) -> bool {
+		use BalancesCall::*;
+		matches!(
+			c,
+			RuntimeCall::Balances(
+				force_adjust_total_issuance { .. }
+					| force_set_balance { .. }
+					| force_transfer { .. }
+					| force_unreserve { .. }
+			)
+		)
+	}
+}
+
 /// The default types are being injected by [`derive_impl`](`frame_support::derive_impl`) from
 /// [`ParaChainDefaultConfig`](`struct@frame_system::config_preludes::ParaChainDefaultConfig`),
 /// but overridden as needed.
@@ -325,6 +342,8 @@ impl frame_system::Config for Runtime {
 	type BlockLength = RuntimeBlockLength;
 	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
 	type SS58Prefix = SS58Prefix;
+	/// The basic call filter to use in dispatchable. Supports everything as the default.
+	type BaseCallFilter = EverythingBut<FilteredCalls>;
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;


### PR DESCRIPTION
Network now launches with zero total issuance, requiring a reserve transfer from the relay to get started. This will be automated with a pop up feature, but for now one can reserve transfer from relay to Pop with the following encoded calls:
- Send 100 UNIT to Alice on Pop
`0x630804000100098e0400010100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d04040000000b00407a10f35a0000000000`
- Send 100 UNIT to Bob on Pop
`0x630804000100098e04000101008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a4804040000000b00407a10f35a0000000000`

Commits:
- filter `balances::force*` calls to prevent minting of native token, ensuring network can only be funded from relay token
- removes endowments from chainspec 
- removes endowments from genesis within integration tests, updating tests accordingly