### PR TITLE
refactor(pop-network): remove coretime use case from testnet

### DIFF
--- a/runtime/testnet/src/extensions.rs
+++ b/runtime/testnet/src/extensions.rs
@@ -672,7 +672,10 @@ mod tests {
 			}
 
 			// check for revert
-			assert!(result.result.is_err(), "Contract execution should have failed - unimplemented runtime call!");
+			assert!(
+				result.result.is_err(),
+				"Contract execution should have failed - unimplemented runtime call!"
+			);
 		});
 	}
 


### PR DESCRIPTION
Closes https://github.com/r0gue-io/pop-node/issues/54

Removes XCM use cases for contracts from testnet runtime.