### PR TITLE
build(release): add macos support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,12 @@ on:
       ref:
         description: ref to build binary from
         required: false
+  push:
+    branches:
+      - 'frank/build-macos'
 
 jobs:
-  build-node:
+  build-node-for-linux:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -24,6 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: ${{ github.event.inputs.ref }}
 
       - name: Install packages
@@ -39,6 +43,53 @@ jobs:
           mkdir -p build
           cp target/production/pop-node build/${{ env.name }}
           sha256sum build/${{ env.name }} > build/${{ env.name }}.sha256
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: build
+
+      - name: Add binary to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            build/${{ env.name }}
+            build/${{ env.name }}.sha256
+
+  build-node-for-macos:
+    runs-on: macos-14
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        target: [ "aarch64-apple-darwin", "x86_64-apple-darwin" ]
+    env:
+      name: "pop-node-${{ matrix.target }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Install packages
+        run: |
+          brew install protobuf
+          protoc --version
+
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build node
+        run: cargo build --profile=production -p pop-node --target ${{ matrix.target }}
+
+      - name: Save binary
+        run: |
+          mkdir -p build
+          cp target/${{ matrix.target }}/production/pop-node build/${{ env.name }}
+          shasum -a 256 build/${{ env.name }} > build/${{ env.name }}.sha256
 
       - name: Upload binary
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,22 +85,21 @@ jobs:
       - name: Build node
         run: cargo build --profile=production -p pop-node --target ${{ matrix.target }}
 
-      - name: Save binary
+      - name: Package binary
         run: |
-          mkdir -p build
-          cp target/${{ matrix.target }}/production/pop-node build/${{ env.name }}
-          shasum -a 256 build/${{ env.name }} > build/${{ env.name }}.sha256
+          cd target/${{ matrix.target }}/production
+          shasum -a 256 pop-node > pop-node.sha256
+          tar -czf pop-node-${{ matrix.target }}.tar.gz pop-node pop-node.sha256
 
       - name: Upload binary
         uses: actions/upload-artifact@v3
         with:
           name: binaries
-          path: build
+          path: target/${{ matrix.target }}/production/pop-node-${{ matrix.target }}.tar.gz
 
       - name: Add binary to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            build/${{ env.name }}
-            build/${{ env.name }}.sha256
+            target/${{ matrix.target }}/production/pop-node-${{ matrix.target }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,51 +13,6 @@ on:
       - 'frank/build-macos'
 
 jobs:
-  #  build-node-for-linux:
-  #    runs-on: ubuntu-22.04
-  #    permissions:
-  #      contents: write
-  #    strategy:
-  #      matrix:
-  #        cpu: [ "", "skylake" ]
-  #    env:
-  #      RUSTFLAGS: "-C target-cpu=${{ matrix.cpu }}"
-  #      name: "pop-node${{ matrix.cpu != '' && format('-{0}', matrix.cpu) || '' }}"
-  #    steps:
-  #      - name: Checkout
-  #        uses: actions/checkout@v4
-  #        with:
-  #          fetch-depth: 0
-  #          ref: ${{ github.event.inputs.ref }}
-  #
-  #      - name: Install packages
-  #        run: |
-  #          sudo apt-get install -y protobuf-compiler
-  #          protoc --version
-  #
-  #      - name: Build node
-  #        run: cargo build --profile=production -p pop-node
-  #
-  #      - name: Save binary
-  #        run: |
-  #          mkdir -p build
-  #          cp target/production/pop-node build/${{ env.name }}
-  #          sha256sum build/${{ env.name }} > build/${{ env.name }}.sha256
-  #
-  #      - name: Upload binary
-  #        uses: actions/upload-artifact@v3
-  #        with:
-  #          name: binaries
-  #          path: build
-  #
-  #      - name: Add binary to release
-  #        if: github.event_name == 'release'
-  #        uses: softprops/action-gh-release@v1
-  #        with:
-  #          files: |
-  #            build/${{ env.name }}
-  #            build/${{ env.name }}.sha256
-
   build-node:
     runs-on: ${{ matrix.platform.os }}
     permissions:
@@ -66,8 +21,8 @@ jobs:
       matrix:
         platform:
           # Linux
-          #          - os: ubuntu-22.04
-          #            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-22.04
+            target: aarch64-unknown-linux-gnu
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04
@@ -79,7 +34,7 @@ jobs:
           - os: macos-14
             target: x86_64-apple-darwin
     env:
-      RUSTFLAGS: "${{ matrix.platform.cpu != '' && format('-C target-cpu={0}', matrix.platform.cpu) || '' }}"
+      RUSTFLAGS: "${{ matrix.platform.cpu != '' && format('-C target-cpu={0}', matrix.platform.cpu) || '' }} ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && '-C linker=aarch64-linux-gnu-gcc' || '' }}"
       path: "target/${{ matrix.platform.target }}/production"
       package: "pop-node-${{ matrix.platform.target }}${{ matrix.platform.cpu != '' && format('-{0}', matrix.platform.cpu) || '' }}.tar.gz"
     steps:
@@ -92,9 +47,8 @@ jobs:
       - name: Install packages (Linux)
         if: contains(matrix.platform.target, 'linux')
         run: |
-          sudo apt-get install -y protobuf-compiler 
+          sudo apt-get install -y protobuf-compiler ${{ contains(matrix.platform.target, 'aarch64') && 'crossbuild-essential-arm64' || '' }}
           protoc --version
-      #          gcc-aarch64-linux-gnu
 
       - name: Install packages (macOS)
         if: contains(matrix.platform.target, 'apple')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,75 @@ on:
       - 'frank/build-macos'
 
 jobs:
-  build-node-for-linux:
-    runs-on: ubuntu-22.04
+  #  build-node-for-linux:
+  #    runs-on: ubuntu-22.04
+  #    permissions:
+  #      contents: write
+  #    strategy:
+  #      matrix:
+  #        cpu: [ "", "skylake" ]
+  #    env:
+  #      RUSTFLAGS: "-C target-cpu=${{ matrix.cpu }}"
+  #      name: "pop-node${{ matrix.cpu != '' && format('-{0}', matrix.cpu) || '' }}"
+  #    steps:
+  #      - name: Checkout
+  #        uses: actions/checkout@v4
+  #        with:
+  #          fetch-depth: 0
+  #          ref: ${{ github.event.inputs.ref }}
+  #
+  #      - name: Install packages
+  #        run: |
+  #          sudo apt-get install -y protobuf-compiler
+  #          protoc --version
+  #
+  #      - name: Build node
+  #        run: cargo build --profile=production -p pop-node
+  #
+  #      - name: Save binary
+  #        run: |
+  #          mkdir -p build
+  #          cp target/production/pop-node build/${{ env.name }}
+  #          sha256sum build/${{ env.name }} > build/${{ env.name }}.sha256
+  #
+  #      - name: Upload binary
+  #        uses: actions/upload-artifact@v3
+  #        with:
+  #          name: binaries
+  #          path: build
+  #
+  #      - name: Add binary to release
+  #        if: github.event_name == 'release'
+  #        uses: softprops/action-gh-release@v1
+  #        with:
+  #          files: |
+  #            build/${{ env.name }}
+  #            build/${{ env.name }}.sha256
+
+  build-node:
+    runs-on: ${{ matrix.platform.os }}
     permissions:
       contents: write
     strategy:
       matrix:
-        cpu: [ "", "skylake" ]
+        platform:
+          # Linux
+          #          - os: ubuntu-22.04
+          #            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            cpu: skylake
+          # macOS
+          - os: macos-14
+            target: aarch64-apple-darwin
+          - os: macos-14
+            target: x86_64-apple-darwin
     env:
-      RUSTFLAGS: "-C target-cpu=${{ matrix.cpu }}"
-      name: "pop-node${{ matrix.cpu != '' && format('-{0}', matrix.cpu) || '' }}"
+      RUSTFLAGS: "${{ matrix.platform.cpu != '' && format('-C target-cpu={0}', matrix.platform.cpu) || '' }}"
+      path: "target/${{ matrix.platform.target }}/production"
+      package: "pop-node-${{ matrix.platform.target }}${{ matrix.platform.cpu != '' && format('-{0}', matrix.platform.cpu) || '' }}.tar.gz"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,76 +89,48 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.ref }}
 
-      - name: Install packages
+      - name: Install packages (Linux)
+        if: contains(matrix.platform.target, 'linux')
         run: |
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler 
           protoc --version
+      #          gcc-aarch64-linux-gnu
 
-      - name: Build node
-        run: cargo build --profile=production -p pop-node
-
-      - name: Save binary
-        run: |
-          mkdir -p build
-          cp target/production/pop-node build/${{ env.name }}
-          sha256sum build/${{ env.name }} > build/${{ env.name }}.sha256
-
-      - name: Upload binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: binaries
-          path: build
-
-      - name: Add binary to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            build/${{ env.name }}
-            build/${{ env.name }}.sha256
-
-  build-node-for-macos:
-    runs-on: macos-14
-    permissions:
-      contents: write
-    strategy:
-      matrix:
-        target: [ "aarch64-apple-darwin", "x86_64-apple-darwin" ]
-    env:
-      name: "pop-node-${{ matrix.target }}"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.ref }}
-
-      - name: Install packages
+      - name: Install packages (macOS)
+        if: contains(matrix.platform.target, 'apple')
         run: |
           brew install protobuf
           protoc --version
 
       - name: Add target
-        run: rustup target add ${{ matrix.target }}
+        run: rustup target add ${{ matrix.platform.target }}
 
       - name: Build node
-        run: cargo build --profile=production -p pop-node --target ${{ matrix.target }}
+        run: cargo build --profile=production -p pop-node --target ${{ matrix.platform.target }}
 
-      - name: Package binary
+      - name: Package binary (Linux)
+        if: contains(matrix.platform.target, 'linux')
         run: |
-          cd target/${{ matrix.target }}/production
+          cd ${{ env.path }}
+          sha256sum pop-node > pop-node.sha256
+          tar -czf ${{ env.package }} pop-node pop-node.sha256
+
+      - name: Package binary (macOS)
+        if: contains(matrix.platform.target, 'apple')
+        run: |
+          cd ${{ env.path }}
           shasum -a 256 pop-node > pop-node.sha256
-          tar -czf pop-node-${{ matrix.target }}.tar.gz pop-node pop-node.sha256
+          tar -czf ${{ env.package }} pop-node pop-node.sha256
 
       - name: Upload binary
         uses: actions/upload-artifact@v3
         with:
           name: binaries
-          path: target/${{ matrix.target }}/production/pop-node-${{ matrix.target }}.tar.gz
+          path: ${{ env.path }}/${{ env.package }}
 
       - name: Add binary to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/${{ matrix.target }}/production/pop-node-${{ matrix.target }}.tar.gz
+            ${{ env.path }}/${{ env.package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         run: rustup target add ${{ matrix.platform.target }}
 
       - name: Build node
-        run: cargo build --profile=production -p pop-node --target ${{ matrix.platform.target }}
+        run: cargo build --profile=production -p pop-node --target ${{ matrix.platform.target }} --features paseo
 
       - name: Package binary (Linux)
         if: contains(matrix.platform.target, 'linux')


### PR DESCRIPTION
Reworks the release workflow to include macOS binaries (Apple Silicon and x64), along with aarch64 on Linux.

Examples at https://github.com/r0gue-io/pop-node/releases/tag/test, where binary for each release is compressed and labelled using `pop-node-(target)(-cpu)` convention, making the files much smaller to download and more importantly, all use `pop-node` once extracted.