### PR TITLE
fix(testnet): add missing migration

### DIFF
--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -107,6 +107,9 @@ pub type SignedExtra = (
 pub type UncheckedExtrinsic =
 	generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
 
+/// Migrations to apply on runtime upgrade.
+pub type Migrations = (pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,);
+
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
 	Runtime,
@@ -114,6 +117,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	Migrations,
 >;
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the


### PR DESCRIPTION
Running `try-runtime` on the testnet runtime from `main` indicates a missing migration:

```
cargo b -r --features try-runtime
try-runtime --runtime ./target/release/wbuild/pop-runtime-testnet/pop_runtime_testnet.wasm on-runtime-upgrade live --uri wss://rpc2.paseo.popnetwork.xyz
```

```
2024-08-03T21:13:28Z ERROR runtime::frame-support] CollatorSelection: On chain storage version StorageVersion(1) doesn't match current storage version StorageVersion(2).
[2024-08-03T21:13:28Z ERROR runtime] panicked at /Users/frank/dev/pop-node/runtime/testnet/src/lib.rs:876:65:
    called `Result::unwrap()` on an `Err` value: Other("On chain and current storage version do not match. Missing runtime upgrade?")
thread 'main' panicked at cli/main.rs:324:10
```