### PR TITLE
style: naming examples

### DIFF
--- a/pop-api/examples/balance-transfer/Cargo.toml
+++ b/pop-api/examples/balance-transfer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pop_api_balances"
+name = "balances"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"

--- a/pop-api/examples/balance-transfer/Cargo.toml
+++ b/pop-api/examples/balance-transfer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pop_api_extension_demo"
+name = "pop_api_balances"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"

--- a/pop-api/examples/balance-transfer/Cargo.toml
+++ b/pop-api/examples/balance-transfer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "balances"
+name = "balance_transfer"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"

--- a/pop-api/examples/balance-transfer/lib.rs
+++ b/pop-api/examples/balance-transfer/lib.rs
@@ -36,14 +36,14 @@ mod balance_transfer {
 			value: Balance,
 		) -> Result<(), ContractError> {
 			ink::env::debug_println!(
-				"BalanceTransfer::transfer_through_runtime: \nreceiver: {:?}, \nvalue: {:?}",
+				"BalanceTransfer::transfer: \nreceiver: {:?}, \nvalue: {:?}",
 				receiver,
 				value
 			);
 
 			transfer_keep_alive(receiver, value)?;
 
-			ink::env::debug_println!("BalanceTransfer::transfer_through_runtime end");
+			ink::env::debug_println!("BalanceTransfer::transfer end");
 			Ok(())
 		}
 	}

--- a/pop-api/examples/balance-transfer/lib.rs
+++ b/pop-api/examples/balance-transfer/lib.rs
@@ -15,17 +15,17 @@ impl From<balances::Error> for ContractError {
 }
 
 #[ink::contract(env = pop_api::Environment)]
-mod pop_api_extension_demo {
+mod pop_api_balances {
 	use super::ContractError;
 
 	#[ink(storage)]
 	#[derive(Default)]
-	pub struct PopApiExtensionDemo;
+	pub struct PopApiBalances;
 
-	impl PopApiExtensionDemo {
+	impl PopApiBalances {
 		#[ink(constructor, payable)]
 		pub fn new() -> Self {
-			ink::env::debug_println!("PopApiExtensionDemo::new");
+			ink::env::debug_println!("PopApiBalances::new");
 			Default::default()
 		}
 
@@ -36,14 +36,14 @@ mod pop_api_extension_demo {
 			value: Balance,
 		) -> Result<(), ContractError> {
 			ink::env::debug_println!(
-				"PopApiExtensionDemo::transfer_through_runtime: \nreceiver: {:?}, \nvalue: {:?}",
+				"PopApiBalances::transfer_through_runtime: \nreceiver: {:?}, \nvalue: {:?}",
 				receiver,
 				value
 			);
 
 			pop_api::balances::transfer_keep_alive(receiver, value)?;
 
-			ink::env::debug_println!("PopApiExtensionDemo::transfer_through_runtime end");
+			ink::env::debug_println!("PopApiBalances::transfer_through_runtime end");
 			Ok(())
 		}
 	}

--- a/pop-api/examples/balance-transfer/lib.rs
+++ b/pop-api/examples/balance-transfer/lib.rs
@@ -1,49 +1,49 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-use pop_api::balances;
+use pop_api::balances::*;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub enum ContractError {
-	BalancesError(balances::Error),
+	BalancesError(Error),
 }
 
-impl From<balances::Error> for ContractError {
-	fn from(value: balances::Error) -> Self {
+impl From<Error> for ContractError {
+	fn from(value: Error) -> Self {
 		ContractError::BalancesError(value)
 	}
 }
 
 #[ink::contract(env = pop_api::Environment)]
-mod pop_api_balances {
-	use super::ContractError;
+mod balance_transfer {
+	use super::*;
 
 	#[ink(storage)]
 	#[derive(Default)]
-	pub struct PopApiBalances;
+	pub struct BalanceTransfer;
 
-	impl PopApiBalances {
+	impl BalanceTransfer {
 		#[ink(constructor, payable)]
 		pub fn new() -> Self {
-			ink::env::debug_println!("PopApiBalances::new");
+			ink::env::debug_println!("BalanceTransfer::new");
 			Default::default()
 		}
 
 		#[ink(message)]
-		pub fn transfer_through_runtime(
+		pub fn transfer(
 			&mut self,
 			receiver: AccountId,
 			value: Balance,
 		) -> Result<(), ContractError> {
 			ink::env::debug_println!(
-				"PopApiBalances::transfer_through_runtime: \nreceiver: {:?}, \nvalue: {:?}",
+				"BalanceTransfer::transfer_through_runtime: \nreceiver: {:?}, \nvalue: {:?}",
 				receiver,
 				value
 			);
 
-			pop_api::balances::transfer_keep_alive(receiver, value)?;
+			transfer_keep_alive(receiver, value)?;
 
-			ink::env::debug_println!("PopApiBalances::transfer_through_runtime end");
+			ink::env::debug_println!("BalanceTransfer::transfer_through_runtime end");
 			Ok(())
 		}
 	}
@@ -107,7 +107,7 @@ mod pop_api_balances {
 				client.free_balance(receiver).await.expect("Failed to get account balance");
 
 			// when
-			let transfer_message = call_builder.transfer_through_runtime(receiver, TRANSFER_VALUE);
+			let transfer_message = call_builder.transfer(receiver, TRANSFER_VALUE);
 
 			let call_res = client
 				.call(&ink_e2e::alice(), &transfer_message)

--- a/pop-api/examples/nfts/Cargo.toml
+++ b/pop-api/examples/nfts/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pop_api_nft_example"
+name = "pop_api_nfts"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"

--- a/pop-api/examples/nfts/Cargo.toml
+++ b/pop-api/examples/nfts/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pop_api_nfts"
+name = "nfts"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"

--- a/pop-api/examples/nfts/lib.rs
+++ b/pop-api/examples/nfts/lib.rs
@@ -18,17 +18,17 @@ impl From<nfts::Error> for ContractError {
 }
 
 #[ink::contract(env = pop_api::Environment)]
-mod pop_api_extension_demo {
+mod pop_api_nfts {
 	use super::ContractError;
 
 	#[ink(storage)]
 	#[derive(Default)]
-	pub struct PopApiExtensionDemo;
+	pub struct PopApiNfts;
 
-	impl PopApiExtensionDemo {
+	impl PopApiNfts {
 		#[ink(constructor, payable)]
 		pub fn new() -> Self {
-			ink::env::debug_println!("Contract::new");
+			ink::env::debug_println!("PopApiNfts::new");
 			Default::default()
 		}
 
@@ -40,7 +40,7 @@ mod pop_api_extension_demo {
 			receiver: AccountId,
 		) -> Result<(), ContractError> {
 			ink::env::debug_println!(
-				"Contract::mint_through_runtime: collection_id: {:?} item_id {:?} receiver: {:?}",
+				"PopApiNfts::mint_through_runtime: collection_id: {:?} item_id {:?} receiver: {:?}",
 				collection_id,
 				item_id,
 				receiver
@@ -53,13 +53,13 @@ mod pop_api_extension_demo {
 
 			// mint api
 			pop_api::nfts::mint(collection_id, item_id, receiver)?;
-			ink::env::debug_println!("Contract::mint_through_runtime: item minted successfully");
+			ink::env::debug_println!("PopApiNfts::mint_through_runtime: item minted successfully");
 
 			// check owner
 			match pop_api::nfts::owner(collection_id, item_id)? {
 				Some(owner) if owner == receiver => {
 					ink::env::debug_println!(
-						"Contract::mint_through_runtime success: minted item belongs to receiver"
+						"PopApiNfts::mint_through_runtime success: minted item belongs to receiver"
 					);
 				},
 				_ => {
@@ -67,7 +67,7 @@ mod pop_api_extension_demo {
 				},
 			}
 
-			ink::env::debug_println!("Contract::mint_through_runtime end");
+			ink::env::debug_println!("PopApiNfts::mint_through_runtime end");
 			Ok(())
 		}
 	}
@@ -78,7 +78,7 @@ mod pop_api_extension_demo {
 
 		#[ink::test]
 		fn default_works() {
-			PopApiExtensionDemo::new();
+			PopApiNfts::new();
 		}
 	}
 }

--- a/pop-api/examples/nfts/lib.rs
+++ b/pop-api/examples/nfts/lib.rs
@@ -1,34 +1,34 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-use pop_api::nfts;
+use pop_api::nfts::*;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub enum ContractError {
 	InvalidCollection,
 	ItemAlreadyExists,
-	NftsError(nfts::Error),
+	NftsError(Error),
 	NotOwner,
 }
 
-impl From<nfts::Error> for ContractError {
-	fn from(value: nfts::Error) -> Self {
+impl From<Error> for ContractError {
+	fn from(value: Error) -> Self {
 		ContractError::NftsError(value)
 	}
 }
 
 #[ink::contract(env = pop_api::Environment)]
-mod pop_api_nfts {
-	use super::ContractError;
+mod nfts {
+	use super::*;
 
 	#[ink(storage)]
 	#[derive(Default)]
-	pub struct PopApiNfts;
+	pub struct Nfts;
 
-	impl PopApiNfts {
+	impl Nfts {
 		#[ink(constructor, payable)]
 		pub fn new() -> Self {
-			ink::env::debug_println!("PopApiNfts::new");
+			ink::env::debug_println!("Nfts::new");
 			Default::default()
 		}
 
@@ -40,26 +40,26 @@ mod pop_api_nfts {
 			receiver: AccountId,
 		) -> Result<(), ContractError> {
 			ink::env::debug_println!(
-				"PopApiNfts::mint_through_runtime: collection_id: {:?} item_id {:?} receiver: {:?}",
+				"Nfts::mint_through_runtime: collection_id: {:?} item_id {:?} receiver: {:?}",
 				collection_id,
 				item_id,
 				receiver
 			);
 
 			// Check if item already exists (demo purposes only, unnecessary as would expect check in mint call)
-			if pop_api::nfts::item(collection_id, item_id)?.is_some() {
+			if item(collection_id, item_id)?.is_some() {
 				return Err(ContractError::ItemAlreadyExists);
 			}
 
 			// mint api
-			pop_api::nfts::mint(collection_id, item_id, receiver)?;
-			ink::env::debug_println!("PopApiNfts::mint_through_runtime: item minted successfully");
+			mint(collection_id, item_id, receiver)?;
+			ink::env::debug_println!("Nfts::mint_through_runtime: item minted successfully");
 
 			// check owner
-			match pop_api::nfts::owner(collection_id, item_id)? {
+			match owner(collection_id, item_id)? {
 				Some(owner) if owner == receiver => {
 					ink::env::debug_println!(
-						"PopApiNfts::mint_through_runtime success: minted item belongs to receiver"
+						"Nfts::mint_through_runtime success: minted item belongs to receiver"
 					);
 				},
 				_ => {
@@ -67,7 +67,7 @@ mod pop_api_nfts {
 				},
 			}
 
-			ink::env::debug_println!("PopApiNfts::mint_through_runtime end");
+			ink::env::debug_println!("Nfts::mint_through_runtime end");
 			Ok(())
 		}
 	}
@@ -78,7 +78,7 @@ mod pop_api_nfts {
 
 		#[ink::test]
 		fn default_works() {
-			PopApiNfts::new();
+			Nfts::new();
 		}
 	}
 }

--- a/pop-api/examples/nfts/lib.rs
+++ b/pop-api/examples/nfts/lib.rs
@@ -33,14 +33,14 @@ mod nfts {
 		}
 
 		#[ink(message)]
-		pub fn mint_through_runtime(
+		pub fn mint(
 			&mut self,
 			collection_id: u32,
 			item_id: u32,
 			receiver: AccountId,
 		) -> Result<(), ContractError> {
 			ink::env::debug_println!(
-				"Nfts::mint_through_runtime: collection_id: {:?} item_id {:?} receiver: {:?}",
+				"Nfts::mint: collection_id: {:?} item_id {:?} receiver: {:?}",
 				collection_id,
 				item_id,
 				receiver
@@ -53,13 +53,13 @@ mod nfts {
 
 			// mint api
 			mint(collection_id, item_id, receiver)?;
-			ink::env::debug_println!("Nfts::mint_through_runtime: item minted successfully");
+			ink::env::debug_println!("Nfts::mint: item minted successfully");
 
 			// check owner
 			match owner(collection_id, item_id)? {
 				Some(owner) if owner == receiver => {
 					ink::env::debug_println!(
-						"Nfts::mint_through_runtime success: minted item belongs to receiver"
+						"Nfts::mint success: minted item belongs to receiver"
 					);
 				},
 				_ => {
@@ -67,7 +67,7 @@ mod nfts {
 				},
 			}
 
-			ink::env::debug_println!("Nfts::mint_through_runtime end");
+			ink::env::debug_println!("Nfts::mint end");
 			Ok(())
 		}
 	}

--- a/pop-api/examples/place-spot-order/Cargo.toml
+++ b/pop-api/examples/place-spot-order/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pop_api_spot_order_example"
+name = "pop_api_spot_order"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"

--- a/pop-api/examples/place-spot-order/Cargo.toml
+++ b/pop-api/examples/place-spot-order/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pop_api_spot_order"
+name = "spot_order"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"

--- a/pop-api/examples/place-spot-order/lib.rs
+++ b/pop-api/examples/place-spot-order/lib.rs
@@ -18,17 +18,17 @@ impl From<nfts::Error> for ContractError {
 }
 
 #[ink::contract(env = pop_api::Environment)]
-mod pop_api_spot_order_example {
+mod pop_api_spot_order {
 	use super::ContractError;
 
 	#[ink(storage)]
 	#[derive(Default)]
-	pub struct PopApiSpotOrderExample;
+	pub struct PopApiSpotOrder;
 
-	impl PopApiSpotOrderExample {
+	impl PopApiSpotOrder {
 		#[ink(constructor, payable)]
 		pub fn new() -> Self {
-			ink::env::debug_println!("Contract::new");
+			ink::env::debug_println!("PopApiSpotOrder::new");
 			Default::default()
 		}
 
@@ -39,18 +39,18 @@ mod pop_api_spot_order_example {
 			para_id: u32,
 		) -> Result<(), ContractError> {
 			ink::env::debug_println!(
-				"Contract::place_spot_order: max_amount {:?} para_id: {:?} ",
+				"PopApiSpotOrder::place_spot_order: max_amount {:?} para_id: {:?} ",
 				max_amount,
 				para_id,
 			);
 
 			let res = pop_api::cross_chain::coretime::place_spot_order(max_amount, para_id);
 			ink::env::debug_println!(
-				"Contract::place_spot_order: res {:?} ",
+				"PopApiSpotOrder::place_spot_order: res {:?} ",
 				res,
 			);
 
-			ink::env::debug_println!("Contract::place_spot_order end");
+			ink::env::debug_println!("PopApiSpotOrder::place_spot_order end");
 			Ok(())
 		}
 	}
@@ -61,7 +61,7 @@ mod pop_api_spot_order_example {
 
 		#[ink::test]
 		fn default_works() {
-			PopApiSpotOrderExample::new();
+			PopApiSpotOrder::new();
 		}
 	}
 }

--- a/pop-api/examples/place-spot-order/lib.rs
+++ b/pop-api/examples/place-spot-order/lib.rs
@@ -1,34 +1,16 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-use pop_api::nfts;
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
-#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-pub enum ContractError {
-	InvalidCollection,
-	ItemAlreadyExists,
-	NftsError(nfts::Error),
-	NotOwner,
-}
-
-impl From<nfts::Error> for ContractError {
-	fn from(value: nfts::Error) -> Self {
-		ContractError::NftsError(value)
-	}
-}
-
 #[ink::contract(env = pop_api::Environment)]
-mod pop_api_spot_order {
-	use super::ContractError;
+mod spot_order {
 
 	#[ink(storage)]
 	#[derive(Default)]
-	pub struct PopApiSpotOrder;
+	pub struct SpotOrder;
 
-	impl PopApiSpotOrder {
+	impl SpotOrder {
 		#[ink(constructor, payable)]
 		pub fn new() -> Self {
-			ink::env::debug_println!("PopApiSpotOrder::new");
+			ink::env::debug_println!("SpotOrder::new");
 			Default::default()
 		}
 
@@ -37,21 +19,21 @@ mod pop_api_spot_order {
 			&mut self,
 			max_amount: Balance,
 			para_id: u32,
-		) -> Result<(), ContractError> {
+		) {
 			ink::env::debug_println!(
-				"PopApiSpotOrder::place_spot_order: max_amount {:?} para_id: {:?} ",
+				"SpotOrder::place_spot_order: max_amount {:?} para_id: {:?} ",
 				max_amount,
 				para_id,
 			);
 
+			#[allow(unused_variables)]
 			let res = pop_api::cross_chain::coretime::place_spot_order(max_amount, para_id);
 			ink::env::debug_println!(
-				"PopApiSpotOrder::place_spot_order: res {:?} ",
+				"SpotOrder::place_spot_order: res {:?} ",
 				res,
 			);
 
-			ink::env::debug_println!("PopApiSpotOrder::place_spot_order end");
-			Ok(())
+			ink::env::debug_println!("SpotOrder::place_spot_order end");
 		}
 	}
 
@@ -61,7 +43,7 @@ mod pop_api_spot_order {
 
 		#[ink::test]
 		fn default_works() {
-			PopApiSpotOrder::new();
+			SpotOrder::new();
 		}
 	}
 }

--- a/pop-api/examples/read-runtime-state/Cargo.toml
+++ b/pop-api/examples/read-runtime-state/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pop_api_extension_demo"
+name = "pop_api_read_relay_blocknumber"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"

--- a/pop-api/examples/read-runtime-state/Cargo.toml
+++ b/pop-api/examples/read-runtime-state/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pop_api_read_relay_blocknumber"
+name = "read_relay_blocknumber"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"

--- a/pop-api/examples/read-runtime-state/lib.rs
+++ b/pop-api/examples/read-runtime-state/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 #[ink::contract(env = pop_api::Environment)]
-mod pop_api_extension_demo {
+mod pop_api_read_relay_blocknumber {
     use pop_api::primitives::storage_keys::{
         ParachainSystemKeys::LastRelayChainBlockNumber, RuntimeStateKeys::ParachainSystem,
     };
@@ -13,12 +13,12 @@ mod pop_api_extension_demo {
 
     #[ink(storage)]
     #[derive(Default)]
-    pub struct PopApiExtensionDemo;
+    pub struct PopApiReadRelayBlockNumber;
 
-    impl PopApiExtensionDemo {
+    impl PopApiReadRelayBlockNumber {
         #[ink(constructor, payable)]
         pub fn new() -> Self {
-            ink::env::debug_println!("PopApiExtensionDemo::new");
+            ink::env::debug_println!("PopApiReadRelayBlockNumber::new");
             Default::default()
         }
 

--- a/pop-api/examples/read-runtime-state/lib.rs
+++ b/pop-api/examples/read-runtime-state/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 #[ink::contract(env = pop_api::Environment)]
-mod pop_api_read_relay_blocknumber {
+mod read_relay_blocknumber {
     use pop_api::primitives::storage_keys::{
         ParachainSystemKeys::LastRelayChainBlockNumber, RuntimeStateKeys::ParachainSystem,
     };
@@ -13,12 +13,12 @@ mod pop_api_read_relay_blocknumber {
 
     #[ink(storage)]
     #[derive(Default)]
-    pub struct PopApiReadRelayBlockNumber;
+    pub struct ReadRelayBlockNumber;
 
-    impl PopApiReadRelayBlockNumber {
+    impl ReadRelayBlockNumber {
         #[ink(constructor, payable)]
         pub fn new() -> Self {
-            ink::env::debug_println!("PopApiReadRelayBlockNumber::new");
+            ink::env::debug_println!("ReadRelayBlockNumber::new");
             Default::default()
         }
 

--- a/runtime/devnet/src/extensions.rs
+++ b/runtime/devnet/src/extensions.rs
@@ -415,7 +415,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/balance-transfer/target/ink/pop_api_balances.wasm",
+				"../../pop-api/examples/balance-transfer/target/ink/balances.wasm",
 			)
 			.unwrap();
 
@@ -480,10 +480,9 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let _ = env_logger::try_init();
 
-			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/nfts/target/ink/pop_api_nfts.wasm",
-			)
-			.unwrap();
+			let (wasm_binary, _) =
+				load_wasm_module::<Runtime>("../../pop-api/examples/nfts/target/ink/nfts.wasm")
+					.unwrap();
 
 			let init_value = 100;
 
@@ -560,10 +559,9 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let _ = env_logger::try_init();
 
-			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/nfts/target/ink/pop_api_nfts.wasm",
-			)
-			.unwrap();
+			let (wasm_binary, _) =
+				load_wasm_module::<Runtime>("../../pop-api/examples/nfts/target/ink/nfts.wasm")
+					.unwrap();
 
 			let init_value = 100;
 
@@ -626,7 +624,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/read-runtime-state/target/ink/pop_api_read_relay_blocknumber.wasm",
+				"../../pop-api/examples/read-runtime-state/target/ink/read_relay_blocknumber.wasm",
 			)
 			.unwrap();
 
@@ -685,7 +683,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/place-spot-order/target/ink/pop_api_spot_order.wasm",
+				"../../pop-api/examples/place-spot-order/target/ink/spot_order.wasm",
 			)
 			.unwrap();
 

--- a/runtime/devnet/src/extensions.rs
+++ b/runtime/devnet/src/extensions.rs
@@ -415,7 +415,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/balance-transfer/target/ink/pop_api_extension_demo.wasm",
+				"../../pop-api/examples/balance-transfer/target/ink/pop_api_balances.wasm",
 			)
 			.unwrap();
 
@@ -481,7 +481,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/nfts/target/ink/pop_api_nft_example.wasm",
+				"../../pop-api/examples/nfts/target/ink/pop_api_nfts.wasm",
 			)
 			.unwrap();
 
@@ -561,7 +561,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/nfts/target/ink/pop_api_nft_example.wasm",
+				"../../pop-api/examples/nfts/target/ink/pop_api_nfts.wasm",
 			)
 			.unwrap();
 
@@ -626,7 +626,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/read-runtime-state/target/ink/pop_api_extension_demo.wasm",
+				"../../pop-api/examples/read-runtime-state/target/ink/pop_api_read_relay_blocknumber.wasm",
 			)
 			.unwrap();
 
@@ -685,7 +685,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/place-spot-order/target/ink/pop_api_spot_order_example.wasm",
+				"../../pop-api/examples/place-spot-order/target/ink/pop_api_spot_order.wasm",
 			)
 			.unwrap();
 

--- a/runtime/devnet/src/extensions.rs
+++ b/runtime/devnet/src/extensions.rs
@@ -415,7 +415,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/balance-transfer/target/ink/balances.wasm",
+				"../../pop-api/examples/balance-transfer/target/ink/balance_transfer.wasm",
 			)
 			.unwrap();
 

--- a/runtime/testnet/src/extensions.rs
+++ b/runtime/testnet/src/extensions.rs
@@ -350,7 +350,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/balance-transfer/target/ink/pop_api_extension_demo.wasm",
+				"../../pop-api/examples/balance-transfer/target/ink/balances.wasm",
 			)
 			.unwrap();
 
@@ -415,10 +415,9 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let _ = env_logger::try_init();
 
-			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/nfts/target/ink/pop_api_nft_example.wasm",
-			)
-			.unwrap();
+			let (wasm_binary, _) =
+				load_wasm_module::<Runtime>("../../pop-api/examples/nfts/target/ink/nfts.wasm")
+					.unwrap();
 
 			let init_value = 100;
 
@@ -495,10 +494,9 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let _ = env_logger::try_init();
 
-			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/nfts/target/ink/pop_api_nft_example.wasm",
-			)
-			.unwrap();
+			let (wasm_binary, _) =
+				load_wasm_module::<Runtime>("../../pop-api/examples/nfts/target/ink/nfts.wasm")
+					.unwrap();
 
 			let init_value = 100;
 
@@ -561,7 +559,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/read-runtime-state/target/ink/pop_api_extension_demo.wasm",
+				"../../pop-api/examples/read-runtime-state/target/ink/read_relay_blocknumber.wasm",
 			)
 			.unwrap();
 
@@ -620,7 +618,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/place-spot-order/target/ink/pop_api_spot_order_example.wasm",
+				"../../pop-api/examples/place-spot-order/target/ink/spot_order.wasm",
 			)
 			.unwrap();
 

--- a/runtime/testnet/src/extensions.rs
+++ b/runtime/testnet/src/extensions.rs
@@ -350,7 +350,7 @@ mod tests {
 			let _ = env_logger::try_init();
 
 			let (wasm_binary, _) = load_wasm_module::<Runtime>(
-				"../../pop-api/examples/balance-transfer/target/ink/balances.wasm",
+				"../../pop-api/examples/balance-transfer/target/ink/balance_transfer.wasm",
 			)
 			.unwrap();
 


### PR DESCRIPTION
There was a warning in compiling a contract when adding pop api dependency. This should resolve it.

I also updated the naming, which we can use to move forward with the examples.

This is just naming things, examples need a lot more work.