### PR TITLE
build(deps): allow specifying ink version via feature

### DIFF
--- a/pop-api/Cargo.toml
+++ b/pop-api/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 enumflags2 = { version = "0.7.7" }
-ink = { version = "5.0.0-rc.3", default-features = false }
+inkv4 = { package = "ink", version = "4.3.0", default-features = false, optional = true }
+inkv5 = { package = "ink", version = "5.0.0", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"] }
 sp-io = { version = "23.0.0", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
@@ -24,10 +25,11 @@ crate-type = ["rlib"]
 default = ["std"]
 std = [
     "enumflags2/std",
-    "ink/std",
     "pop-primitives/std",
     "scale/std",
     "scale-info/std",
     "sp-io/std",
     "sp-runtime/std",
 ]
+inkv4 = ["dep:inkv4"]
+inkv5 = ["dep:inkv5"]

--- a/pop-api/examples/balance-transfer/Cargo.toml
+++ b/pop-api/examples/balance-transfer/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0-rc.3", default-features = false }
-pop-api = { path = "../../../pop-api", default-features = false }
+ink = { version = "4.3.0", default-features = false }
+pop-api = { path = "../../../pop-api", default-features = false, features = ["inkv4"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/pop-api/examples/nfts/Cargo.toml
+++ b/pop-api/examples/nfts/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0-rc.3", default-features = false }
-pop-api = { path = "../../../pop-api", default-features = false }
+ink = { version = "5.0.0", default-features = false }
+pop-api = { path = "../../../pop-api", default-features = false, features = ["inkv5"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/pop-api/examples/place-spot-order/Cargo.toml
+++ b/pop-api/examples/place-spot-order/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0-rc.3", default-features = false }
-pop-api = { path = "../../../pop-api", default-features = false }
+ink = { version = "5.0.0", default-features = false }
+pop-api = { path = "../../../pop-api", default-features = false, features = ["inkv5"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/pop-api/examples/read-runtime-state/Cargo.toml
+++ b/pop-api/examples/read-runtime-state/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0-rc.3", default-features = false }
-pop-api = { path = "../../../pop-api", default-features = false }
+ink = { version = "4.3.0", default-features = false }
+pop-api = { path = "../../../pop-api", default-features = false, features = ["inkv4"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 


### PR DESCRIPTION
Makes the selection of major ink version explicit until ink! v5 is audited. Not the best solution by any means, as it means that use needs to explicitly set the required version, but perhaps this at least allows the user to consider which version they are using. Perhaps also allows some backwards compatibility for now, but need to consider how this might work in the future when v5 becomes the default.

`pop-api = { path = "../../../pop-api", default-features = false, features = ["inkv4"] }`

Example contracts alternate between using v4 and v5.

Closes #56 