### PR TITLE
feat: asset management

### DIFF
--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -75,6 +75,9 @@ pub mod pallet {
 		/// Token decimals for a given asset ID.
 		#[codec(index = 10)]
 		TokenDecimals(AssetIdOf<T>),
+		/// Check if token exists for a given asset ID.
+		#[codec(index = 18)]
+		AssetExists(AssetIdOf<T>),
 	}
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
@@ -319,6 +322,7 @@ pub mod pallet {
 				TokenDecimals(id) => {
 					<AssetsOf<T> as MetadataInspect<AccountIdOf<T>>>::decimals(id).encode()
 				},
+				AssetExists(id) => AssetsOf::<T>::asset_exists(id).encode(),
 			}
 		}
 

--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -21,6 +21,7 @@ type AssetIdParameterOf<T> = <T as pallet_assets::Config<AssetsInstanceOf<T>>>::
 type AssetsOf<T> = pallet_assets::Pallet<T, AssetsInstanceOf<T>>;
 type AssetsInstanceOf<T> = <T as Config>::AssetsInstance;
 type AssetsWeightInfoOf<T> = <T as pallet_assets::Config<AssetsInstanceOf<T>>>::WeightInfo;
+type RemoveItemsLimitOf<T> = <T as pallet_assets::Config<AssetsInstanceOf<T>>>::RemoveItemsLimit;
 type BalanceOf<T> = <pallet_assets::Pallet<T, AssetsInstanceOf<T>> as Inspect<
 	<T as frame_system::Config>::AccountId,
 >>::Balance;
@@ -196,12 +197,64 @@ pub mod pallet {
 			AssetsOf::<T>::create(origin, id.into(), admin, min_balance)
 		}
 
+		/// Create a new token with a given asset ID.
+		///
+		/// # Arguments
+		/// * `id` - The ID of the asset.
+		/// * `admin` - The account that will administer the asset.
+		/// * `min_balance` - The minimum balance required for accounts holding this asset.
+		#[pallet::call_index(12)]
+		#[pallet::weight(AssetsWeightInfoOf::<T>::start_destroy())]
+		pub fn start_destroy(origin: OriginFor<T>, id: AssetIdOf<T>) -> DispatchResult {
+			AssetsOf::<T>::start_destroy(origin, id.into())
+		}
+
+		/// Destroy all accounts associated with a token with a given asset ID.
+		///
+		/// # Parameters
+		/// - `id` - The ID of the asset.
+		// TODO: weight function
+		#[pallet::call_index(13)]
+		#[pallet::weight(AssetsWeightInfoOf::<T>::destroy_accounts(RemoveItemsLimitOf::<T>::get() / 6))]
+		pub fn destroy_accounts(
+			origin: OriginFor<T>,
+			id: AssetIdOf<T>,
+		) -> DispatchResultWithPostInfo {
+			AssetsOf::<T>::destroy_accounts(origin, id.into())
+		}
+
+		/// Destroy all approvals associated with a token with a given asset ID.
+		///
+		/// # Parameters
+		/// - `id` - The ID of the asset.
+		// TODO: weight function
+		#[pallet::call_index(14)]
+		#[pallet::weight(AssetsWeightInfoOf::<T>::destroy_approvals(RemoveItemsLimitOf::<T>::get() / 4))]
+		pub fn destroy_approvals(
+			origin: OriginFor<T>,
+			id: AssetIdOf<T>,
+		) -> DispatchResultWithPostInfo {
+			AssetsOf::<T>::destroy_approvals(origin, id.into())
+		}
+
+		/// Complete the process of destroying a token with a given asset ID.
+		///
+		/// # Parameters
+		/// - `id` - The ID of the asset.
+		#[pallet::call_index(15)]
+		#[pallet::weight(AssetsWeightInfoOf::<T>::finish_destroy())]
+		pub fn finish_destroy(origin: OriginFor<T>, id: AssetIdOf<T>) -> DispatchResult {
+			AssetsOf::<T>::finish_destroy(origin, id.into())
+		}
+
 		/// Set the metadata for a token with a given asset ID.
 		///
 		/// # Parameters
 		/// - `id`: The identifier of the asset to update.
-		/// - `name`: The user friendly name of this asset. Limited in length by `StringLimit`.
-		/// - `symbol`: The exchange symbol for this asset. Limited in length by `StringLimit`.
+		/// - `name`: The user friendly name of this asset. Limited in length by
+		///   `pallet_assets::Config::StringLimit`.
+		/// - `symbol`: The exchange symbol for this asset. Limited in length by
+		///   `pallet_assets::Config::StringLimit`.
 		/// - `decimals`: The number of decimals this asset uses to represent one unit.
 		#[pallet::call_index(16)]
 		#[pallet::weight(AssetsWeightInfoOf::<T>::set_metadata(name.len() as u32, symbol.len() as u32))]
@@ -213,6 +266,12 @@ pub mod pallet {
 			decimals: u8,
 		) -> DispatchResult {
 			AssetsOf::<T>::set_metadata(origin, id.into(), name, symbol, decimals)
+		}
+
+		#[pallet::call_index(17)]
+		#[pallet::weight(AssetsWeightInfoOf::<T>::clear_metadata())]
+		pub fn clear_metadata(origin: OriginFor<T>, id: AssetIdOf<T>) -> DispatchResult {
+			AssetsOf::<T>::clear_metadata(origin, id.into())
 		}
 	}
 

--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -293,6 +293,42 @@ pub mod pallet {
 		pub fn clear_metadata(origin: OriginFor<T>, id: AssetIdOf<T>) -> DispatchResult {
 			AssetsOf::<T>::clear_metadata(origin, id.into())
 		}
+
+		/// Creates `amount` tokens and assigns them to `account`, increasing the total supply.
+		///
+		/// # Parameters
+		/// - `id` - The ID of the asset.
+		/// - `owner` - The account to be credited with the created tokens.
+		/// - `value` - The number of tokens to mint.
+		#[pallet::call_index(19)]
+		#[pallet::weight(AssetsWeightInfoOf::<T>::mint())]
+		pub fn mint(
+			origin: OriginFor<T>,
+			id: AssetIdOf<T>,
+			account: AccountIdOf<T>,
+			amount: BalanceOf<T>,
+		) -> DispatchResult {
+			let account = T::Lookup::unlookup(account);
+			AssetsOf::<T>::mint(origin, id.into(), account, amount)
+		}
+
+		/// Destroys `amount` tokens from `account`, reducing the total supply.
+		///
+		/// # Parameters
+		/// - `id` - The ID of the asset.
+		/// - `owner` - The account from which the tokens will be destroyed.
+		/// - `value` - The number of tokens to destroy.
+		#[pallet::call_index(20)]
+		#[pallet::weight(AssetsWeightInfoOf::<T>::burn())]
+		pub fn burn(
+			origin: OriginFor<T>,
+			id: AssetIdOf<T>,
+			account: AccountIdOf<T>,
+			amount: BalanceOf<T>,
+		) -> DispatchResult {
+			let account = T::Lookup::unlookup(account);
+			AssetsOf::<T>::burn(origin, id.into(), account, amount)
+		}
 	}
 
 	impl<T: Config> Pallet<T> {

--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -177,6 +177,43 @@ pub mod pallet {
 			let spender = T::Lookup::unlookup(spender);
 			AssetsOf::<T>::approve_transfer(origin, id.into(), spender, value)
 		}
+
+		/// Create a new token with a given asset ID.
+		///
+		/// # Arguments
+		/// * `id` - The ID of the asset.
+		/// * `admin` - The account that will administer the asset.
+		/// * `min_balance` - The minimum balance required for accounts holding this asset.
+		#[pallet::call_index(11)]
+		#[pallet::weight(AssetsWeightInfoOf::<T>::create())]
+		pub fn create(
+			origin: OriginFor<T>,
+			id: AssetIdOf<T>,
+			admin: AccountIdOf<T>,
+			min_balance: BalanceOf<T>,
+		) -> DispatchResult {
+			let admin = T::Lookup::unlookup(admin);
+			AssetsOf::<T>::create(origin, id.into(), admin, min_balance)
+		}
+
+		/// Set the metadata for a token with a given asset ID.
+		///
+		/// # Parameters
+		/// - `id`: The identifier of the asset to update.
+		/// - `name`: The user friendly name of this asset. Limited in length by `StringLimit`.
+		/// - `symbol`: The exchange symbol for this asset. Limited in length by `StringLimit`.
+		/// - `decimals`: The number of decimals this asset uses to represent one unit.
+		#[pallet::call_index(16)]
+		#[pallet::weight(AssetsWeightInfoOf::<T>::set_metadata(name.len() as u32, symbol.len() as u32))]
+		pub fn set_metadata(
+			origin: OriginFor<T>,
+			id: AssetIdOf<T>,
+			name: Vec<u8>,
+			symbol: Vec<u8>,
+			decimals: u8,
+		) -> DispatchResult {
+			AssetsOf::<T>::set_metadata(origin, id.into(), name, symbol, decimals)
+		}
 	}
 
 	impl<T: Config> Pallet<T> {

--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -96,9 +96,9 @@ pub mod pallet {
 		/// `data` in unspecified format.
 		///
 		/// # Parameters
-		/// * `id` - The ID of the asset.
-		/// * `to` - The recipient account.
-		/// * `value` - The number of tokens to transfer.
+		/// - `id` - The ID of the asset.
+		/// - `to` - The recipient account.
+		/// - `value` - The number of tokens to transfer.
 		#[pallet::call_index(3)]
 		#[pallet::weight(AssetsWeightInfoOf::<T>::transfer_keep_alive())]
 		pub fn transfer(
@@ -114,9 +114,9 @@ pub mod pallet {
 		/// Approves an account to spend a specified number of tokens on behalf of the caller.
 		///
 		/// # Parameters
-		/// * `id` - The ID of the asset.
-		/// * `spender` - The account that is allowed to spend the tokens.
-		/// * `value` - The number of tokens to approve.
+		/// - `id` - The ID of the asset.
+		/// - `spender` - The account that is allowed to spend the tokens.
+		/// - `value` - The number of tokens to approve.
 		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::approve(1, 1))]
 		pub fn approve(
@@ -164,9 +164,9 @@ pub mod pallet {
 		/// Increases the allowance of a spender.
 		///
 		/// # Parameters
-		/// * `id` - The ID of the asset.
-		/// * `spender` - The account that is allowed to spend the tokens.
-		/// * `value` - The number of tokens to increase the allowance by.
+		/// - `id` - The ID of the asset.
+		/// - `spender` - The account that is allowed to spend the tokens.
+		/// - `value` - The number of tokens to increase the allowance by.
 		#[pallet::call_index(6)]
 		#[pallet::weight(AssetsWeightInfoOf::<T>::approve_transfer())]
 		pub fn increase_allowance(
@@ -181,10 +181,10 @@ pub mod pallet {
 
 		/// Create a new token with a given asset ID.
 		///
-		/// # Arguments
-		/// * `id` - The ID of the asset.
-		/// * `admin` - The account that will administer the asset.
-		/// * `min_balance` - The minimum balance required for accounts holding this asset.
+		/// # Parameters
+		/// - `id` - The ID of the asset.
+		/// - `admin` - The account that will administer the asset.
+		/// - `min_balance` - The minimum balance required for accounts holding this asset.
 		#[pallet::call_index(11)]
 		#[pallet::weight(AssetsWeightInfoOf::<T>::create())]
 		pub fn create(
@@ -199,10 +199,10 @@ pub mod pallet {
 
 		/// Create a new token with a given asset ID.
 		///
-		/// # Arguments
-		/// * `id` - The ID of the asset.
-		/// * `admin` - The account that will administer the asset.
-		/// * `min_balance` - The minimum balance required for accounts holding this asset.
+		/// # Parameters
+		/// - `id` - The ID of the asset.
+		/// - `admin` - The account that will administer the asset.
+		/// - `min_balance` - The minimum balance required for accounts holding this asset.
 		#[pallet::call_index(12)]
 		#[pallet::weight(AssetsWeightInfoOf::<T>::start_destroy())]
 		pub fn start_destroy(origin: OriginFor<T>, id: AssetIdOf<T>) -> DispatchResult {
@@ -282,7 +282,7 @@ pub mod pallet {
 		/// encoded result.
 		///
 		/// # Parameter
-		/// * `value` - An instance of `Read<T>`, which specifies the type of state query and
+		/// - `value` - An instance of `Read<T>`, which specifies the type of state query and
 		/// 		  the associated parameters.
 		pub fn read_state(value: Read<T>) -> Vec<u8> {
 			use Read::*;

--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -21,7 +21,6 @@ type AssetIdParameterOf<T> = <T as pallet_assets::Config<AssetsInstanceOf<T>>>::
 type AssetsOf<T> = pallet_assets::Pallet<T, AssetsInstanceOf<T>>;
 type AssetsInstanceOf<T> = <T as Config>::AssetsInstance;
 type AssetsWeightInfoOf<T> = <T as pallet_assets::Config<AssetsInstanceOf<T>>>::WeightInfo;
-type RemoveItemsLimitOf<T> = <T as pallet_assets::Config<AssetsInstanceOf<T>>>::RemoveItemsLimit;
 type BalanceOf<T> = <pallet_assets::Pallet<T, AssetsInstanceOf<T>> as Inspect<
 	<T as frame_system::Config>::AccountId,
 >>::Balance;
@@ -207,44 +206,6 @@ pub mod pallet {
 		#[pallet::weight(AssetsWeightInfoOf::<T>::start_destroy())]
 		pub fn start_destroy(origin: OriginFor<T>, id: AssetIdOf<T>) -> DispatchResult {
 			AssetsOf::<T>::start_destroy(origin, id.into())
-		}
-
-		/// Destroy all accounts associated with a token with a given asset ID.
-		///
-		/// # Parameters
-		/// - `id` - The ID of the asset.
-		// TODO: weight function
-		#[pallet::call_index(13)]
-		#[pallet::weight(AssetsWeightInfoOf::<T>::destroy_accounts(RemoveItemsLimitOf::<T>::get() / 6))]
-		pub fn destroy_accounts(
-			origin: OriginFor<T>,
-			id: AssetIdOf<T>,
-		) -> DispatchResultWithPostInfo {
-			AssetsOf::<T>::destroy_accounts(origin, id.into())
-		}
-
-		/// Destroy all approvals associated with a token with a given asset ID.
-		///
-		/// # Parameters
-		/// - `id` - The ID of the asset.
-		// TODO: weight function
-		#[pallet::call_index(14)]
-		#[pallet::weight(AssetsWeightInfoOf::<T>::destroy_approvals(RemoveItemsLimitOf::<T>::get() / 4))]
-		pub fn destroy_approvals(
-			origin: OriginFor<T>,
-			id: AssetIdOf<T>,
-		) -> DispatchResultWithPostInfo {
-			AssetsOf::<T>::destroy_approvals(origin, id.into())
-		}
-
-		/// Complete the process of destroying a token with a given asset ID.
-		///
-		/// # Parameters
-		/// - `id` - The ID of the asset.
-		#[pallet::call_index(15)]
-		#[pallet::weight(AssetsWeightInfoOf::<T>::finish_destroy())]
-		pub fn finish_destroy(origin: OriginFor<T>, id: AssetIdOf<T>) -> DispatchResult {
-			AssetsOf::<T>::finish_destroy(origin, id.into())
 		}
 
 		/// Set the metadata for a token with a given asset ID.

--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -303,7 +303,7 @@ pub mod pallet {
 		///
 		/// # Parameter
 		/// - `value` - An instance of `Read<T>`, which specifies the type of state query and
-		/// 		  the associated parameters.
+		///   the associated parameters.
 		pub fn read_state(value: Read<T>) -> Vec<u8> {
 			use Read::*;
 

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -190,6 +190,14 @@ fn token_metadata_works() {
 	});
 }
 
+#[test]
+fn asset_exists_works() {
+	new_test_ext().execute_with(|| {
+		create_asset(ALICE, ASSET, 100);
+		assert_eq!(Assets::asset_exists(ASSET).encode(), Fungibles::read_state(AssetExists(ASSET)));
+	});
+}
+
 fn signed(account: AccountId) -> RuntimeOrigin {
 	RuntimeOrigin::signed(account)
 }

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -2,7 +2,9 @@ use crate::{fungibles::Read::*, mock::*};
 use codec::Encode;
 use frame_support::{
 	assert_ok,
-	traits::fungibles::{approvals::Inspect, metadata::Inspect as MetadataInspect},
+	traits::fungibles::{
+		approvals::Inspect as ApprovalInspect, metadata::Inspect as MetadataInspect, Inspect,
+	},
 };
 
 const ASSET: u32 = 42;
@@ -54,6 +56,35 @@ fn increase_allowance_works() {
 		// Additive.
 		assert_ok!(Fungibles::increase_allowance(signed(ALICE), ASSET, BOB, amount));
 		assert_eq!(Assets::allowance(ASSET, &ALICE, &BOB), amount * 2);
+	});
+}
+
+#[test]
+fn create_works() {
+	new_test_ext().execute_with(|| {
+		assert!(!Assets::asset_exists(ASSET));
+		assert_ok!(Fungibles::create(signed(ALICE), ASSET, ALICE, 100));
+		assert!(Assets::asset_exists(ASSET));
+	});
+}
+
+#[test]
+fn set_metadata_works() {
+	new_test_ext().execute_with(|| {
+		let name = vec![42];
+		let symbol = vec![42];
+		let decimals = 42;
+		create_asset(ALICE, ASSET, 100);
+		assert_ok!(Fungibles::set_metadata(
+			signed(ALICE),
+			ASSET,
+			name.clone(),
+			symbol.clone(),
+			decimals
+		));
+		assert_eq!(Assets::name(ASSET), name);
+		assert_eq!(Assets::symbol(ASSET), symbol);
+		assert_eq!(Assets::decimals(ASSET), decimals);
 	});
 }
 

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -69,6 +69,17 @@ fn create_works() {
 }
 
 #[test]
+fn destroy_asset_works() {
+	new_test_ext().execute_with(|| {
+		create_asset(ALICE, ASSET, 100);
+		assert_ok!(Fungibles::start_destroy(signed(ALICE), ASSET));
+		assert_ok!(Fungibles::destroy_accounts(signed(ALICE), ASSET));
+		assert_ok!(Fungibles::destroy_approvals(signed(ALICE), ASSET));
+		assert_ok!(Fungibles::finish_destroy(signed(ALICE), ASSET));
+	});
+}
+
+#[test]
 fn set_metadata_works() {
 	new_test_ext().execute_with(|| {
 		let name = vec![42];
@@ -85,6 +96,20 @@ fn set_metadata_works() {
 		assert_eq!(Assets::name(ASSET), name);
 		assert_eq!(Assets::symbol(ASSET), symbol);
 		assert_eq!(Assets::decimals(ASSET), decimals);
+	});
+}
+
+#[test]
+fn clear_metadata_works() {
+	new_test_ext().execute_with(|| {
+		let name = vec![42];
+		let symbol = vec![42];
+		let decimals = 42;
+		create_asset_and_set_metadata(ALICE, ASSET, name, symbol, decimals);
+		assert_ok!(Fungibles::clear_metadata(signed(ALICE), ASSET));
+		assert_eq!(Assets::name(ASSET), Vec::<u8>::new());
+		assert_eq!(Assets::symbol(ASSET), Vec::<u8>::new());
+		assert_eq!(Assets::decimals(ASSET), 0u8);
 	});
 }
 

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -69,13 +69,10 @@ fn create_works() {
 }
 
 #[test]
-fn destroy_asset_works() {
+fn start_destroy_works() {
 	new_test_ext().execute_with(|| {
 		create_asset(ALICE, ASSET, 100);
 		assert_ok!(Fungibles::start_destroy(signed(ALICE), ASSET));
-		assert_ok!(Fungibles::destroy_accounts(signed(ALICE), ASSET));
-		assert_ok!(Fungibles::destroy_approvals(signed(ALICE), ASSET));
-		assert_ok!(Fungibles::finish_destroy(signed(ALICE), ASSET));
 	});
 }
 

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -108,7 +108,7 @@ fn create_works() {
 #[test]
 fn start_destroy_works() {
 	new_test_ext().execute_with(|| {
-		create_asset(ALICE, ASSET, 100);
+		create_asset(ALICE, ASSET);
 		assert_ok!(Fungibles::start_destroy(signed(ALICE), ASSET));
 	});
 }
@@ -119,7 +119,7 @@ fn set_metadata_works() {
 		let name = vec![42];
 		let symbol = vec![42];
 		let decimals = 42;
-		create_asset(ALICE, ASSET, 100);
+		create_asset(ALICE, ASSET);
 		assert_ok!(Fungibles::set_metadata(
 			signed(ALICE),
 			ASSET,
@@ -144,6 +144,30 @@ fn clear_metadata_works() {
 		assert_eq!(Assets::name(ASSET), Vec::<u8>::new());
 		assert_eq!(Assets::symbol(ASSET), Vec::<u8>::new());
 		assert_eq!(Assets::decimals(ASSET), 0u8);
+	});
+}
+
+#[test]
+fn mint_works() {
+	new_test_ext().execute_with(|| {
+		let amount: Balance = 100 * UNIT;
+		create_asset(ALICE, ASSET);
+		let balance_before_mint = Assets::balance(ASSET, &BOB);
+		assert_ok!(Fungibles::mint(signed(ALICE), ASSET, BOB, amount));
+		let balance_after_mint = Assets::balance(ASSET, &BOB);
+		assert_eq!(balance_after_mint, balance_before_mint + amount);
+	});
+}
+
+#[test]
+fn burn_works() {
+	new_test_ext().execute_with(|| {
+		let amount: Balance = 100 * UNIT;
+		create_asset_and_mint_to(ALICE, ASSET, BOB, amount);
+		let balance_before_burn = Assets::balance(ASSET, &BOB);
+		assert_ok!(Fungibles::burn(signed(ALICE), ASSET, BOB, amount));
+		let balance_after_burn = Assets::balance(ASSET, &BOB);
+		assert_eq!(balance_after_burn, balance_before_burn - amount);
 	});
 }
 
@@ -193,7 +217,7 @@ fn token_metadata_works() {
 #[test]
 fn asset_exists_works() {
 	new_test_ext().execute_with(|| {
-		create_asset(ALICE, ASSET, 100);
+		create_asset(ALICE, ASSET);
 		assert_eq!(Assets::asset_exists(ASSET).encode(), Fungibles::read_state(AssetExists(ASSET)));
 	});
 }
@@ -202,8 +226,8 @@ fn signed(account: AccountId) -> RuntimeOrigin {
 	RuntimeOrigin::signed(account)
 }
 
-fn create_asset(owner: AccountId, asset_id: AssetId, min_balance: Balance) {
-	assert_ok!(Assets::create(signed(owner), asset_id, owner, min_balance));
+fn create_asset(owner: AccountId, asset_id: AssetId) {
+	assert_ok!(Assets::create(signed(owner), asset_id, owner, 1));
 }
 
 fn mint_asset(owner: AccountId, asset_id: AssetId, to: AccountId, value: Balance) {
@@ -211,7 +235,7 @@ fn mint_asset(owner: AccountId, asset_id: AssetId, to: AccountId, value: Balance
 }
 
 fn create_asset_and_mint_to(owner: AccountId, asset_id: AssetId, to: AccountId, value: Balance) {
-	create_asset(owner, asset_id, 1);
+	create_asset(owner, asset_id);
 	mint_asset(owner, asset_id, to, value)
 }
 

--- a/pop-api/examples/balance-transfer/lib.rs
+++ b/pop-api/examples/balance-transfer/lib.rs
@@ -1,3 +1,4 @@
+// DEPRECATED
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 use pop_api::balances::*;

--- a/pop-api/examples/nfts/lib.rs
+++ b/pop-api/examples/nfts/lib.rs
@@ -1,3 +1,4 @@
+// DEPRECATED
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 use pop_api::nfts::*;
@@ -33,27 +34,29 @@ mod nfts {
 		}
 
 		#[ink(message)]
-		pub fn create_nft_collection( &self ) -> Result<(), ContractError>{
+		pub fn create_nft_collection(&self) -> Result<(), ContractError> {
 			ink::env::debug_println!("Nfts::create_nft_collection: collection creation started.");
-            let admin = Self::env().caller();
-            let item_settings = ItemSettings(BitFlags::from(ItemSetting::Transferable));
+			let admin = Self::env().caller();
+			let item_settings = ItemSettings(BitFlags::from(ItemSetting::Transferable));
 
-            let mint_settings = MintSettings {
-                mint_type: MintType::Issuer,
-                price: Some(0),
-                start_block: Some(0),
-                end_block: Some(0),
-                default_item_settings: item_settings,
-            };
+			let mint_settings = MintSettings {
+				mint_type: MintType::Issuer,
+				price: Some(0),
+				start_block: Some(0),
+				end_block: Some(0),
+				default_item_settings: item_settings,
+			};
 
-            let config = CollectionConfig {
-                settings: CollectionSettings(BitFlags::from(CollectionSetting::TransferableItems)),  
-                max_supply: None,
-                mint_settings,
-            };
-            pop_api::nfts::create(admin, config)?;
-			ink::env::debug_println!("Nfts::create_nft_collection: collection created successfully.");
-            Ok(())
+			let config = CollectionConfig {
+				settings: CollectionSettings(BitFlags::from(CollectionSetting::TransferableItems)),
+				max_supply: None,
+				mint_settings,
+			};
+			pop_api::nfts::create(admin, config)?;
+			ink::env::debug_println!(
+				"Nfts::create_nft_collection: collection created successfully."
+			);
+			Ok(())
 		}
 
 		#[ink(message)]
@@ -82,9 +85,7 @@ mod nfts {
 			// check owner
 			match owner(collection_id, item_id)? {
 				Some(owner) if owner == receiver => {
-					ink::env::debug_println!(
-						"Nfts::mint success: minted item belongs to receiver"
-					);
+					ink::env::debug_println!("Nfts::mint success: minted item belongs to receiver");
 				},
 				_ => {
 					return Err(ContractError::NotOwner);

--- a/pop-api/examples/place-spot-order/lib.rs
+++ b/pop-api/examples/place-spot-order/lib.rs
@@ -1,3 +1,4 @@
+// DEPRECATED
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 #[ink::contract(env = pop_api::Environment)]
@@ -15,11 +16,7 @@ mod spot_order {
 		}
 
 		#[ink(message)]
-		pub fn place_spot_order(
-			&mut self,
-			max_amount: Balance,
-			para_id: u32,
-		) {
+		pub fn place_spot_order(&mut self, max_amount: Balance, para_id: u32) {
 			ink::env::debug_println!(
 				"SpotOrder::place_spot_order: max_amount {:?} para_id: {:?} ",
 				max_amount,
@@ -28,10 +25,7 @@ mod spot_order {
 
 			#[allow(unused_variables)]
 			let res = pop_api::cross_chain::coretime::place_spot_order(max_amount, para_id);
-			ink::env::debug_println!(
-				"SpotOrder::place_spot_order: res {:?} ",
-				res,
-			);
+			ink::env::debug_println!("SpotOrder::place_spot_order: res {:?} ", res,);
 
 			ink::env::debug_println!("SpotOrder::place_spot_order end");
 		}

--- a/pop-api/examples/read-runtime-state/lib.rs
+++ b/pop-api/examples/read-runtime-state/lib.rs
@@ -1,35 +1,36 @@
+// DEPRECATED
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 #[ink::contract(env = pop_api::Environment)]
 mod read_relay_blocknumber {
-    use pop_api::primitives::storage_keys::{
-        ParachainSystemKeys::LastRelayChainBlockNumber, RuntimeStateKeys::ParachainSystem,
-    };
+	use pop_api::primitives::storage_keys::{
+		ParachainSystemKeys::LastRelayChainBlockNumber, RuntimeStateKeys::ParachainSystem,
+	};
 
-    #[ink(event)]
-    pub struct RelayBlockNumberRead {
-        value: BlockNumber,
-    }
+	#[ink(event)]
+	pub struct RelayBlockNumberRead {
+		value: BlockNumber,
+	}
 
-    #[ink(storage)]
-    #[derive(Default)]
-    pub struct ReadRelayBlockNumber;
+	#[ink(storage)]
+	#[derive(Default)]
+	pub struct ReadRelayBlockNumber;
 
-    impl ReadRelayBlockNumber {
-        #[ink(constructor, payable)]
-        pub fn new() -> Self {
-            ink::env::debug_println!("ReadRelayBlockNumber::new");
-            Default::default()
-        }
+	impl ReadRelayBlockNumber {
+		#[ink(constructor, payable)]
+		pub fn new() -> Self {
+			ink::env::debug_println!("ReadRelayBlockNumber::new");
+			Default::default()
+		}
 
-        #[ink(message)]
-        pub fn read_relay_block_number(&self) {
-            let result =
-                pop_api::state::read::<BlockNumber>(ParachainSystem(LastRelayChainBlockNumber));
-            ink::env::debug_println!("Last relay block number read by contract: {:?}", result);
-            self.env().emit_event(RelayBlockNumberRead {
-                value: result.expect("Failed to read relay block number."),
-            });
-        }
-    }
+		#[ink(message)]
+		pub fn read_relay_block_number(&self) {
+			let result =
+				pop_api::state::read::<BlockNumber>(ParachainSystem(LastRelayChainBlockNumber));
+			ink::env::debug_println!("Last relay block number read by contract: {:?}", result);
+			self.env().emit_event(RelayBlockNumberRead {
+				value: result.expect("Failed to read relay block number."),
+			});
+		}
+	}
 }

--- a/pop-api/integration-tests/contracts/.gitignore
+++ b/pop-api/integration-tests/contracts/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+**/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+**/Cargo.lock

--- a/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.toml
+++ b/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "create_token_in_constructor"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "5.0.0", default-features = false }
+pop-api = { path = "../../..", default-features = false, features = ["fungibles"] }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "pop-api/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/pop-api/integration-tests/contracts/create_token_in_constructor/lib.rs
+++ b/pop-api/integration-tests/contracts/create_token_in_constructor/lib.rs
@@ -22,8 +22,9 @@ mod create_token_in_constructor {
 		#[ink(constructor, payable)]
 		pub fn new(id: AssetId, min_balance: Balance) -> Result<Self> {
 			let contract = Self { id };
-			let account = contract.env().account_id();
-			api::create(id, account, min_balance)?;
+			// AccountId of the contract which will be set to the owner of the fungible token.
+			let owner = contract.env().account_id();
+			api::create(id, owner, min_balance)?;
 			Ok(contract)
 		}
 

--- a/pop-api/integration-tests/contracts/create_token_in_constructor/lib.rs
+++ b/pop-api/integration-tests/contracts/create_token_in_constructor/lib.rs
@@ -1,0 +1,45 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+use ink::prelude::vec::Vec;
+use pop_api::{
+	assets::fungibles::{self as api},
+	primitives::AssetId,
+	StatusCode,
+};
+
+pub type Result<T> = core::result::Result<T, StatusCode>;
+
+#[ink::contract]
+mod create_token_in_constructor {
+	use super::*;
+
+	#[ink(storage)]
+	pub struct Fungible {
+		id: AssetId,
+	}
+
+	impl Fungible {
+		#[ink(constructor, payable)]
+		pub fn new(id: AssetId, min_balance: Balance) -> Result<Self> {
+			let contract = Self { id };
+			let account = contract.env().account_id();
+			api::create(id, account, min_balance)?;
+			Ok(contract)
+		}
+
+		#[ink(message)]
+		pub fn asset_exists(&self) -> Result<bool> {
+			api::asset_exists(self.id)
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+
+		#[ink::test]
+		fn default_works() {
+			PopApiFungiblesExample::new();
+		}
+	}
+}

--- a/pop-api/integration-tests/contracts/fungibles/lib.rs
+++ b/pop-api/integration-tests/contracts/fungibles/lib.rs
@@ -122,14 +122,14 @@ mod fungibles {
 			api::token_decimals(id)
 		}
 
-		// 3. Asset Management:
-		// - create
-		// - start_destroy
-		// - destroy_accounts
-		// - destroy_approvals
-		// - finish_destroy
-		// - set_metadata
-		// - clear_metadata
+		/// 3. Asset Management:
+		/// - create
+		/// - start_destroy
+		/// - destroy_accounts
+		/// - destroy_approvals
+		/// - finish_destroy
+		/// - set_metadata
+		/// - clear_metadata
 
 		#[ink(message)]
 		pub fn create(&self, id: AssetId, admin: AccountId, min_balance: Balance) -> Result<()> {
@@ -160,6 +160,19 @@ mod fungibles {
 		#[ink(message)]
 		pub fn asset_exists(&self, id: AssetId) -> Result<bool> {
 			api::asset_exists(id)
+		}
+		/// 4. PSP-22 Mintable & Burnable Interface:
+		/// - mint
+		/// - burn
+
+		#[ink(message)]
+		pub fn mint(&self, id: AssetId, account: AccountId, amount: Balance) -> Result<()> {
+			api::mint(id, account, amount)
+		}
+
+		#[ink(message)]
+		pub fn burn(&self, id: AssetId, account: AccountId, amount: Balance) -> Result<()> {
+			api::burn(id, account, amount)
 		}
 	}
 

--- a/pop-api/integration-tests/contracts/fungibles/lib.rs
+++ b/pop-api/integration-tests/contracts/fungibles/lib.rs
@@ -142,21 +142,6 @@ mod fungibles {
 		}
 
 		#[ink(message)]
-		pub fn destroy_accounts(&self, id: AssetId) -> Result<()> {
-			api::destroy_accounts(id)
-		}
-
-		#[ink(message)]
-		pub fn destroy_approvals(&self, id: AssetId) -> Result<()> {
-			api::destroy_approvals(id)
-		}
-
-		#[ink(message)]
-		pub fn finish_destroy(&self, id: AssetId) -> Result<()> {
-			api::finish_destroy(id)
-		}
-
-		#[ink(message)]
 		pub fn set_metadata(
 			&self,
 			id: AssetId,

--- a/pop-api/integration-tests/contracts/fungibles/lib.rs
+++ b/pop-api/integration-tests/contracts/fungibles/lib.rs
@@ -131,40 +131,21 @@ mod fungibles {
 		// - set_metadata
 		// - clear_metadata
 
-		// #[ink(message)]
-		// pub fn create(&self, id: AssetId, admin: AccountId, min_balance: Balance) -> Result<()> {
-		// 	ink::env::debug_println!(
-		// 		"PopApiFungiblesExample::create: id: {:?} admin: {:?} min_balance: {:?}",
-		// 		id,
-		// 		admin,
-		// 		min_balance,
-		// 	);
-		// 	let result = api::create(id, admin, min_balance);
-		// 	ink::env::debug_println!("Result: {:?}", result);
-		// result.map_err(|e| e.into())
-		// result
-		// }
+		#[ink(message)]
+		pub fn create(&self, id: AssetId, admin: AccountId, min_balance: Balance) -> Result<()> {
+			api::create(id, admin, min_balance)
+		}
 
-		// #[ink(message)]
-		// pub fn set_metadata(
-		// 	&self,
-		// 	id: AssetId,
-		// 	name: Vec<u8>,
-		// 	symbol: Vec<u8>,
-		// 	decimals: u8,
-		// ) -> Result<()> {
-		// 	ink::env::debug_println!(
-		// 		"PopApiFungiblesExample::set_metadata: id: {:?} name: {:?} symbol: {:?}, decimals: {:?}",
-		// 		id,
-		// 		name,
-		// 		symbol,
-		// 		decimals,
-		// 	);
-		// 	let result = api::set_metadata(id, name, symbol, decimals);
-		// 	ink::env::debug_println!("Result: {:?}", result);
-		// 	// result.map_err(|e| e.into())
-		// 	result
-		// }
+		#[ink(message)]
+		pub fn set_metadata(
+			&self,
+			id: AssetId,
+			name: Vec<u8>,
+			symbol: Vec<u8>,
+			decimals: u8,
+		) -> Result<()> {
+			api::set_metadata(id, name, symbol, decimals)
+		}
 		//
 		// #[ink(message)]
 		// pub fn asset_exists(&self, id: AssetId) -> Result<bool> {

--- a/pop-api/integration-tests/contracts/fungibles/lib.rs
+++ b/pop-api/integration-tests/contracts/fungibles/lib.rs
@@ -137,6 +137,26 @@ mod fungibles {
 		}
 
 		#[ink(message)]
+		pub fn start_destroy(&self, id: AssetId) -> Result<()> {
+			api::start_destroy(id)
+		}
+
+		#[ink(message)]
+		pub fn destroy_accounts(&self, id: AssetId) -> Result<()> {
+			api::destroy_accounts(id)
+		}
+
+		#[ink(message)]
+		pub fn destroy_approvals(&self, id: AssetId) -> Result<()> {
+			api::destroy_approvals(id)
+		}
+
+		#[ink(message)]
+		pub fn finish_destroy(&self, id: AssetId) -> Result<()> {
+			api::finish_destroy(id)
+		}
+
+		#[ink(message)]
 		pub fn set_metadata(
 			&self,
 			id: AssetId,
@@ -146,7 +166,12 @@ mod fungibles {
 		) -> Result<()> {
 			api::set_metadata(id, name, symbol, decimals)
 		}
-		//
+
+		#[ink(message)]
+		pub fn clear_metadata(&self, id: AssetId) -> Result<()> {
+			api::clear_metadata(id)
+		}
+
 		// #[ink(message)]
 		// pub fn asset_exists(&self, id: AssetId) -> Result<bool> {
 		// 	// api::asset_exists(id).map_err(|e| e.into())

--- a/pop-api/integration-tests/contracts/fungibles/lib.rs
+++ b/pop-api/integration-tests/contracts/fungibles/lib.rs
@@ -157,11 +157,10 @@ mod fungibles {
 			api::clear_metadata(id)
 		}
 
-		// #[ink(message)]
-		// pub fn asset_exists(&self, id: AssetId) -> Result<bool> {
-		// 	// api::asset_exists(id).map_err(|e| e.into())
-		// 	api::asset_exists(id)
-		// }
+		#[ink(message)]
+		pub fn asset_exists(&self, id: AssetId) -> Result<bool> {
+			api::asset_exists(id)
+		}
 	}
 
 	#[cfg(test)]

--- a/pop-api/integration-tests/src/fungibles/mod.rs
+++ b/pop-api/integration-tests/src/fungibles/mod.rs
@@ -358,8 +358,15 @@ fn instantiate_and_create_fungible_works() {
 		let _ = env_logger::try_init();
 		let contract =
 			"contracts/create_token_in_constructor/target/ink/create_token_in_constructor.wasm";
-		let addr = instantiate_and_create_fungible(contract, ASSET_ID, 1);
-		assert_eq!(asset_exists(addr, ASSET_ID), Ok(Assets::asset_exists(ASSET_ID)));
+		// Asset already exists.
+		create_asset(ALICE, 0, 1);
+		assert_eq!(
+			instantiate_and_create_fungible(contract, 0, 1),
+			Err(Module { index: 52, error: 5 })
+		);
+		// Successfully create an asset when instantiating the contract.
+		assert_ok!(instantiate_and_create_fungible(contract, ASSET_ID, 1));
+		assert!(Assets::asset_exists(ASSET_ID));
 	});
 }
 

--- a/pop-api/integration-tests/src/fungibles/utils.rs
+++ b/pop-api/integration-tests/src/fungibles/utils.rs
@@ -1,0 +1,333 @@
+use super::*;
+
+pub(super) fn decoded<T: Decode>(result: ExecReturnValue) -> Result<T, ExecReturnValue> {
+	<T>::decode(&mut &result.data[1..]).map_err(|_| result)
+}
+
+pub(super) fn total_supply(addr: AccountId32, asset_id: AssetId) -> Result<Balance, Error> {
+	let function = function_selector("total_supply");
+	let params = [function, asset_id.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<Balance, Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn balance_of(
+	addr: AccountId32,
+	asset_id: AssetId,
+	owner: AccountId32,
+) -> Result<Balance, Error> {
+	let function = function_selector("balance_of");
+	let params = [function, asset_id.encode(), owner.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<Balance, Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn allowance(
+	addr: AccountId32,
+	asset_id: AssetId,
+	owner: AccountId32,
+	spender: AccountId32,
+) -> Result<Balance, Error> {
+	let function = function_selector("allowance");
+	let params = [function, asset_id.encode(), owner.encode(), spender.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<Balance, Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn token_name(addr: AccountId32, asset_id: AssetId) -> Result<Vec<u8>, Error> {
+	let function = function_selector("token_name");
+	let params = [function, asset_id.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<Vec<u8>, Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn token_symbol(addr: AccountId32, asset_id: AssetId) -> Result<Vec<u8>, Error> {
+	let function = function_selector("token_symbol");
+	let params = [function, asset_id.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<Vec<u8>, Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn token_decimals(addr: AccountId32, asset_id: AssetId) -> Result<u8, Error> {
+	let function = function_selector("token_decimals");
+	let params = [function, asset_id.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<u8, Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn asset_exists(addr: AccountId32, asset_id: AssetId) -> Result<bool, Error> {
+	let function = function_selector("asset_exists");
+	let params = [function, asset_id.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<bool, Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn transfer(
+	addr: AccountId32,
+	asset_id: AssetId,
+	to: AccountId32,
+	value: Balance,
+) -> Result<(), Error> {
+	let function = function_selector("transfer");
+	let params = [function, asset_id.encode(), to.encode(), value.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn transfer_from(
+	addr: AccountId32,
+	asset_id: AssetId,
+	from: AccountId32,
+	to: AccountId32,
+	value: Balance,
+) -> Result<(), Error> {
+	let function = function_selector("transfer_from");
+	let data: Vec<u8> = vec![];
+	let params =
+		[function, asset_id.encode(), from.encode(), to.encode(), value.encode(), data.encode()]
+			.concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn approve(
+	addr: AccountId32,
+	asset_id: AssetId,
+	spender: AccountId32,
+	value: Balance,
+) -> Result<(), Error> {
+	let function = function_selector("approve");
+	let params = [function, asset_id.encode(), spender.encode(), value.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn increase_allowance(
+	addr: AccountId32,
+	asset_id: AssetId,
+	spender: AccountId32,
+	value: Balance,
+) -> Result<(), Error> {
+	let function = function_selector("increase_allowance");
+	let params = [function, asset_id.encode(), spender.encode(), value.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn decrease_allowance(
+	addr: AccountId32,
+	asset_id: AssetId,
+	spender: AccountId32,
+	value: Balance,
+) -> Result<(), Error> {
+	let function = function_selector("decrease_allowance");
+	let params = [function, asset_id.encode(), spender.encode(), value.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn create(
+	addr: AccountId32,
+	asset_id: AssetId,
+	admin: AccountId32,
+	min_balance: Balance,
+) -> Result<(), Error> {
+	let function = function_selector("create");
+	let params = [function, asset_id.encode(), admin.encode(), min_balance.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn start_destroy(addr: AccountId32, asset_id: AssetId) -> Result<(), Error> {
+	let function = function_selector("start_destroy");
+	let params = [function, asset_id.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	match decoded::<Result<(), Error>>(result) {
+		Ok(x) => x,
+		Err(result) => panic!("Contract reverted: {:?}", result),
+	}
+}
+
+pub(super) fn set_metadata(
+	addr: AccountId32,
+	asset_id: AssetId,
+	name: Vec<u8>,
+	symbol: Vec<u8>,
+	decimals: u8,
+) -> Result<(), Error> {
+	let function = function_selector("set_metadata");
+	let params =
+		[function, asset_id.encode(), name.encode(), symbol.encode(), decimals.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn clear_metadata(addr: AccountId32, asset_id: AssetId) -> Result<(), Error> {
+	let function = function_selector("clear_metadata");
+	let params = [function, asset_id.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn create_asset(owner: AccountId32, asset_id: AssetId, min_balance: Balance) -> AssetId {
+	assert_ok!(Assets::create(
+		RuntimeOrigin::signed(owner.clone()),
+		asset_id.into(),
+		owner.into(),
+		min_balance
+	));
+	asset_id
+}
+
+pub(super) fn mint_asset(
+	owner: AccountId32,
+	asset_id: AssetId,
+	to: AccountId32,
+	value: Balance,
+) -> AssetId {
+	assert_ok!(Assets::mint(
+		RuntimeOrigin::signed(owner.clone()),
+		asset_id.into(),
+		to.into(),
+		value
+	));
+	asset_id
+}
+
+pub(super) fn create_asset_and_mint_to(
+	owner: AccountId32,
+	asset_id: AssetId,
+	to: AccountId32,
+	value: Balance,
+) -> AssetId {
+	create_asset(owner.clone(), asset_id, 1);
+	mint_asset(owner, asset_id, to, value)
+}
+
+// Create an asset, mints to, and approves spender.
+pub(super) fn create_asset_mint_and_approve(
+	owner: AccountId32,
+	asset_id: AssetId,
+	to: AccountId32,
+	mint: Balance,
+	spender: AccountId32,
+	approve: Balance,
+) -> AssetId {
+	create_asset_and_mint_to(owner.clone(), asset_id, to.clone(), mint);
+	assert_ok!(Assets::approve_transfer(
+		RuntimeOrigin::signed(to.into()),
+		asset_id.into(),
+		spender.into(),
+		approve,
+	));
+	asset_id
+}
+
+// Freeze an asset.
+pub(super) fn freeze_asset(owner: AccountId32, asset_id: AssetId) {
+	assert_ok!(Assets::freeze_asset(RuntimeOrigin::signed(owner.into()), asset_id.into()));
+}
+
+// Thaw an asset.
+pub(super) fn thaw_asset(owner: AccountId32, asset_id: AssetId) {
+	assert_ok!(Assets::thaw_asset(RuntimeOrigin::signed(owner.into()), asset_id.into()));
+}
+
+// Start destroying an asset.
+pub(super) fn start_destroy_asset(owner: AccountId32, asset_id: AssetId) {
+	assert_ok!(Assets::start_destroy(RuntimeOrigin::signed(owner.into()), asset_id.into()));
+}
+
+// Create an asset and set metadata.
+pub(super) fn create_asset_and_set_metadata(
+	owner: AccountId32,
+	asset_id: AssetId,
+	name: Vec<u8>,
+	symbol: Vec<u8>,
+	decimals: u8,
+) -> AssetId {
+	assert_ok!(Assets::create(
+		RuntimeOrigin::signed(owner.clone()),
+		asset_id.into(),
+		owner.clone().into(),
+		100
+	));
+	set_metadata_asset(owner, asset_id, name, symbol, decimals);
+	asset_id
+}
+
+// Set metadata of an asset.
+pub(super) fn set_metadata_asset(
+	owner: AccountId32,
+	asset_id: AssetId,
+	name: Vec<u8>,
+	symbol: Vec<u8>,
+	decimals: u8,
+) {
+	assert_ok!(Assets::set_metadata(
+		RuntimeOrigin::signed(owner.into()),
+		asset_id.into(),
+		name,
+		symbol,
+		decimals
+	));
+}
+
+pub(super) fn token_name_asset(asset_id: AssetId) -> Vec<u8> {
+	<pallet_assets::Pallet<Runtime, TrustBackedAssetsInstance> as MetadataInspect<AccountId32>>::name(
+        asset_id,
+    )
+}
+
+pub(super) fn token_symbol_asset(asset_id: AssetId) -> Vec<u8> {
+	<pallet_assets::Pallet<Runtime, TrustBackedAssetsInstance> as MetadataInspect<AccountId32>>::symbol(
+        asset_id,
+    )
+}
+
+pub(super) fn token_decimals_asset(asset_id: AssetId) -> u8 {
+	<pallet_assets::Pallet<Runtime, TrustBackedAssetsInstance> as MetadataInspect<AccountId32>>::decimals(
+        asset_id,
+    )
+}
+
+pub(super) fn instantiate_and_create_fungible(
+	contract: &str,
+	asset_id: AssetId,
+	min_balance: Balance,
+) -> AccountId32 {
+	let function = function_selector("new");
+	let input = [function, asset_id.encode(), min_balance.encode()].concat();
+	let (wasm_binary, _) =
+		load_wasm_module::<Runtime>(contract).expect("could not read .wasm file");
+	let result = Contracts::bare_instantiate(
+		ALICE,
+		INIT_VALUE,
+		GAS_LIMIT,
+		None,
+		Code::Upload(wasm_binary),
+		input,
+		vec![],
+		DEBUG_OUTPUT,
+		CollectEvents::Skip,
+	)
+	.result
+	.unwrap();
+	assert!(!result.result.did_revert(), "deploying contract reverted {:?}", result);
+	result.account_id
+}

--- a/pop-api/integration-tests/src/fungibles/utils.rs
+++ b/pop-api/integration-tests/src/fungibles/utils.rs
@@ -184,6 +184,32 @@ pub(super) fn clear_metadata(addr: AccountId32, asset_id: AssetId) -> Result<(),
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
+pub(super) fn mint(
+	addr: AccountId32,
+	asset_id: AssetId,
+	account: AccountId32,
+	amount: Balance,
+) -> Result<(), Error> {
+	let function = function_selector("mint");
+	let params = [function, asset_id.encode(), account.encode(), amount.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
+pub(super) fn burn(
+	addr: AccountId32,
+	asset_id: AssetId,
+	account: AccountId32,
+	amount: Balance,
+) -> Result<(), Error> {
+	let function = function_selector("burn");
+	let params = [function, asset_id.encode(), account.encode(), amount.encode()].concat();
+	let result = bare_call(addr, params, 0).expect("should work");
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+}
+
 pub(super) fn create_asset(owner: AccountId32, asset_id: AssetId, min_balance: Balance) -> AssetId {
 	assert_ok!(Assets::create(
 		RuntimeOrigin::signed(owner.clone()),

--- a/pop-api/integration-tests/src/fungibles/utils.rs
+++ b/pop-api/integration-tests/src/fungibles/utils.rs
@@ -310,7 +310,7 @@ pub(super) fn instantiate_and_create_fungible(
 	contract: &str,
 	asset_id: AssetId,
 	min_balance: Balance,
-) -> AccountId32 {
+) -> Result<(), Error> {
 	let function = function_selector("new");
 	let input = [function, asset_id.encode(), min_balance.encode()].concat();
 	let (wasm_binary, _) =
@@ -327,7 +327,8 @@ pub(super) fn instantiate_and_create_fungible(
 		CollectEvents::Skip,
 	)
 	.result
-	.unwrap();
-	assert!(!result.result.did_revert(), "deploying contract reverted {:?}", result);
-	result.account_id
+	.expect("should work")
+	.result;
+	decoded::<Result<(), Error>>(result.clone())
+		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }

--- a/pop-api/integration-tests/src/lib.rs
+++ b/pop-api/integration-tests/src/lib.rs
@@ -16,7 +16,7 @@ use pop_runtime_devnet::{
 	UNIT,
 };
 
-mod local_fungibles;
+mod fungibles;
 
 type AssetId = u32;
 type Balance = u128;

--- a/pop-api/integration-tests/src/local_fungibles.rs
+++ b/pop-api/integration-tests/src/local_fungibles.rs
@@ -128,27 +128,6 @@ fn start_destroy(addr: AccountId32, asset_id: AssetId) -> ExecReturnValue {
 	result
 }
 
-fn destroy_accounts(addr: AccountId32, asset_id: AssetId) -> ExecReturnValue {
-	let function = function_selector("destroy_accounts");
-	let params = [function, asset_id.encode()].concat();
-	let result = bare_call(addr, params, 0).expect("should work");
-	result
-}
-
-fn destroy_approvals(addr: AccountId32, asset_id: AssetId) -> ExecReturnValue {
-	let function = function_selector("destroy_approvals");
-	let params = [function, asset_id.encode()].concat();
-	let result = bare_call(addr, params, 0).expect("should work");
-	result
-}
-
-fn finish_destroy(addr: AccountId32, asset_id: AssetId) -> ExecReturnValue {
-	let function = function_selector("finish_destroy");
-	let params = [function, asset_id.encode()].concat();
-	let result = bare_call(addr, params, 0).expect("should work");
-	result
-}
-
 fn set_metadata(
 	addr: AccountId32,
 	asset_id: AssetId,
@@ -601,72 +580,6 @@ fn start_destroy_works() {
 		);
 		let asset = create_asset(addr.clone(), ASSET_ID, 1);
 		let result = start_destroy(addr.clone(), asset);
-		assert!(!result.did_revert(), "Contract reverted!");
-	});
-}
-
-#[test]
-fn destroy_accounts_works() {
-	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
-		let addr = instantiate(CONTRACT, INIT_VALUE, vec![2]);
-		// Asset does not exist.
-		assert_eq!(
-			decoded::<Error>(destroy_accounts(addr.clone(), ASSET_ID)),
-			Ok(Module { index: 52, error: 3 }),
-		);
-		let asset = create_asset(addr.clone(), ASSET_ID, 1);
-		// The destroy process hasn't been started.
-		assert_eq!(
-			decoded::<Error>(destroy_accounts(addr.clone(), asset)),
-			Ok(Module { index: 52, error: 17 }),
-		);
-		start_destroy_asset(addr.clone(), asset);
-		let result = destroy_accounts(addr.clone(), asset);
-		assert!(!result.did_revert(), "Contract reverted!");
-	});
-}
-
-#[test]
-fn destroy_approvals_works() {
-	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
-		let addr = instantiate(CONTRACT, INIT_VALUE, vec![2]);
-		// Asset does not exist.
-		assert_eq!(
-			decoded::<Error>(destroy_approvals(addr.clone(), ASSET_ID)),
-			Ok(Module { index: 52, error: 3 }),
-		);
-		let asset = create_asset(addr.clone(), ASSET_ID, 1);
-		// The destroy process hasn't been started.
-		assert_eq!(
-			decoded::<Error>(destroy_approvals(addr.clone(), asset)),
-			Ok(Module { index: 52, error: 17 }),
-		);
-		start_destroy_asset(addr.clone(), asset);
-		let result = destroy_approvals(addr.clone(), asset);
-		assert!(!result.did_revert(), "Contract reverted!");
-	});
-}
-
-#[test]
-fn finish_destroy_works() {
-	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
-		let addr = instantiate(CONTRACT, INIT_VALUE, vec![2]);
-		// Asset does not exist.
-		assert_eq!(
-			decoded::<Error>(finish_destroy(addr.clone(), ASSET_ID)),
-			Ok(Module { index: 52, error: 3 }),
-		);
-		let asset = create_asset(addr.clone(), ASSET_ID, 1);
-		// The destroy process hasn't been started.
-		assert_eq!(
-			decoded::<Error>(finish_destroy(addr.clone(), asset)),
-			Ok(Module { index: 52, error: 17 }),
-		);
-		start_destroy_asset(addr.clone(), asset);
-		let result = finish_destroy(addr.clone(), asset);
 		assert!(!result.did_revert(), "Contract reverted!");
 	});
 }

--- a/pop-api/src/v0/assets/fungibles.rs
+++ b/pop-api/src/v0/assets/fungibles.rs
@@ -3,6 +3,7 @@ use crate::{
 	primitives::{AccountId, AssetId, Balance},
 	Result, StatusCode,
 };
+pub use asset_management::*;
 use constants::*;
 use ink::{env::chain_extension::ChainExtensionMethod, prelude::vec::Vec};
 pub use metadata::*;
@@ -30,45 +31,34 @@ fn build_read_state(state_query: u8) -> ChainExtensionMethod<(), (), (), false> 
 
 mod constants {
 	/// 1. PSP-22 Interface:
-	/// - total_supply
-	pub const TOTAL_SUPPLY: u8 = 0;
-	/// - balance_of
-	pub const BALANCE_OF: u8 = 1;
-	/// - allowance
-	pub const ALLOWANCE: u8 = 2;
-	/// - transfer
+	pub(super) const TOTAL_SUPPLY: u8 = 0;
+	pub(super) const BALANCE_OF: u8 = 1;
+	pub(super) const ALLOWANCE: u8 = 2;
 	pub(super) const TRANSFER: u8 = 3;
-	/// - transfer_from
 	pub(super) const TRANSFER_FROM: u8 = 4;
-	/// - approve
 	pub(super) const APPROVE: u8 = 5;
-	/// - increase_allowance
 	pub(super) const INCREASE_ALLOWANCE: u8 = 6;
-	/// - decrease_allowance
 	pub(super) const DECREASE_ALLOWANCE: u8 = 7;
 
 	/// 2. PSP-22 Metadata Interface:
-	/// - token_name
-	pub const TOKEN_NAME: u8 = 8;
-	/// - token_symbol
-	pub const TOKEN_SYMBOL: u8 = 9;
-	/// - token_decimals
-	pub const TOKEN_DECIMALS: u8 = 10;
+	pub(super) const TOKEN_NAME: u8 = 8;
+	pub(super) const TOKEN_SYMBOL: u8 = 9;
+	pub(super) const TOKEN_DECIMALS: u8 = 10;
 
-	// 3. Asset Management:
-	// - create
-	// - start_destroy
-	// - destroy_accounts
-	// - destroy_approvals
-	// - finish_destroy
-	// - set_metadata
-	// - clear_metadata
+	/// 3. Asset Management:
+	pub(super) const CREATE: u8 = 11;
+	pub(super) const START_DESTROY: u8 = 12;
+	pub(super) const DESTROY_ACCOUNTS: u8 = 13;
+	pub(super) const DESTROY_APPROVALS: u8 = 14;
+	pub(super) const FINISH_DESTROY: u8 = 15;
+	pub(super) const SET_METADATA: u8 = 16;
+	pub(super) const CLEAR_METADATA: u8 = 17;
 }
 
 /// Returns the total token supply for a given asset ID.
 ///
-/// # Arguments
-/// * `id` - The ID of the asset.
+/// # Parameters
+/// - `id` - The ID of the asset.
 ///
 /// # Returns
 /// The total supply of the token, or an error if the operation fails.
@@ -84,9 +74,9 @@ pub fn total_supply(id: AssetId) -> Result<Balance> {
 /// Returns the account balance for the specified `owner` for a given asset ID. Returns `0` if
 /// the account is non-existent.
 ///
-/// # Arguments
-/// * `id` - The ID of the asset.
-/// * `owner` - The account whose balance is being queried.
+/// # Parameters
+/// - `id` - The ID of the asset.
+/// - `owner` - The account whose balance is being queried.
 ///
 /// # Returns
 /// The balance of the specified account, or an error if the operation fails.
@@ -102,10 +92,10 @@ pub fn balance_of(id: AssetId, owner: AccountId) -> Result<Balance> {
 /// Returns the amount which `spender` is still allowed to withdraw from `owner` for a given
 /// asset ID. Returns `0` if no allowance has been set.
 ///
-/// # Arguments
-/// * `id` - The ID of the asset.
-/// * `owner` - The account that owns the tokens.
-/// * `spender` - The account that is allowed to spend the tokens.
+/// # Parameters
+/// - `id` - The ID of the asset.
+/// - `owner` - The account that owns the tokens.
+/// - `spender` - The account that is allowed to spend the tokens.
 ///
 /// # Returns
 /// The remaining allowance, or an error if the operation fails.
@@ -121,10 +111,10 @@ pub fn allowance(id: AssetId, owner: AccountId, spender: AccountId) -> Result<Ba
 /// Transfers `value` amount of tokens from the caller's account to account `to`, with additional
 /// `data` in unspecified format.
 ///
-/// # Arguments
-/// * `id` - The ID of the asset.
-/// * `to` - The recipient account.
-/// * `value` - The number of tokens to transfer.
+/// # Parameters
+/// - `id` - The ID of the asset.
+/// - `to` - The recipient account.
+/// - `value` - The number of tokens to transfer.
 ///
 /// # Returns
 /// Returns `Ok(())` if successful, or an error if the transfer fails.
@@ -141,11 +131,11 @@ pub fn transfer(id: AssetId, target: AccountId, amount: Balance) -> Result<()> {
 /// in unspecified format. If `from` is equal to `None`, tokens will be minted to account `to`. If
 /// `to` is equal to `None`, tokens will be burned from account `from`.
 ///
-/// # Arguments
-/// * `id` - The ID of the asset.
-/// * `from` - The account from which the tokens are transferred.
-/// * `to` - The recipient account.
-/// * `value` - The number of tokens to transfer.
+/// # Parameters
+/// - `id` - The ID of the asset.
+/// - `from` - The account from which the tokens are transferred.
+/// - `to` - The recipient account.
+/// - `value` - The number of tokens to transfer.
 ///
 /// # Returns
 /// Returns `Ok(())` if successful, or an error if the transfer fails.
@@ -160,10 +150,10 @@ pub fn transfer_from(id: AssetId, from: AccountId, to: AccountId, amount: Balanc
 
 /// Approves an account to spend a specified number of tokens on behalf of the caller.
 ///
-/// # Arguments
-/// * `id` - The ID of the asset.
-/// * `spender` - The account that is allowed to spend the tokens.
-/// * `value` - The number of tokens to approve.
+/// # Parameters
+/// - `id` - The ID of the asset.
+/// - `spender` - The account that is allowed to spend the tokens.
+/// - `value` - The number of tokens to approve.
 ///
 /// # Returns
 /// Returns `Ok(())` if successful, or an error if the approval fails.
@@ -178,10 +168,10 @@ pub fn approve(id: AssetId, spender: AccountId, amount: Balance) -> Result<()> {
 
 /// Increases the allowance of a spender.
 ///
-/// # Arguments
-/// * `id` - The ID of the asset.
-/// * `spender` - The account that is allowed to spend the tokens.
-/// * `value` - The number of tokens to increase the allowance by.
+/// # Parameters
+/// - `id` - The ID of the asset.
+/// - `spender` - The account that is allowed to spend the tokens.
+/// - `value` - The number of tokens to increase the allowance by.
 ///
 /// # Returns
 /// Returns `Ok(())` if successful, or an error if the operation fails.
@@ -196,10 +186,10 @@ pub fn increase_allowance(id: AssetId, spender: AccountId, value: Balance) -> Re
 
 /// Decreases the allowance of a spender.
 ///
-/// # Arguments
-/// * `id` - The ID of the asset.
-/// * `spender` - The account that is allowed to spend the tokens.
-/// * `value` - The number of tokens to decrease the allowance by.
+/// # Parameters
+/// - `id` - The ID of the asset.
+/// - `spender` - The account that is allowed to spend the tokens.
+/// - `value` - The number of tokens to decrease the allowance by.
 ///
 /// # Returns
 /// Returns `Ok(())` if successful, or an error if the operation fails.
@@ -216,8 +206,8 @@ pub mod metadata {
 	use super::*;
 	/// Returns the token name for a given asset ID.
 	///
-	/// # Arguments
-	/// * `id` - The ID of the asset.
+	/// # Parameters
+	/// - `id` - The ID of the asset.
 	///
 	/// # Returns
 	/// The name of the token as a byte vector, or an error if the operation fails.
@@ -232,8 +222,8 @@ pub mod metadata {
 
 	/// Returns the token symbol for a given asset ID.
 	///
-	/// # Arguments
-	/// * `id` - The ID of the asset.
+	/// # Parameters
+	/// - `id` - The ID of the asset.
 	///
 	/// # Returns
 	///  The symbol of the token as a byte vector, or an error if the operation fails.
@@ -248,8 +238,8 @@ pub mod metadata {
 
 	/// Returns the token decimals for a given asset ID.
 	///
-	/// # Arguments
-	/// * `id` - The ID of the asset.
+	/// # Parameters
+	/// - `id` - The ID of the asset.
 	///
 	/// # Returns
 	///  The number of decimals of the token as a byte vector, or an error if the operation fails.
@@ -263,90 +253,122 @@ pub mod metadata {
 	}
 }
 
-// pub asset_management {
-// /// Create a new token with a given asset ID.
-// ///
-// /// # Arguments
-// /// * `id` - The ID of the asset.
-// /// * `admin` - The account that will administer the asset.
-// /// * `min_balance` - The minimum balance required for accounts holding this asset.
-// ///
-// /// # Returns
-// /// Returns `Ok(())` if successful, or an error if the creation fails.
-// pub fn create(id: AssetId, admin: impl Into<MultiAddress<AccountId, ()>>, min_balance: Balance) -> Result<()> {
-// 	Ok(())
-// }
-//
-// /// Start the process of destroying a token with a given asset ID.
-// ///
-// /// # Arguments
-// /// * `id` - The ID of the asset.
-// ///
-// /// # Returns
-// /// Returns `Ok(())` if successful, or an error if the operation fails.
-// fn start_destroy(id: AssetId) -> Result<()> {
-// 	Ok(())
-// }
-//
-// /// Destroy all accounts associated with a token with a given asset ID.
-// ///
-// /// # Arguments
-// /// * `id` - The ID of the asset.
-// ///
-// /// # Returns
-// /// Returns `Ok(())` if successful, or an error if the operation fails.
-// fn destroy_accounts(id: AssetId) -> Result<()> {
-// 	Ok(())
-// }
-//
-// /// Destroy all approvals associated with a token with a given asset ID.
-// ///
-// /// # Arguments
-// /// * `id` - The ID of the asset.
-// ///
-// /// # Returns
-// /// Returns `Ok(())` if successful, or an error if the operation fails.
-// fn destroy_approvals(id: AssetId) -> Result<()> {
-// 	Ok(())
-// }
-//
-// /// Complete the process of destroying a token with a given asset ID.
-// ///
-// /// # Arguments
-// /// * `id` - The ID of the asset.
-// ///
-// /// # Returns
-// /// Returns `Ok(())` if successful, or an error if the operation fails.
-// fn finish_destroy(id: AssetId) -> Result<()> {
-// 	Ok(())
-// }
-//
-// /// Set the metadata for a token with a given asset ID.
-// ///
-// /// # Arguments
-// /// * `id` - The ID of the asset.
-// ///
-// /// # Returns
-// /// Returns `Ok(())` if successful, or an error if the operation fails.
-// pub fn set_metadata(id: AssetId, name: Vec<u8>, symbol: Vec<u8>, decimals: u8) -> Result<()> {
-// 	Ok(())
-// }
-//
-// /// Clear the metadata for a token with a given asset ID.
-// ///
-// /// # Arguments
-// /// * `id` - The ID of the asset.
-// ///
-// /// # Returns
-// /// Returns `Ok(())` if successful, or an error if the operation fails.
-// fn clear_metadata(id: AssetId) -> Result<()> {
-//  Ok(())
-// }
-// }
-//
-// pub fn asset_exists(id: AssetId) -> Result<bool> {
-// 	assets::asset_exists(id)
-// }
+pub mod asset_management {
+	use super::*;
+	/// Create a new token with a given asset ID.
+	///
+	/// # Parameters
+	/// - `id` - The ID of the asset.
+	/// - `admin` - The account that will administer the asset.
+	/// - `min_balance` - The minimum balance required for accounts holding this asset.
+	///
+	/// # Returns
+	/// Returns `Ok(())` if successful, or an error if the creation fails.
+	pub fn create(id: AssetId, admin: AccountId, min_balance: Balance) -> Result<()> {
+		build_dispatch(CREATE)
+			.input::<(AssetId, AccountId, Balance)>()
+			.output::<Result<()>, true>()
+			.handle_error_code::<StatusCode>()
+			.call(&(id, admin, min_balance))
+	}
+
+	/// Start the process of destroying a token with a given asset ID.
+	///
+	/// # Parameters
+	/// - `id` - The ID of the asset.
+	///
+	/// # Returns
+	/// Returns `Ok(())` if successful, or an error if the operation fails.
+	fn start_destroy(id: AssetId) -> Result<()> {
+		build_dispatch(START_DESTROY)
+			.input::<AssetId>()
+			.output::<Result<()>, true>()
+			.handle_error_code::<StatusCode>()
+			.call(&(id))
+	}
+
+	/// Destroy all accounts associated with a token with a given asset ID.
+	///
+	/// # Parameters
+	/// - `id` - The ID of the asset.
+	///
+	/// # Returns
+	/// Returns `Ok(())` if successful, or an error if the operation fails.
+	fn destroy_accounts(id: AssetId) -> Result<()> {
+		build_dispatch(DESTROY_ACCOUNTS)
+			.input::<AssetId>()
+			.output::<Result<()>, true>()
+			.handle_error_code::<StatusCode>()
+			.call(&(id))
+	}
+
+	/// Destroy all approvals associated with a token with a given asset ID.
+	///
+	/// # Parameters
+	/// - `id` - The ID of the asset.
+	///
+	/// # Returns
+	/// Returns `Ok(())` if successful, or an error if the operation fails.
+	fn destroy_approvals(id: AssetId) -> Result<()> {
+		build_dispatch(DESTROY_APPROVALS)
+			.input::<AssetId>()
+			.output::<Result<()>, true>()
+			.handle_error_code::<StatusCode>()
+			.call(&(id))
+	}
+
+	/// Complete the process of destroying a token with a given asset ID.
+	///
+	/// # Parameters
+	/// - `id` - The ID of the asset.
+	///
+	/// # Returns
+	/// Returns `Ok(())` if successful, or an error if the operation fails.
+	fn finish_destroy(id: AssetId) -> Result<()> {
+		build_dispatch(FINISH_DESTROY)
+			.input::<AssetId>()
+			.output::<Result<()>, true>()
+			.handle_error_code::<StatusCode>()
+			.call(&(id))
+	}
+
+	/// Set the metadata for a token with a given asset ID.
+	///
+	/// # Parameters
+	/// - `id`: The identifier of the asset to update.
+	/// - `name`: The user friendly name of this asset. Limited in length by `StringLimit`.
+	/// - `symbol`: The exchange symbol for this asset. Limited in length by `StringLimit`.
+	/// - `decimals`: The number of decimals this asset uses to represent one unit.
+	///
+	/// # Returns
+	/// Returns `Ok(())` if successful, or an error if the operation fails.
+	pub fn set_metadata(id: AssetId, name: Vec<u8>, symbol: Vec<u8>, decimals: u8) -> Result<()> {
+		build_dispatch(SET_METADATA)
+			.input::<(AssetId, Vec<u8>, Vec<u8>, u8)>()
+			.output::<Result<()>, true>()
+			.handle_error_code::<StatusCode>()
+			.call(&(id, name, symbol, decimals))
+	}
+
+	/// Clear the metadata for a token with a given asset ID.
+	///
+	/// # Parameters
+	/// - `id` - The ID of the asset.
+	///
+	/// # Returns
+	/// Returns `Ok(())` if successful, or an error if the operation fails.
+	fn clear_metadata(id: AssetId) -> Result<()> {
+		build_dispatch(CLEAR_METADATA)
+			.input::<AssetId>()
+			.output::<Result<()>, true>()
+			.handle_error_code::<StatusCode>()
+			.call(&(id))
+	}
+	//
+	// pub fn asset_exists(id: AssetId) -> Result<bool> {
+	// 	assets::asset_exists(id)
+	// }
+}
 
 /// Represents various errors related to local fungible assets in the Pop API.
 ///

--- a/pop-api/src/v0/assets/fungibles.rs
+++ b/pop-api/src/v0/assets/fungibles.rs
@@ -279,7 +279,7 @@ pub mod asset_management {
 	///
 	/// # Returns
 	/// Returns `Ok(())` if successful, or an error if the operation fails.
-	fn start_destroy(id: AssetId) -> Result<()> {
+	pub fn start_destroy(id: AssetId) -> Result<()> {
 		build_dispatch(START_DESTROY)
 			.input::<AssetId>()
 			.output::<Result<()>, true>()
@@ -294,7 +294,7 @@ pub mod asset_management {
 	///
 	/// # Returns
 	/// Returns `Ok(())` if successful, or an error if the operation fails.
-	fn destroy_accounts(id: AssetId) -> Result<()> {
+	pub fn destroy_accounts(id: AssetId) -> Result<()> {
 		build_dispatch(DESTROY_ACCOUNTS)
 			.input::<AssetId>()
 			.output::<Result<()>, true>()
@@ -309,7 +309,7 @@ pub mod asset_management {
 	///
 	/// # Returns
 	/// Returns `Ok(())` if successful, or an error if the operation fails.
-	fn destroy_approvals(id: AssetId) -> Result<()> {
+	pub fn destroy_approvals(id: AssetId) -> Result<()> {
 		build_dispatch(DESTROY_APPROVALS)
 			.input::<AssetId>()
 			.output::<Result<()>, true>()
@@ -324,7 +324,7 @@ pub mod asset_management {
 	///
 	/// # Returns
 	/// Returns `Ok(())` if successful, or an error if the operation fails.
-	fn finish_destroy(id: AssetId) -> Result<()> {
+	pub fn finish_destroy(id: AssetId) -> Result<()> {
 		build_dispatch(FINISH_DESTROY)
 			.input::<AssetId>()
 			.output::<Result<()>, true>()
@@ -357,7 +357,7 @@ pub mod asset_management {
 	///
 	/// # Returns
 	/// Returns `Ok(())` if successful, or an error if the operation fails.
-	fn clear_metadata(id: AssetId) -> Result<()> {
+	pub fn clear_metadata(id: AssetId) -> Result<()> {
 		build_dispatch(CLEAR_METADATA)
 			.input::<AssetId>()
 			.output::<Result<()>, true>()

--- a/pop-api/src/v0/assets/fungibles.rs
+++ b/pop-api/src/v0/assets/fungibles.rs
@@ -28,6 +28,7 @@ fn build_read_state(state_query: u8) -> ChainExtensionMethod<(), (), (), false> 
 /// 1. PSP-22 Interface
 /// 2. PSP-22 Metadata Interface
 /// 3. Asset Management
+/// 4. PSP-22 Mintable & Burnable Interface
 
 mod constants {
 	/// 1. PSP-22 Interface:
@@ -51,6 +52,10 @@ mod constants {
 	pub(super) const SET_METADATA: u8 = 16;
 	pub(super) const CLEAR_METADATA: u8 = 17;
 	pub(super) const ASSET_EXISTS: u8 = 18;
+
+	/// 4. PSP-22 Mintable & Burnable interface:
+	pub(super) const MINT: u8 = 19;
+	pub(super) const BURN: u8 = 20;
 }
 
 /// Returns the total token supply for a given asset ID.
@@ -200,8 +205,43 @@ pub fn decrease_allowance(id: AssetId, spender: AccountId, value: Balance) -> Re
 		.call(&(id, spender, value))
 }
 
+/// Creates `amount` tokens and assigns them to `account`, increasing the total supply.
+///
+/// # Parameters
+/// - `id` - The ID of the asset.
+/// - `owner` - The account to be credited with the created tokens.
+/// - `value` - The number of tokens to mint.
+///
+/// # Returns
+/// Returns `Ok(())` if successful, or an error if the operation fails.
+pub fn mint(id: AssetId, account: AccountId, amount: Balance) -> Result<()> {
+	build_dispatch(MINT)
+		.input::<(AssetId, AccountId, Balance)>()
+		.output::<Result<()>, true>()
+		.handle_error_code::<StatusCode>()
+		.call(&(id, account, amount))
+}
+
+/// Destroys `amount` tokens from `account`, reducing the total supply.
+///
+/// # Parameters
+/// - `id` - The ID of the asset.
+/// - `owner` - The account from which the tokens will be destroyed.
+/// - `value` - The number of tokens to destroy.
+///
+/// # Returns
+/// Returns `Ok(())` if successful, or an error if the operation fails.
+pub fn burn(id: AssetId, account: AccountId, amount: Balance) -> Result<()> {
+	build_dispatch(BURN)
+		.input::<(AssetId, AccountId, Balance)>()
+		.output::<Result<()>, true>()
+		.handle_error_code::<StatusCode>()
+		.call(&(id, account, amount))
+}
+
 pub mod metadata {
 	use super::*;
+
 	/// Returns the token name for a given asset ID.
 	///
 	/// # Parameters
@@ -253,6 +293,7 @@ pub mod metadata {
 
 pub mod asset_management {
 	use super::*;
+
 	/// Create a new token with a given asset ID.
 	///
 	/// # Parameters

--- a/pop-api/src/v0/assets/fungibles.rs
+++ b/pop-api/src/v0/assets/fungibles.rs
@@ -48,9 +48,6 @@ mod constants {
 	/// 3. Asset Management:
 	pub(super) const CREATE: u8 = 11;
 	pub(super) const START_DESTROY: u8 = 12;
-	pub(super) const DESTROY_ACCOUNTS: u8 = 13;
-	pub(super) const DESTROY_APPROVALS: u8 = 14;
-	pub(super) const FINISH_DESTROY: u8 = 15;
 	pub(super) const SET_METADATA: u8 = 16;
 	pub(super) const CLEAR_METADATA: u8 = 17;
 }
@@ -281,51 +278,6 @@ pub mod asset_management {
 	/// Returns `Ok(())` if successful, or an error if the operation fails.
 	pub fn start_destroy(id: AssetId) -> Result<()> {
 		build_dispatch(START_DESTROY)
-			.input::<AssetId>()
-			.output::<Result<()>, true>()
-			.handle_error_code::<StatusCode>()
-			.call(&(id))
-	}
-
-	/// Destroy all accounts associated with a token with a given asset ID.
-	///
-	/// # Parameters
-	/// - `id` - The ID of the asset.
-	///
-	/// # Returns
-	/// Returns `Ok(())` if successful, or an error if the operation fails.
-	pub fn destroy_accounts(id: AssetId) -> Result<()> {
-		build_dispatch(DESTROY_ACCOUNTS)
-			.input::<AssetId>()
-			.output::<Result<()>, true>()
-			.handle_error_code::<StatusCode>()
-			.call(&(id))
-	}
-
-	/// Destroy all approvals associated with a token with a given asset ID.
-	///
-	/// # Parameters
-	/// - `id` - The ID of the asset.
-	///
-	/// # Returns
-	/// Returns `Ok(())` if successful, or an error if the operation fails.
-	pub fn destroy_approvals(id: AssetId) -> Result<()> {
-		build_dispatch(DESTROY_APPROVALS)
-			.input::<AssetId>()
-			.output::<Result<()>, true>()
-			.handle_error_code::<StatusCode>()
-			.call(&(id))
-	}
-
-	/// Complete the process of destroying a token with a given asset ID.
-	///
-	/// # Parameters
-	/// - `id` - The ID of the asset.
-	///
-	/// # Returns
-	/// Returns `Ok(())` if successful, or an error if the operation fails.
-	pub fn finish_destroy(id: AssetId) -> Result<()> {
-		build_dispatch(FINISH_DESTROY)
 			.input::<AssetId>()
 			.output::<Result<()>, true>()
 			.handle_error_code::<StatusCode>()

--- a/pop-api/src/v0/assets/fungibles.rs
+++ b/pop-api/src/v0/assets/fungibles.rs
@@ -50,6 +50,7 @@ mod constants {
 	pub(super) const START_DESTROY: u8 = 12;
 	pub(super) const SET_METADATA: u8 = 16;
 	pub(super) const CLEAR_METADATA: u8 = 17;
+	pub(super) const ASSET_EXISTS: u8 = 18;
 }
 
 /// Returns the total token supply for a given asset ID.
@@ -316,10 +317,19 @@ pub mod asset_management {
 			.handle_error_code::<StatusCode>()
 			.call(&(id))
 	}
-	//
-	// pub fn asset_exists(id: AssetId) -> Result<bool> {
-	// 	assets::asset_exists(id)
-	// }
+
+	/// Checks if token exists for a given asset ID.
+	///
+	/// # Parameters
+	/// - `id` - The ID of the asset.
+	#[inline]
+	pub fn asset_exists(id: AssetId) -> Result<bool> {
+		build_read_state(ASSET_EXISTS)
+			.input::<AssetId>()
+			.output::<Result<bool>, true>()
+			.handle_error_code::<StatusCode>()
+			.call(&(id))
+	}
 }
 
 /// Represents various errors related to local fungible assets in the Pop API.

--- a/runtime/devnet/src/config/api.rs
+++ b/runtime/devnet/src/config/api.rs
@@ -43,7 +43,7 @@ impl<T: fungibles::Config> Contains<RuntimeRead<T>> for AllowedApiCalls {
 				TotalSupply(..)
 					| BalanceOf { .. } | Allowance { .. }
 					| TokenName(..) | TokenSymbol(..)
-					| TokenDecimals(..)
+					| TokenDecimals(..) | AssetExists(..)
 			)
 		)
 	}

--- a/runtime/devnet/src/config/api.rs
+++ b/runtime/devnet/src/config/api.rs
@@ -25,9 +25,6 @@ impl Contains<RuntimeCall> for AllowedApiCalls {
 					| approve { .. } | increase_allowance { .. }
 					| create { .. } | set_metadata { .. }
 					| start_destroy { .. }
-					| destroy_accounts { .. }
-					| destroy_approvals { .. }
-					| finish_destroy { .. }
 					| clear_metadata { .. }
 			)
 		)

--- a/runtime/devnet/src/config/api.rs
+++ b/runtime/devnet/src/config/api.rs
@@ -28,6 +28,7 @@ impl Contains<RuntimeCall> for AllowedApiCalls {
 					| create { .. } | set_metadata { .. }
 					| start_destroy { .. }
 					| clear_metadata { .. }
+					| mint { .. } | burn { .. }
 			)
 		)
 	}

--- a/runtime/devnet/src/config/api.rs
+++ b/runtime/devnet/src/config/api.rs
@@ -24,6 +24,11 @@ impl Contains<RuntimeCall> for AllowedApiCalls {
 				transfer { .. }
 					| approve { .. } | increase_allowance { .. }
 					| create { .. } | set_metadata { .. }
+					| start_destroy { .. }
+					| destroy_accounts { .. }
+					| destroy_approvals { .. }
+					| finish_destroy { .. }
+					| clear_metadata { .. }
 			)
 		)
 	}

--- a/runtime/devnet/src/config/api.rs
+++ b/runtime/devnet/src/config/api.rs
@@ -20,7 +20,11 @@ impl Contains<RuntimeCall> for AllowedApiCalls {
 		use fungibles::Call::*;
 		matches!(
 			c,
-			RuntimeCall::Fungibles(transfer { .. } | approve { .. } | increase_allowance { .. })
+			RuntimeCall::Fungibles(
+				transfer { .. }
+					| approve { .. } | increase_allowance { .. }
+					| create { .. } | set_metadata { .. }
+			)
 		)
 	}
 }


### PR DESCRIPTION
Implements the functionality for asset management:
- [x] create
- [x] start_destroy
- [x] set_metadata
- [x] clear_metadata
- [x] integration test for creating an asset in the constructor

Additional changes:
- added `DEPRECATED` to old examples and automatic formatting was applied.
- refactored the integration tests helper functions in a separate file `utils.rs`.

The dispatchables required to destroy an asset but not added to the api are `destroy_accounts`, `destroy_approvals` and `finish_destroy`. They have not been included in the api because they do not have to be signed by the owner of the asset and cause complexities in the implementation*. Asset owners (in this case via a contract) are required to complete the steps of destroying an asset via pallet assets in stead of the contract (as it is normally also the case). Only starting the destroying process of an asset has to be initiated by the contract if it is the owner of the asset. If developers want this implemented in the api, we can always do this. Yet now due to the complexity and because destroying assets doesn't happen often we leave it as is. This has to be documented, an issue is created #152. 

*It requires a config type `RemoveItemsLimit` (same as pallet assets) which has to be configured to a smaller amount than in pallet assets. `RemoveItemsLimit` is the max. # of accounts and approvals that can be removed in a single tx. Due to the call being made by a contract this has to be configured to a smaller amount in the api::fungibles pallet. 

Contract examples showing how to to use the `create()`, whether in the constructor or not (or not at all, instantiating a contract which wraps around an existing asset), have been included in #108.

Closes #92 