### PR TITLE
build(testnet): bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9784,7 +9784,7 @@ dependencies = [
 
 [[package]]
 name = "pop-runtime-testnet"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pop-runtime-testnet"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 description.workspace = true
 license = "Unlicense"

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -177,7 +177,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("pop"),
 	authoring_version: 1,
 	#[allow(clippy::zero_prefixed_literal)]
-	spec_version: 00_01_00,
+	spec_version: 00_02_00,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Bumps runtime version ahead of next release, purely to resolve a node syncing issue introduced with the last version bump of dependencies (i.e. 1.7 SDK update via `psvm -v 1.7.0`). 

The executor used is still the below, so the native wasm now built is panicing when verifying state roots, presumably due to the changes introduced in sp_api. 

`type ParachainExecutor<E> = NativeElseWasmExecutor<E>;`

This version bump would have had to have happend in any case, but doing so ensures that the onchain wasm is used and the node syncs.

Further investigation and testing should be carried out.