### PR TITLE
feat(runtimes): update devnet and testnet runtimes to v1.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -348,12 +348,6 @@ dependencies = [
 
 [[package]]
 name = "array-bytes"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
-
-[[package]]
-name = "array-bytes"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f840fb7195bcfc5e17ea40c26e5ce6d5b9ce5d584466e17703209657e459ae0"
@@ -385,8 +379,24 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
 dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
+ "asn1-rs-derive 0.4.0",
+ "asn1-rs-impl 0.1.0",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl 0.2.0",
  "displaydoc",
  "nom",
  "num-traits",
@@ -404,7 +414,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -416,6 +438,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -432,105 +465,106 @@ dependencies = [
  "assets-common",
  "bp-asset-hub-paseo",
  "bp-bridge-hub-paseo",
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-aura",
- "cumulus-primitives-core",
- "cumulus-primitives-utility",
- "frame-benchmarking",
- "frame-executive",
- "frame-metadata-hash-extension",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
+ "cumulus-pallet-aura-ext 0.8.0",
+ "cumulus-pallet-parachain-system 0.8.1",
+ "cumulus-pallet-session-benchmarking 10.0.0",
+ "cumulus-pallet-xcm 0.8.0",
+ "cumulus-pallet-xcmp-queue 0.8.0",
+ "cumulus-primitives-aura 0.8.0",
+ "cumulus-primitives-core 0.8.0",
+ "cumulus-primitives-utility 0.8.1",
+ "frame-benchmarking 29.0.0",
+ "frame-executive 29.0.0",
+ "frame-metadata-hash-extension 0.1.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "frame-system-benchmarking 29.0.0",
+ "frame-system-rpc-runtime-api 27.0.0",
+ "frame-try-runtime 0.35.0",
  "hex-literal",
  "log",
- "pallet-asset-conversion",
+ "pallet-asset-conversion 11.0.0",
  "pallet-asset-conversion-tx-payment",
- "pallet-assets",
- "pallet-aura",
- "pallet-authorship",
- "pallet-balances",
- "pallet-collator-selection",
- "pallet-message-queue",
- "pallet-multisig",
- "pallet-nfts",
- "pallet-nfts-runtime-api",
- "pallet-proxy",
- "pallet-session",
- "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-assets 30.0.0",
+ "pallet-aura 28.0.0",
+ "pallet-authorship 29.0.0",
+ "pallet-balances 29.0.2",
+ "pallet-collator-selection 10.0.3",
+ "pallet-message-queue 32.0.0",
+ "pallet-multisig 29.0.0",
+ "pallet-nfts 23.0.0",
+ "pallet-nfts-runtime-api 15.0.0",
+ "pallet-proxy 29.0.0",
+ "pallet-session 29.0.0",
+ "pallet-timestamp 28.0.0",
+ "pallet-transaction-payment 29.0.2",
+ "pallet-transaction-payment-rpc-runtime-api 29.0.0",
  "pallet-uniques",
- "pallet-utility",
- "pallet-xcm",
- "pallet-xcm-benchmarks",
- "pallet-xcm-bridge-hub-router",
- "parachains-common",
+ "pallet-utility 29.0.0",
+ "pallet-xcm 8.0.5",
+ "pallet-xcm-benchmarks 8.0.2",
+ "pallet-xcm-bridge-hub-router 0.6.0",
+ "parachains-common 8.0.1",
  "parity-scale-codec",
  "paseo-runtime-constants",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
- "polkadot-runtime-common",
+ "polkadot-core-primitives 8.0.0",
+ "polkadot-parachain-primitives 7.0.0",
+ "polkadot-runtime-common 8.0.3",
  "primitive-types",
  "scale-info",
  "snowbridge-router-primitives",
- "sp-api",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
+ "sp-api 27.0.1",
+ "sp-block-builder 27.0.0",
+ "sp-consensus-aura 0.33.0",
+ "sp-core 29.0.0",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 27.0.0",
+ "sp-io 31.0.0",
+ "sp-offchain 27.0.0",
+ "sp-runtime 32.0.0",
+ "sp-session 28.0.0",
  "sp-std",
- "sp-storage",
- "sp-transaction-pool",
- "sp-version",
- "sp-weights",
- "staging-parachain-info",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
- "substrate-wasm-builder",
+ "sp-storage 20.0.0",
+ "sp-transaction-pool 27.0.0",
+ "sp-version 30.0.0",
+ "sp-weights 28.0.0",
+ "staging-parachain-info 0.8.0",
+ "staging-xcm 8.0.1",
+ "staging-xcm-builder 8.0.3",
+ "staging-xcm-executor 8.0.2",
+ "substrate-wasm-builder 18.0.1",
  "system-parachains-constants",
 ]
 
 [[package]]
 name = "asset-test-utils"
-version = "8.0.1"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d78501ca6b4c848efe233672124ebab9293d8efefc44a728d70f3245a8ef595"
+checksum = "8ccc232efa79f7f180856e9bc8535dbb2d813b62418cda7bf154a713adb9ea36"
 dependencies = [
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "frame-support",
- "frame-system",
- "pallet-assets",
- "pallet-balances",
- "pallet-collator-selection",
- "pallet-session",
- "pallet-xcm",
- "pallet-xcm-bridge-hub-router",
- "parachains-common",
+ "cumulus-pallet-parachain-system 0.15.0",
+ "cumulus-pallet-xcmp-queue 0.15.0",
+ "cumulus-primitives-core 0.14.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "pallet-assets 37.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-collator-selection 17.0.0",
+ "pallet-session 36.0.0",
+ "pallet-timestamp 35.0.0",
+ "pallet-xcm 15.0.0",
+ "pallet-xcm-bridge-hub-router 0.13.0",
+ "parachains-common 15.0.0",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
- "sp-io",
- "sp-runtime",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
- "staging-parachain-info",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
- "substrate-wasm-builder",
+ "staging-parachain-info 0.15.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "staging-xcm-executor 15.0.0",
+ "substrate-wasm-builder 23.0.0",
 ]
 
 [[package]]
@@ -539,22 +573,22 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e90021d772c2dd82d45fd085e05a2cb5866464d4c7421ac6a8007733b350bb"
 dependencies = [
- "cumulus-primitives-core",
- "frame-support",
+ "cumulus-primitives-core 0.8.0",
+ "frame-support 29.0.2",
  "impl-trait-for-tuples",
  "log",
- "pallet-asset-conversion",
- "pallet-xcm",
- "parachains-common",
+ "pallet-asset-conversion 11.0.0",
+ "pallet-xcm 8.0.5",
+ "parachains-common 8.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
- "substrate-wasm-builder",
+ "staging-xcm 8.0.1",
+ "staging-xcm-builder 8.0.3",
+ "staging-xcm-executor 8.0.2",
+ "substrate-wasm-builder 18.0.1",
 ]
 
 [[package]]
@@ -578,7 +612,7 @@ dependencies = [
  "event-listener 5.2.0",
  "event-listener-strategy 0.5.0",
  "futures-core",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -663,7 +697,7 @@ checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener 4.0.3",
  "event-listener-strategy 0.4.0",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -720,9 +754,9 @@ checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -739,7 +773,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -753,6 +787,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attohttpc"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
+dependencies = [
+ "http 0.2.12",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "autocfg"
@@ -800,6 +845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +870,16 @@ name = "binary-merkle-tree"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf857f8f411164ce1af14a778626af96251de7a77837711efbc440807e7053f"
+dependencies = [
+ "hash-db",
+ "log",
+]
+
+[[package]]
+name = "binary-merkle-tree"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b5c0fd4282c30c05647e1052d71bf1a0c8067ab1e9a8fc6d0c292dce0ecb237"
 dependencies = [
  "hash-db",
  "log",
@@ -860,7 +921,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "rand",
  "rand_core 0.6.4",
  "serde",
@@ -868,10 +929,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -881,9 +958,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
@@ -1036,9 +1113,9 @@ name = "bp-asset-hub-paseo"
 version = "1.0.0"
 source = "git+https://github.com/paseo-network/runtimes/?tag=v1.2.5-system-chains#e7265b10b28d8b82c3146e72c98895dac2b55729"
 dependencies = [
- "frame-support",
+ "frame-support 29.0.2",
  "sp-std",
- "staging-xcm",
+ "staging-xcm 8.0.1",
  "system-parachains-constants",
 ]
 
@@ -1048,13 +1125,13 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e91ab68506081576066d3641d7794f63d96f3ca1eee0c059c2cc2174e55f638"
 dependencies = [
- "bp-messages",
- "bp-polkadot-core",
- "bp-runtime",
- "frame-support",
- "frame-system",
- "polkadot-primitives",
- "sp-api",
+ "bp-messages 0.8.0",
+ "bp-polkadot-core 0.8.0",
+ "bp-runtime 0.8.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "polkadot-primitives 8.0.1",
+ "sp-api 27.0.1",
  "sp-std",
 ]
 
@@ -1064,16 +1141,16 @@ version = "1.0.0"
 source = "git+https://github.com/paseo-network/runtimes/?tag=v1.2.5-system-chains#e7265b10b28d8b82c3146e72c98895dac2b55729"
 dependencies = [
  "bp-bridge-hub-cumulus",
- "bp-messages",
- "bp-runtime",
- "frame-support",
+ "bp-messages 0.8.0",
+ "bp-runtime 0.8.0",
+ "frame-support 29.0.2",
  "parity-scale-codec",
  "scale-info",
  "snowbridge-core",
- "sp-api",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-xcm",
+ "staging-xcm 8.0.1",
 ]
 
 [[package]]
@@ -1082,15 +1159,33 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96157f586811969b3911d26cc79e02b28cfbecf859d96d7c12b6af10b9ea9350"
 dependencies = [
- "bp-runtime",
+ "bp-runtime 0.8.0",
  "finality-grandpa",
- "frame-support",
+ "frame-support 29.0.2",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-runtime",
+ "sp-consensus-grandpa 14.0.0",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-header-chain"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57cac4b71008e46d43e346476ed1be85cf7b505efacee17dad84d687344bf1b1"
+dependencies = [
+ "bp-runtime 0.15.0",
+ "finality-grandpa",
+ "frame-support 36.0.1",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-consensus-grandpa 20.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -1100,31 +1195,47 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf43a49ea13d4c2f141481b6cbff85a197c47fe6aec1f5af21e40b68e8fd02fd"
 dependencies = [
- "bp-header-chain",
- "bp-runtime",
- "frame-support",
+ "bp-header-chain 0.8.0",
+ "bp-runtime 0.8.0",
+ "frame-support 29.0.2",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
+ "sp-core 29.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-messages"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97eec00a98efeb052ac9fc9676d9fccf5acd19e3b18530f3d72af1a1faf21ec"
+dependencies = [
+ "bp-header-chain 0.15.0",
+ "bp-runtime 0.15.0",
+ "frame-support 36.0.1",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "bp-parachains"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762e309a008b2ad4088d4c4e9d39fa9f78f59124b6a52c25ceb0ef5f22d901f5"
+checksum = "60c0bde723a5daf39f4f02816483c9ac049818990b06858dff751736636a4ea2"
 dependencies = [
- "bp-header-chain",
- "bp-polkadot-core",
- "bp-runtime",
- "frame-support",
+ "bp-header-chain 0.15.0",
+ "bp-polkadot-core 0.15.0",
+ "bp-runtime 0.15.0",
+ "frame-support 36.0.1",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -1134,31 +1245,50 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b862e8dcccc9a3fafb58a1735bc205b7663d3335d7b3dd942503b98f28d6b067"
 dependencies = [
- "bp-messages",
- "bp-runtime",
- "frame-support",
- "frame-system",
+ "bp-messages 0.8.0",
+ "bp-runtime 0.8.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "parity-util-mem",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-polkadot-core"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef2272823ecfee580c00f6542dfcab3ec7abdb00857af853429736847c3a2d9"
+dependencies = [
+ "bp-messages 0.15.0",
+ "bp-runtime 0.15.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "bp-relayers"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a4b0e2771227611fe9e6a2c37ba2bf7408cf2385a9eb2f44e6096bb0e616ec"
+checksum = "5a589f5bb70baa4377a798823be752042aa6c220d51afc559716667e29b0203d"
 dependencies = [
- "bp-messages",
- "bp-runtime",
- "frame-support",
+ "bp-messages 0.15.0",
+ "bp-runtime 0.15.0",
+ "frame-support 36.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -1168,8 +1298,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b29668fffbc3e4a7ad789b498424ed6d8a313f93544a090bbaaef8a1f7fd243"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "hash-db",
  "impl-trait-for-tuples",
  "log",
@@ -1177,41 +1307,65 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-state-machine 0.36.0",
  "sp-std",
- "sp-trie",
- "trie-db",
+ "sp-trie 30.0.0",
+ "trie-db 0.28.0",
+]
+
+[[package]]
+name = "bp-runtime"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904644c23b437dde65741f3148067624ed0b4d8360f68adf9e92273aeb970814"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "hash-db",
+ "impl-trait-for-tuples",
+ "log",
+ "num-traits",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
+ "sp-std",
+ "sp-trie 36.0.0",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
 name = "bp-test-utils"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6640a95733148b4f2004d362471eba49583da4b961681f5ea722039478924d31"
+checksum = "85062410c8f85ba074f04d843c59f39c7fcb64b83f2ece5bd4379f8c34a4bf15"
 dependencies = [
- "bp-header-chain",
+ "bp-header-chain 0.15.0",
  "bp-parachains",
- "bp-polkadot-core",
- "bp-runtime",
+ "bp-polkadot-core 0.15.0",
+ "bp-runtime 0.15.0",
  "ed25519-dalek",
  "finality-grandpa",
  "parity-scale-codec",
- "sp-application-crypto",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-runtime",
+ "sp-application-crypto 37.0.0",
+ "sp-consensus-grandpa 20.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
- "sp-trie",
+ "sp-trie 36.0.0",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6663e0179d475e30cfcf28cf597cdc8f4bb1c2c39a557b4cbe0057db0657fb67"
+checksum = "192804908f1d3b7bfad12abce448fb3b7ec8dda765cac4a8d811fa75557e528f"
 dependencies = [
  "sp-std",
 ]
@@ -1224,44 +1378,57 @@ checksum = "86ff4abe93be7bc1663adc41817b1aa3476fbec953ce361537419924310d5dd4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+]
+
+[[package]]
+name = "bp-xcm-bridge-hub-router"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7dae4d1ec894ee920195dd39070b279ef3c1d4d078c3fcf7336c93a1d502a9d"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
 name = "bridge-runtime-common"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be96f5eb3ef2ce92e0337e06b76a2e0e9f120a5f6fd96bf8db817e5643c118b9"
+checksum = "639591635551f94b6e310852430b669495bd99cfd2af20b00a00f6cc7169e70d"
 dependencies = [
- "bp-header-chain",
- "bp-messages",
+ "bp-header-chain 0.15.0",
+ "bp-messages 0.15.0",
  "bp-parachains",
- "bp-polkadot-core",
+ "bp-polkadot-core 0.15.0",
  "bp-relayers",
- "bp-runtime",
+ "bp-runtime 0.15.0",
  "bp-xcm-bridge-hub",
- "bp-xcm-bridge-hub-router",
- "frame-support",
- "frame-system",
+ "bp-xcm-bridge-hub-router 0.13.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "hash-db",
  "log",
  "pallet-bridge-grandpa",
  "pallet-bridge-messages",
  "pallet-bridge-parachains",
  "pallet-bridge-relayers",
- "pallet-transaction-payment",
- "pallet-utility",
+ "pallet-transaction-payment 36.0.0",
+ "pallet-utility 36.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-api 33.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
- "sp-trie",
- "staging-xcm",
- "staging-xcm-builder",
+ "sp-trie 36.0.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "tuplex",
 ]
 
 [[package]]
@@ -1388,6 +1555,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,7 +1648,20 @@ dependencies = [
  "multibase",
  "multihash 0.17.0",
  "serde",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "cid"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+dependencies = [
+ "core2",
+ "multibase",
+ "multihash 0.18.1",
+ "serde",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -1608,6 +1794,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "comfy-table"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,7 +1863,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1773,7 +1969,7 @@ dependencies = [
  "gimli 0.27.3",
  "hashbrown 0.13.2",
  "log",
- "regalloc2",
+ "regalloc2 0.6.1",
  "smallvec",
  "target-lexicon",
 ]
@@ -1846,6 +2042,21 @@ dependencies = [
  "wasmparser",
  "wasmtime-types",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -1960,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d2597fe3235d263457aaff65d0fb5bed506698b81530e2e6afecd6d6c9af32"
+checksum = "b64901f2fde878bec8f4c3949b5e5ee6fb5de45dd19b45d9fcd6a23a859fd0cc"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1971,55 +2182,56 @@ dependencies = [
  "sc-client-api",
  "sc-service",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "url",
 ]
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c06ae72a125d056da3b722f00f87881a2afbb2af8fe9fa9a91587f139b9667e"
+checksum = "2311f438161902135ff57db8a81ed3c701e33fd4bccbcc72e785f1efc73e1df3"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.14.0",
  "futures",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sc-client-api",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f4977f6a88af39c46832d571ac0d95e8322bf22eab42550fec34f72da9f034"
+checksum = "76c45052da56eb1631e177812f47c9426cb2617a5bfcc4c76a746e6a4c660df2"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-consensus-proposer",
  "cumulus-client-parachain-inherent",
- "cumulus-primitives-aura",
- "cumulus-primitives-core",
+ "cumulus-primitives-aura 0.14.0",
+ "cumulus-primitives-core 0.14.0",
  "cumulus-relay-chain-interface",
  "futures",
  "parity-scale-codec",
+ "parking_lot 0.12.3",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-aura",
@@ -2027,125 +2239,129 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "schnellru",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-block-builder 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
- "sp-timestamp",
+ "sp-consensus-aura 0.39.0",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
+ "sp-timestamp 33.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350db1fc8841a44f344474b791d2ebe61b79bf6061043a7d826b3d02d1935a56"
+checksum = "83b4de5c24c4304b509dffccb95218f22c2ef619a91aee85a3d9523b63347be2"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.14.0",
  "cumulus-relay-chain-interface",
  "dyn-clone",
  "futures",
  "log",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-babe",
  "schnellru",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots",
- "sp-core",
- "sp-runtime",
- "sp-timestamp",
- "sp-trie",
+ "sp-consensus-slots 0.39.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "sp-timestamp 33.0.0",
+ "sp-trie 36.0.0",
+ "sp-version 36.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.8.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38028f75597a34d447f059d6a7fd9c1c91bce0b8c48b08b1cbd19eb3def9c376"
+checksum = "56e980b3e5c05415eaa4ac07f398bc8e74666811f3112f19a654ccb3a948018e"
 dependencies = [
  "anyhow",
  "async-trait",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-parachain-inherent 0.14.0",
  "sp-consensus",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac095ef439c595ccb998be5a9d40778d8963c5a8ebbaed838fed6293232915b"
+checksum = "ed8d6844af4dbb35a925d493331b631f4ccd3b15568643e92afbf0ee7f4b22e3"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "polkadot-node-primitives",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
  "sc-client-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
+ "sp-version 36.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.2.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b516290cd4a6efc117824135761f3642dc57685e13da00727c460053ce978fe"
+checksum = "e99367f72d7bce6d8996eb397d265290e4a982fbbc4b0fd7659e57a2ad5b6b7b"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-core 0.14.0",
+ "cumulus-primitives-parachain-inherent 0.14.0",
  "cumulus-relay-chain-interface",
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "sc-client-api",
  "scale-info",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-crypto-hashing",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
  "sp-std",
- "sp-storage",
- "sp-trie",
+ "sp-storage 21.0.0",
+ "sp-trie 36.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d55e96004ca9aa9d9b96a28ab2d97b1ca8d303c9d2405ea34cdf1462d4c4f0"
+checksum = "21e3bd944ef351edb61fdaca5bf6d9a964d7c7571bd0b0236ea51f167bec9b6f"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.14.0",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
@@ -2153,34 +2369,36 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "rand",
  "sc-client-api",
  "sc-consensus",
+ "sp-api 33.0.0",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 38.0.1",
+ "sp-version 36.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657f57c56159bb6cb74d9221de8f11c9e09962666381357896562662d3019799"
+checksum = "fb134f1526eba4455290859ad34174ab787c8f36f509063f41eeac17202a8f78"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core",
- "cumulus-primitives-proof-size-hostfunction",
+ "cumulus-primitives-core 0.14.0",
+ "cumulus-primitives-proof-size-hostfunction 0.9.0",
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
  "futures",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
@@ -2192,12 +2410,13 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-transaction-pool",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-transaction-pool 33.0.0",
 ]
 
 [[package]]
@@ -2206,16 +2425,35 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8e78b18548ae3454bc8a46e2bc2e3f521ea547844cbaecc9344d4741f4b1ef"
 dependencies = [
- "cumulus-pallet-parachain-system",
- "frame-support",
- "frame-system",
- "pallet-aura",
- "pallet-timestamp",
+ "cumulus-pallet-parachain-system 0.8.1",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "pallet-aura 28.0.0",
+ "pallet-timestamp 28.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-consensus-aura",
- "sp-runtime",
+ "sp-application-crypto 31.0.0",
+ "sp-consensus-aura 0.33.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "cumulus-pallet-aura-ext"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e8af48090936c45483d489ee681acb54277763586b53fa3dbd17173aa474fc"
+dependencies = [
+ "cumulus-pallet-parachain-system 0.15.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "pallet-aura 35.0.0",
+ "pallet-timestamp 35.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto 37.0.0",
+ "sp-consensus-aura 0.39.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -2227,32 +2465,69 @@ checksum = "1a215fe4d66d23e8f3956bd21b9d80d2b33239f3b150b36d56fa238cfc9421a5"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
- "cumulus-primitives-proof-size-hostfunction",
+ "cumulus-primitives-core 0.8.0",
+ "cumulus-primitives-parachain-inherent 0.8.0",
+ "cumulus-primitives-proof-size-hostfunction 0.3.0",
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-message-queue",
+ "pallet-message-queue 32.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-parachain-primitives 7.0.0",
+ "polkadot-runtime-common 8.0.3",
+ "polkadot-runtime-parachains 8.0.3",
  "scale-info",
- "sp-core",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 29.0.0",
+ "sp-externalities 0.26.0",
+ "sp-inherents 27.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-state-machine 0.36.0",
  "sp-std",
- "sp-trie",
- "sp-version",
- "staging-xcm",
- "trie-db",
+ "sp-trie 30.0.0",
+ "sp-version 30.0.0",
+ "staging-xcm 8.0.1",
+ "trie-db 0.28.0",
+]
+
+[[package]]
+name = "cumulus-pallet-parachain-system"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300d5509bd8ac95bafe158fa475278315175a4eb0422c2cd82e08e8b9dde035c"
+dependencies = [
+ "bytes",
+ "cumulus-pallet-parachain-system-proc-macro",
+ "cumulus-primitives-core 0.14.0",
+ "cumulus-primitives-parachain-inherent 0.14.0",
+ "cumulus-primitives-proof-size-hostfunction 0.9.0",
+ "environmental",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-message-queue 39.0.0",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-runtime-common 15.0.0",
+ "polkadot-runtime-parachains 15.0.1",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
+ "sp-std",
+ "sp-trie 36.0.0",
+ "sp-version 36.0.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
@@ -2273,12 +2548,27 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3259f743f70f39baa3abf2d9d8de864e18120465f8731b99bef039a3bf9329"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-session",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "pallet-session 29.0.0",
  "parity-scale-codec",
- "sp-runtime",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "cumulus-pallet-session-benchmarking"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506daacefa861aa2909b64f26e76495ce029227fd8355b97e074cc1d5dc54ab2"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "pallet-session 36.0.0",
+ "parity-scale-codec",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -2288,15 +2578,32 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e802291060763f8d1176bf808da97aafe5afe7351f62bb093c317c1d35c5cee"
 dependencies = [
- "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "cumulus-primitives-core 0.8.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-xcm",
+ "staging-xcm 8.0.1",
+]
+
+[[package]]
+name = "cumulus-pallet-xcm"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5224285f60e5159bab549f458079d606a7f95ef779def8b89f1a244dc7cf81"
+dependencies = [
+ "cumulus-primitives-core 0.14.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "staging-xcm 14.1.0",
 ]
 
 [[package]]
@@ -2306,23 +2613,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa22d6e479a4d3a2790bab291269ba0917a1ac384255a54a2ebc3f7c37e505e"
 dependencies = [
  "bounded-collections 0.2.0",
- "bp-xcm-bridge-hub-router",
- "cumulus-primitives-core",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "bp-xcm-bridge-hub-router 0.7.0",
+ "cumulus-primitives-core 0.8.0",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-message-queue",
+ "pallet-message-queue 32.0.0",
  "parity-scale-codec",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-common 8.0.3",
+ "polkadot-runtime-parachains 8.0.3",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm 8.0.1",
+ "staging-xcm-executor 8.0.2",
+]
+
+[[package]]
+name = "cumulus-pallet-xcmp-queue"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0adf5409618b21e754fef0ac70f257878d22d61c48fdeefcab666835dcb8e0f0"
+dependencies = [
+ "bounded-collections 0.2.0",
+ "bp-xcm-bridge-hub-router 0.13.0",
+ "cumulus-primitives-core 0.14.0",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-message-queue 39.0.0",
+ "parity-scale-codec",
+ "polkadot-runtime-common 15.0.0",
+ "polkadot-runtime-parachains 15.0.1",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "staging-xcm-executor 15.0.0",
 ]
 
 [[package]]
@@ -2332,11 +2666,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f07d6177692154043d7ddcc0b87ca5365ae8e4d94b90d9931f6b2f76e162f09"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-primitives",
- "sp-api",
- "sp-consensus-aura",
- "sp-runtime",
+ "polkadot-core-primitives 8.0.0",
+ "polkadot-primitives 8.0.1",
+ "sp-api 27.0.1",
+ "sp-consensus-aura 0.33.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "cumulus-primitives-aura"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e7977947ad43a4cbc532ca33abcde136ae3deffdc7168b2ae253d73ccd371e4"
+dependencies = [
+ "parity-scale-codec",
+ "polkadot-core-primitives 14.0.0",
+ "polkadot-primitives 14.0.0",
+ "sp-api 33.0.0",
+ "sp-consensus-aura 0.39.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -2347,15 +2696,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df07f6825fd50ea30aae335e43dc1a615a05de7465f5f329b9e414f2c886a12"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
+ "polkadot-core-primitives 8.0.0",
+ "polkadot-parachain-primitives 7.0.0",
+ "polkadot-primitives 8.0.1",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-trie",
- "staging-xcm",
+ "sp-trie 30.0.0",
+ "staging-xcm 8.0.1",
+]
+
+[[package]]
+name = "cumulus-primitives-core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "751e64b89a839d5cfabebc1c797936e5eee791d0fa2322d91e86f8440a743ddb"
+dependencies = [
+ "parity-scale-codec",
+ "polkadot-core-primitives 14.0.0",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
+ "scale-info",
+ "sp-api 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-trie 36.0.0",
+ "staging-xcm 14.1.0",
 ]
 
 [[package]]
@@ -2365,13 +2732,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38ad140a065a6b8001fb26ec42b91391e90fde120f5b4e57986698249a9b98c8"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.8.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-inherents",
+ "sp-core 29.0.0",
+ "sp-inherents 27.0.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 30.0.0",
+]
+
+[[package]]
+name = "cumulus-primitives-parachain-inherent"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df521e13b48278b86d02c61d6e44036d6d263deb5aaec4838b1751da8988d3d2"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core 0.14.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
+ "sp-std",
+ "sp-trie 36.0.0",
 ]
 
 [[package]]
@@ -2380,9 +2765,20 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b74f9141190b9f4bf96a947ade46da64097b77f1ebfa8d611c81724250e119"
 dependencies = [
- "sp-externalities",
- "sp-runtime-interface",
- "sp-trie",
+ "sp-externalities 0.26.0",
+ "sp-runtime-interface 25.0.0",
+ "sp-trie 30.0.0",
+]
+
+[[package]]
+name = "cumulus-primitives-proof-size-hostfunction"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f973d2a7262c90e48dcd42062bcb1e0fbf48bbcdac4ea6df3d85212d8d8be5d"
+dependencies = [
+ "sp-externalities 0.29.0",
+ "sp-runtime-interface 28.0.0",
+ "sp-trie 36.0.0",
 ]
 
 [[package]]
@@ -2391,29 +2787,50 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e65466e56d642f979b556d098a03755ae51972fff5fa0f9b1cdcfdb3df062ea3"
 dependencies = [
- "cumulus-primitives-core",
- "frame-support",
+ "cumulus-primitives-core 0.8.0",
+ "frame-support 29.0.2",
  "log",
- "pallet-asset-conversion",
+ "pallet-asset-conversion 11.0.0",
  "parity-scale-codec",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
- "sp-io",
- "sp-runtime",
+ "polkadot-runtime-common 8.0.3",
+ "polkadot-runtime-parachains 8.0.3",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 8.0.1",
+ "staging-xcm-builder 8.0.3",
+ "staging-xcm-executor 8.0.2",
+]
+
+[[package]]
+name = "cumulus-primitives-utility"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05742c520065e3870d419683113ed7f6d35de66f0c80af6828e7878d1bb0ea94"
+dependencies = [
+ "cumulus-primitives-core 0.14.0",
+ "frame-support 36.0.1",
+ "log",
+ "pallet-asset-conversion 18.0.0",
+ "parity-scale-codec",
+ "polkadot-runtime-common 15.0.0",
+ "polkadot-runtime-parachains 15.0.1",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "staging-xcm-executor 15.0.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff27dec2eab6cd1d854756d62bd7053721ccd115f36f9e8b0976b1e46b70ef7"
+checksum = "511675c9780fe8396e2b0c3ca8a04ff0ddc57d837fd9fe4086cb9aac1b107523"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.14.0",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
@@ -2424,48 +2841,49 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c736f39b50eecf194707e15d0359677bb8fe8138b01f6493ab9b7e10d2d1ae"
+checksum = "36abc0a30972529fad05c4fae9f6866ec6c3edfaf2e20977219c94a807d96ffa"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.14.0",
  "futures",
- "jsonrpsee-core",
+ "jsonrpsee-core 0.23.2",
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
- "sp-state-machine",
+ "sp-state-machine 0.42.0",
+ "sp-version 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7718fe298d567adc44fae3dd7024418d6eff08264041e4b0544d1892861cd6"
+checksum = "b39ec9de6ed195263af022094d63689fc6a914f48f70d74eb3fed8ee48973ea3"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "async-trait",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.14.0",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
  "futures",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 14.0.0",
  "polkadot-network-bridge",
  "polkadot-node-collation-generation",
  "polkadot-node-core-chain-api",
@@ -2474,7 +2892,8 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
+ "polkadot-service",
  "sc-authority-discovery",
  "sc-client-api",
  "sc-network",
@@ -2482,11 +2901,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe",
- "sp-runtime",
+ "sp-consensus-babe 0.39.0",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2494,17 +2913,17 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e2269d4c1f37593257b3d7b90f8b56adab0793d9b9f5c1b5334c9ca7e3b10b"
+checksum = "b22c43792fa5d56a2360bcdbdc58c47aafa23688072d2b6e61844864e69a15c8"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.14.0",
  "cumulus-relay-chain-interface",
  "either",
  "futures",
  "futures-timer",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "parity-scale-codec",
  "pin-project",
  "polkadot-overseer",
@@ -2517,14 +2936,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api",
- "sp-authority-discovery",
- "sp-consensus-babe",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-storage",
- "sp-version",
+ "sp-api 33.0.0",
+ "sp-authority-discovery 33.0.0",
+ "sp-consensus-babe 0.39.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
+ "sp-storage 21.0.0",
+ "sp-version 36.0.0",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2534,17 +2953,17 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.8.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfff604ad01c5c0c397f9a971c8cec6443aea3658813778875b4f64de07847d5"
+checksum = "e1f4ab9d64a581d4a5431f2554f4602a4208c5e28b30be01af386e24d8447599"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.14.0",
  "parity-scale-codec",
- "polkadot-primitives",
- "sp-runtime",
- "sp-state-machine",
+ "polkadot-primitives 14.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 36.0.0",
 ]
 
 [[package]]
@@ -2646,6 +3065,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,7 +3119,21 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -2921,6 +3367,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature",
  "spki",
 ]
@@ -3000,40 +3447,42 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle 2.5.0",
  "zeroize",
 ]
 
 [[package]]
 name = "emulated-integration-tests-common"
-version = "4.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a73ae1af5bb264240ccd199335ae78db85d055da4f749d44333d21719e5896"
+checksum = "aef7c980b99bb2e4edfc9535d4096c1d0b5c8e3b52aab38a497a79563e6005f7"
 dependencies = [
  "asset-test-utils",
- "bp-messages",
+ "bp-messages 0.15.0",
  "bridge-runtime-common",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "frame-support",
- "pallet-assets",
- "pallet-balances",
+ "cumulus-pallet-parachain-system 0.15.0",
+ "cumulus-pallet-xcmp-queue 0.15.0",
+ "cumulus-primitives-core 0.14.0",
+ "frame-support 36.0.1",
+ "pallet-assets 37.0.0",
+ "pallet-balances 37.0.0",
  "pallet-bridge-messages",
- "pallet-message-queue",
- "pallet-xcm",
- "parachains-common",
+ "pallet-message-queue 39.0.0",
+ "pallet-xcm 15.0.0",
+ "parachains-common 15.0.0",
  "parity-scale-codec",
  "paste",
- "polkadot-primitives",
- "polkadot-runtime-parachains",
- "polkadot-service",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
+ "polkadot-runtime-parachains 15.0.1",
  "sc-consensus-grandpa",
- "sp-authority-discovery",
- "sp-consensus-babe",
- "sp-core",
- "sp-runtime",
- "staging-xcm",
+ "sp-authority-discovery 33.0.0",
+ "sp-consensus-babe 0.39.0",
+ "sp-consensus-beefy 20.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "staging-xcm 14.1.0",
  "xcm-emulator",
 ]
 
@@ -3053,6 +3502,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3199,7 +3660,7 @@ checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3210,7 +3671,7 @@ checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3221,7 +3682,7 @@ checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3231,7 +3692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
  "event-listener 4.0.3",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3241,7 +3702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
 dependencies = [
  "event-listener 5.2.0",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3251,18 +3712,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
  "futures",
-]
-
-[[package]]
-name = "expander"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a718c0675c555c5f976fff4ea9e2c150fa06cefa201cadef87cfbf9324075881"
-dependencies = [
- "blake3",
- "fs-err",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -3286,6 +3735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,9 +3757,9 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fatality"
-version = "0.0.6"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad875162843b0d046276327afe0136e9ed3a23d5a754210fb6f1f33610d39ab"
+checksum = "ec6f82451ff7f0568c6181287189126d492b5654e30a788add08027b6363d019"
 dependencies = [
  "fatality-proc-macro",
  "thiserror",
@@ -3312,17 +3767,16 @@ dependencies = [
 
 [[package]]
 name = "fatality-proc-macro"
-version = "0.0.6"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5aa1e3ae159e592ad222dc90c5acbad632b527779ba88486abe92782ab268bd"
+checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
- "expander 0.0.4",
- "indexmap 1.9.3",
- "proc-macro-crate 1.3.1",
+ "expander",
+ "indexmap 2.2.6",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "thiserror",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3385,7 +3839,7 @@ dependencies = [
  "log",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "scale-info",
 ]
 
@@ -3408,17 +3862,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
-dependencies = [
- "crc32fast",
- "libz-sys",
- "miniz_oxide",
-]
-
-[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,10 +3877,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fork-tree"
-version = "12.0.0"
+name = "foreign-types"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93d3f0315c2eccf23453609e0ab92fe7c6ad1ca8129bcaf80b9a08c8d7fc52b"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fork-tree"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad4cc2314d3be8b49c555f6a7e550f5559e73ffd6ef9690ffbd9a706774452e0"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3452,6 +3910,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
 name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3463,43 +3931,69 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4090659c6aaa3c4d5b6c6ec909b4b0a25dec10ad92aad5f729efa8d5bd4d806a"
 dependencies = [
- "frame-support",
- "frame-support-procedural",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-support-procedural 24.0.0",
+ "frame-system 29.0.0",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-runtime-interface",
+ "sp-api 27.0.1",
+ "sp-application-crypto 31.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-runtime-interface 25.0.0",
  "sp-std",
- "sp-storage",
+ "sp-storage 20.0.0",
+ "static_assertions",
+]
+
+[[package]]
+name = "frame-benchmarking"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709b26657ebbba53dc7bb616577375ca462b20fef1b00e8d9b20d2435e87f7bc"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-support-procedural 30.0.2",
+ "frame-system 36.0.0",
+ "linregress",
+ "log",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-runtime-interface 28.0.0",
+ "sp-std",
+ "sp-storage 21.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "33.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe02c96362e3c7308cdea7545859f767194a1f3f00928f0e1357f4b8a0b3b2c"
+checksum = "49302558cac41cba0a28aa784615daea85c49253ecc6d6a6c4a8ee2f2303655a"
 dependencies = [
  "Inflector",
- "array-bytes 6.2.2",
+ "array-bytes",
  "chrono",
  "clap",
  "comfy-table",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "gethostname",
  "handlebars",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "linked-hash-map",
  "log",
@@ -3507,6 +4001,7 @@ dependencies = [
  "rand",
  "rand_pcg",
  "sc-block-builder",
+ "sc-chain-spec",
  "sc-cli",
  "sc-client-api",
  "sc-client-db",
@@ -3515,19 +4010,20 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-database",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
- "sp-storage",
- "sp-trie",
- "sp-wasm-interface",
+ "sp-externalities 0.29.0",
+ "sp-genesis-builder 0.14.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
+ "sp-storage 21.0.0",
+ "sp-trie 36.0.0",
+ "sp-wasm-interface 21.0.0",
  "thiserror",
  "thousands",
 ]
@@ -3545,20 +4041,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-election-provider-solution-type"
+version = "14.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156f209055d352994ecd49e19658c6b469d7c6de923bd79868957d0dcfb6f71"
+dependencies = [
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "frame-election-provider-support"
 version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87da19ee99e6473cd057ead84337d20011fe5e299c6750e88e43b8b7963b8852"
 dependencies = [
- "frame-election-provider-solution-type",
- "frame-support",
- "frame-system",
+ "frame-election-provider-solution-type 13.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-npos-elections",
- "sp-runtime",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-npos-elections 27.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "frame-election-provider-support"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ec289ebad5e601bb165cf7eb6ec2179ae34280ee310d0710a3111d4f8f8f94"
+dependencies = [
+ "frame-election-provider-solution-type 14.0.1",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-npos-elections 33.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -3568,17 +4094,37 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bff9574ee2dcc349f646e1d2faadf76afd688c2ea1bbac5e4a0e19a0c19c59"
 dependencies = [
- "frame-support",
- "frame-system",
- "frame-try-runtime",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "frame-try-runtime 0.35.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 16.0.0",
+]
+
+[[package]]
+name = "frame-executive"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d878830330eaa9e8b886279c338556b05702d0059989cb51cfb226b70bf3fa4"
+dependencies = [
+ "aquamarine",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "frame-try-runtime 0.42.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
@@ -3599,37 +4145,30 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb1eec9eb46d3e016c95b2fa875118c04609f2150013c56a894cae00581e265"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "docify",
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 32.0.0",
 ]
 
 [[package]]
-name = "frame-remote-externalities"
-version = "0.36.0"
+name = "frame-metadata-hash-extension"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360bfdb6821372164a65933d9a6d5998f38c722360b59b69d2bf78a87ef58b2a"
+checksum = "cf37fc730bf4b51e82a34c6357eebe32c04dbacf6525e0a7b9726f6a17ec9427"
 dependencies = [
- "futures",
- "indicatif",
- "jsonrpsee",
+ "array-bytes",
+ "docify",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
  "parity-scale-codec",
- "serde",
- "sp-core",
- "sp-crypto-hashing",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
- "spinners",
- "substrate-rpc-client",
- "tokio",
- "tokio-retry",
+ "scale-info",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -3639,12 +4178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e52c84b611d2049d9253f83a62ab0f093e4be5c42a7ef42ea5bb16d6611e32"
 dependencies = [
  "aquamarine",
- "array-bytes 6.2.2",
+ "array-bytes",
  "bitflags 1.3.2",
  "docify",
  "environmental",
  "frame-metadata",
- "frame-support-procedural",
+ "frame-support-procedural 24.0.0",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -3655,21 +4194,63 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api",
- "sp-arithmetic",
- "sp-core",
+ "sp-api 27.0.1",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-metadata-ir",
- "sp-runtime",
- "sp-staking",
- "sp-state-machine",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 27.0.0",
+ "sp-io 31.0.0",
+ "sp-metadata-ir 0.6.0",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
+ "sp-state-machine 0.36.0",
  "sp-std",
- "sp-tracing",
- "sp-weights",
+ "sp-tracing 16.0.0",
+ "sp-weights 28.0.0",
+ "static_assertions",
+ "tt-call",
+]
+
+[[package]]
+name = "frame-support"
+version = "36.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4d08149c28010bfa568dcfa832aea628fb794d4243794a13b1bdef1aa66fb1"
+dependencies = [
+ "aquamarine",
+ "array-bytes",
+ "bitflags 1.3.2",
+ "docify",
+ "environmental",
+ "frame-metadata",
+ "frame-support-procedural 30.0.2",
+ "impl-trait-for-tuples",
+ "k256",
+ "log",
+ "macro_magic",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sp-api 33.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive",
+ "sp-genesis-builder 0.14.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-metadata-ir 0.7.0",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
+ "sp-state-machine 0.42.0",
+ "sp-std",
+ "sp-tracing 17.0.0",
+ "sp-weights 31.0.0",
  "static_assertions",
  "tt-call",
 ]
@@ -3683,11 +4264,31 @@ dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse 0.1.5",
- "expander 2.1.0",
- "frame-support-procedural-tools",
+ "expander",
+ "frame-support-procedural-tools 10.0.0",
  "itertools 0.10.5",
  "macro_magic",
- "proc-macro-warning",
+ "proc-macro-warning 1.0.2",
+ "proc-macro2",
+ "quote",
+ "sp-crypto-hashing",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4662a809f559aea6234bd90940fa29df583a3c8124a3cf923f66a0d21126b7"
+dependencies = [
+ "Inflector",
+ "cfg-expr",
+ "derive-syn-parse 0.2.0",
+ "expander",
+ "frame-support-procedural-tools 13.0.0",
+ "itertools 0.11.0",
+ "macro_magic",
+ "proc-macro-warning 1.0.2",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
@@ -3700,7 +4301,20 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3363df38464c47a73eb521a4f648bfcc7537a82d70347ef8af3f73b6d019e910"
 dependencies = [
- "frame-support-procedural-tools-derive",
+ "frame-support-procedural-tools-derive 11.0.0",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "frame-support-procedural-tools"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bead15a320be1764cdd50458c4cfacb23e0cee65f64f500f8e34136a94c7eeca"
+dependencies = [
+ "frame-support-procedural-tools-derive 12.0.0",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
@@ -3719,6 +4333,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-support-procedural-tools-derive"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "frame-system"
 version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3726,17 +4351,38 @@ checksum = "5bc20a793c3cec0b11165c1075fe11a255b2491f3eef8230bb3073cb296e7383"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support",
+ "frame-support 29.0.2",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-version",
- "sp-weights",
+ "sp-version 30.0.0",
+ "sp-weights 28.0.0",
+]
+
+[[package]]
+name = "frame-system"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c2f10b6943da5d00f45b1b07b101bea49647d0e6c7e755b2852fd947072d7ee"
+dependencies = [
+ "cfg-if",
+ "docify",
+ "frame-support 36.0.1",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-version 36.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -3745,13 +4391,29 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac47ee48fee3a0b49c9ab9ee68997dee3733776a355f780cf2858449cf495d69"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "frame-system-benchmarking"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15afc91c7780e18274dcea58ed1edb700c48d10e086a9785e3f6708099cd3250"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -3762,7 +4424,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c1b20433c3c76b56ce905ed971631ec8c34fa64cf6c20e590afe46455fc0cc8"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 27.0.1",
+]
+
+[[package]]
+name = "frame-system-rpc-runtime-api"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9e2b7b85e451e367f4fb85ff3295bd039e17f64de1906154d3976e2638ee8"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api 33.0.0",
 ]
 
 [[package]]
@@ -3771,10 +4443,23 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eab87d07bc2f9a2160b818d1b7506c303b3b28b6a8a5f01dc5e2641390450b5"
 dependencies = [
- "frame-support",
+ "frame-support 29.0.2",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "frame-try-runtime"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6ba8b36a52775ad39ccfb45ff4ad814c3cb45ec74d0a4271889e00bd791c6c"
+dependencies = [
+ "frame-support 36.0.1",
+ "parity-scale-codec",
+ "sp-api 33.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -3829,6 +4514,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-bounded"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07bbbe7d7e78809544c6f718d875627addc73a7c3582447abc052cd3dc67e0"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3873,7 +4568,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
  "waker-fn",
 ]
 
@@ -3887,7 +4582,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3903,13 +4598,12 @@ dependencies = [
 
 [[package]]
 name = "futures-rustls"
-version = "0.22.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
+checksum = "35bd3cf68c183738046838e300353e4716c674dc5e56890de4826801a6622a28"
 dependencies = [
  "futures-io",
- "rustls 0.20.9",
- "webpki",
+ "rustls 0.21.10",
 ]
 
 [[package]]
@@ -3943,7 +4637,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
  "pin-utils",
  "slab",
 ]
@@ -3989,24 +4683,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -4035,7 +4718,7 @@ version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "indexmap 1.9.3",
  "stable_deref_trait",
 ]
@@ -4045,12 +4728,36 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+dependencies = [
+ "fallible-iterator 0.3.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "governor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.12.3",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+]
 
 [[package]]
 name = "group"
@@ -4074,7 +4781,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -4084,9 +4810,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.5.0"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
+checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
 dependencies = [
  "log",
  "pest",
@@ -4172,6 +4898,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-literal"
@@ -4260,21 +4992,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
- "pin-project-lite 0.2.13",
+ "http 0.2.12",
+ "pin-project-lite",
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
+name = "http-body"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "httparse"
@@ -4304,18 +5064,38 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.13",
- "socket2 0.5.6",
+ "pin-project-lite",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -4325,13 +5105,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "log",
  "rustls 0.21.10",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tower-service",
 ]
 
 [[package]]
@@ -4364,6 +5161,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -4405,6 +5212,25 @@ dependencies = [
  "system-configuration",
  "tokio",
  "windows",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "log",
+ "rand",
+ "tokio",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -4503,19 +5329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
-name = "indicatif"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
-dependencies = [
- "console",
- "instant",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4554,29 +5367,29 @@ version = "0.0.0"
 dependencies = [
  "asset-hub-paseo-runtime",
  "asset-test-utils",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.14.0",
  "emulated-integration-tests-common",
- "frame-support",
- "pallet-assets",
- "pallet-balances",
- "pallet-message-queue",
- "pallet-xcm",
+ "frame-support 36.0.1",
+ "pallet-assets 37.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-message-queue 39.0.0",
+ "pallet-xcm 15.0.0",
  "parity-scale-codec",
  "paseo-runtime",
  "paseo-runtime-constants",
- "polkadot-primitives",
- "polkadot-runtime-parachains",
+ "polkadot-primitives 14.0.0",
+ "polkadot-runtime-parachains 15.0.1",
  "pop-runtime-common",
  "pop-runtime-devnet",
- "sp-authority-discovery",
- "sp-consensus-aura",
- "sp-consensus-babe",
- "sp-consensus-beefy",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-runtime",
- "staging-xcm",
- "staging-xcm-executor",
+ "sp-authority-discovery 33.0.0",
+ "sp-consensus-aura 0.39.0",
+ "sp-consensus-babe 0.39.0",
+ "sp-consensus-beefy 20.0.0",
+ "sp-consensus-grandpa 20.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "staging-xcm 14.1.0",
+ "staging-xcm-executor 15.0.0",
  "tracing-subscriber 0.3.18",
 ]
 
@@ -4603,7 +5416,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -4660,6 +5473,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4683,11 +5516,22 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affdc52f7596ccb2d7645231fc6163bb314630c989b64998f3699a28b4d5d4dc"
 dependencies = [
- "jsonrpsee-core",
- "jsonrpsee-http-client",
+ "jsonrpsee-core 0.20.3",
+ "jsonrpsee-server 0.20.3",
+ "jsonrpsee-types 0.20.3",
+ "tokio",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
+dependencies = [
+ "jsonrpsee-core 0.23.2",
  "jsonrpsee-proc-macros",
- "jsonrpsee-server",
- "jsonrpsee-types",
+ "jsonrpsee-server 0.23.2",
+ "jsonrpsee-types 0.23.2",
  "jsonrpsee-ws-client",
  "tokio",
  "tracing",
@@ -4695,19 +5539,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.20.3"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b005c793122d03217da09af68ba9383363caa950b90d3436106df8cabce935"
+checksum = "08163edd8bcc466c33d79e10f695cdc98c00d1e6ddfb95cec41b6b0279dd5432"
 dependencies = [
+ "base64 0.22.1",
  "futures-util",
- "http",
- "jsonrpsee-core",
+ "http 1.1.0",
+ "jsonrpsee-core 0.23.2",
  "pin-project",
- "rustls-native-certs",
- "soketto",
+ "rustls 0.23.12",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "soketto 0.8.0",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tracing",
  "url",
@@ -4720,55 +5567,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2327ba8df2fdbd5e897e2b5ed25ce7f299d345b9736b6828814c3dbd1fd47b"
 dependencies = [
  "anyhow",
- "async-lock 2.8.0",
  "async-trait",
  "beef",
- "futures-timer",
  "futures-util",
- "hyper",
- "jsonrpsee-types",
- "parking_lot 0.12.1",
+ "hyper 0.14.28",
+ "jsonrpsee-types 0.20.3",
+ "parking_lot 0.12.3",
  "rand",
  "rustc-hash",
  "serde",
  "serde_json",
- "soketto",
+ "soketto 0.7.1",
  "thiserror",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "jsonrpsee-http-client"
-version = "0.20.3"
+name = "jsonrpsee-core"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f80c17f62c7653ce767e3d7288b793dfec920f97067ceb189ebdd3570f2bc20"
+checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
 dependencies = [
+ "anyhow",
  "async-trait",
- "hyper",
- "hyper-rustls",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "beef",
+ "bytes",
+ "futures-timer",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "jsonrpsee-types 0.23.2",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "tower",
+ "tokio-stream",
  "tracing",
- "url",
 ]
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.20.3"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29110019693a4fa2dbda04876499d098fa16d70eba06b1e6e2b3f1b251419515"
+checksum = "7895f186d5921065d96e16bd795e5ca89ac8356ec423fafc6e3d7cf8ec11aee4"
 dependencies = [
- "heck 0.4.1",
- "proc-macro-crate 1.3.1",
+ "heck 0.5.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4778,14 +5631,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c39a00449c9ef3f50b84fc00fc4acba20ef8f559f07902244abf4c15c5ab9c"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "jsonrpsee-core 0.20.3",
+ "jsonrpsee-types 0.20.3",
  "route-recognizer",
  "serde",
  "serde_json",
- "soketto",
+ "soketto 0.7.1",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-server"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654afab2e92e5d88ebd8a39d6074483f3f2bfdf91c5ac57fe285e7127cdd4f51"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "jsonrpsee-core 0.23.2",
+ "jsonrpsee-types 0.23.2",
+ "pin-project",
+ "route-recognizer",
+ "serde",
+ "serde_json",
+ "soketto 0.8.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4809,15 +5690,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-ws-client"
-version = "0.20.3"
+name = "jsonrpsee-types"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca9cb3933ccae417eb6b08c3448eb1cb46e39834e5b503e395e5e5bd08546c0"
+checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
 dependencies = [
- "http",
+ "beef",
+ "http 1.1.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c28759775f5cb2f1ea9667672d3fe2b0e701d1f4b7b67954e60afe7fd058b5e"
+dependencies = [
+ "http 1.1.0",
  "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.23.2",
+ "jsonrpsee-types 0.23.2",
  "url",
 ]
 
@@ -4831,6 +5725,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2 0.10.8",
 ]
 
@@ -4865,7 +5760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7a85fe66f9ff9cd74e169fdd2c94c6e1e74c412c99a73b4df3200b5d3760b2"
 dependencies = [
  "kvdb",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
@@ -4876,7 +5771,7 @@ checksum = "b644c70b92285f66bfc2032922a79000ea30af7bc2ab31902992a5dcb9b434f6"
 dependencies = [
  "kvdb",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "regex",
  "rocksdb",
  "smallvec",
@@ -4929,14 +5824,15 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libp2p"
-version = "0.51.4"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35eae38201a993ece6bdc823292d6abd1bffed1c4d0f4a3517d2bd8e1d917fe"
+checksum = "e94495eb319a85b70a68b85e2389a95bb3555c71c49025b78c691a854a7e6464"
 dependencies = [
  "bytes",
+ "either",
  "futures",
  "futures-timer",
- "getrandom 0.2.12",
+ "getrandom",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
@@ -4953,18 +5849,21 @@ dependencies = [
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
+ "libp2p-upnp",
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
- "multiaddr",
+ "multiaddr 0.18.1",
  "pin-project",
+ "rw-stream-sink",
+ "thiserror",
 ]
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510daa05efbc25184458db837f6f9a5143888f1caa742426d92e1833ddd38a50"
+checksum = "55b46558c5c0bf99d3e2a1a38fd54ff5476ca66dd1737b12466a1824dd219311"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4974,9 +5873,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa33f1d26ed664c4fe2cca81a08c8e07d4c1c04f2f4ac7655c2dd85467fda0"
+checksum = "2f5107ad45cb20b2f6c3628c7b6014b996fcb13a88053f4569c872c6e30abf58"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4986,9 +5885,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.39.2"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1df63c0b582aa434fb09b2d86897fa2b419ffeccf934b36f87fcedc8e835c2"
+checksum = "dd44289ab25e4c9230d9246c475a22241e301b23e8f4061d3bdef304a1a99713"
 dependencies = [
  "either",
  "fnv",
@@ -4997,50 +5896,53 @@ dependencies = [
  "instant",
  "libp2p-identity",
  "log",
- "multiaddr",
- "multihash 0.17.0",
+ "multiaddr 0.18.1",
+ "multihash 0.19.1",
  "multistream-select",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
  "rand",
  "rw-stream-sink",
  "smallvec",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
  "void",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.39.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146ff7034daae62077c415c2376b8057368042df6ab95f5432ad5e88568b1554"
+checksum = "e6a18db73084b4da2871438f6239fef35190b05023de7656e877c18a00541a3b"
 dependencies = [
+ "async-trait",
  "futures",
  "libp2p-core",
+ "libp2p-identity",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "smallvec",
  "trust-dns-resolver",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.42.2"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5455f472243e63b9c497ff320ded0314254a9eb751799a39c283c6f20b793f3c"
+checksum = "45a96638a0a176bec0a4bcaebc1afa8cf909b114477209d7456ade52c61cd9cd"
 dependencies = [
  "asynchronous-codec",
  "either",
  "futures",
+ "futures-bounded",
  "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "lru 0.10.1",
+ "lru 0.12.4",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
@@ -5050,27 +5952,27 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.1.3"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276bb57e7af15d8f100d3c11cbdd32c6752b7eef4ba7a18ecf464972c07abcce"
+checksum = "55cca1eb2bc1fd29f099f3daaab7effd01e1a54b7c577d0ed082521034d912e8"
 dependencies = [
- "bs58 0.4.0",
+ "bs58 0.5.1",
  "ed25519-dalek",
- "log",
- "multiaddr",
- "multihash 0.17.0",
+ "hkdf",
+ "multihash 0.19.1",
  "quick-protobuf",
  "rand",
  "sha2 0.10.8",
  "thiserror",
+ "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-kad"
-version = "0.43.3"
+version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d5ef876a2b2323d63c258e63c2f8e36f205fe5a11f0b3095d59635650790ff"
+checksum = "16ea178dabba6dde6ffc260a8e0452ccdc8f79becf544946692fff9d412fc29d"
 dependencies = [
  "arrayvec 0.7.4",
  "asynchronous-codec",
@@ -5085,20 +5987,21 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "quick-protobuf",
+ "quick-protobuf-codec",
  "rand",
  "sha2 0.10.8",
  "smallvec",
  "thiserror",
  "uint",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
  "void",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.43.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19983e1f949f979a928f2c603de1cf180cc0dc23e4ac93a62651ccb18341460b"
+checksum = "42a2567c305232f5ef54185e9604579a894fd0674819402bb0ac0246da82f52a"
 dependencies = [
  "data-encoding",
  "futures",
@@ -5109,38 +6012,43 @@ dependencies = [
  "log",
  "rand",
  "smallvec",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
- "trust-dns-proto",
+ "trust-dns-proto 0.22.0",
  "void",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
+checksum = "239ba7d28f8d0b5d77760dc6619c05c7e88e74ec8fbbe97f856f20a56745e620"
 dependencies = [
+ "instant",
  "libp2p-core",
  "libp2p-identify",
+ "libp2p-identity",
  "libp2p-kad",
  "libp2p-ping",
  "libp2p-swarm",
+ "once_cell",
  "prometheus-client",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.42.2"
+version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3673da89d29936bc6435bafc638e2f184180d554ce844db65915113f86ec5e"
+checksum = "d2eeec39ad3ad0677551907dd304b2f13f17208ccebe333bef194076cd2e8921"
 dependencies = [
  "bytes",
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek 4.1.2",
  "futures",
  "libp2p-core",
  "libp2p-identity",
  "log",
+ "multiaddr 0.18.1",
+ "multihash 0.19.1",
  "once_cell",
  "quick-protobuf",
  "rand",
@@ -5148,21 +6056,22 @@ dependencies = [
  "snow",
  "static_assertions",
  "thiserror",
- "x25519-dalek 1.1.1",
+ "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-ping"
-version = "0.42.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e57759c19c28a73ef1eb3585ca410cefb72c1a709fcf6de1612a378e4219202"
+checksum = "e702d75cd0827dfa15f8fd92d15b9932abe38d10d21f47c50438c71dd1b5dae3"
 dependencies = [
  "either",
  "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
  "log",
  "rand",
@@ -5171,9 +6080,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.7.0-alpha.3"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b26abd81cd2398382a1edfe739b539775be8a90fa6914f39b2ab49571ec735"
+checksum = "130d451d83f21b81eb7b35b360bc7972aeafb15177784adc56528db082e6b927"
 dependencies = [
  "bytes",
  "futures",
@@ -5183,19 +6092,21 @@ dependencies = [
  "libp2p-identity",
  "libp2p-tls",
  "log",
- "parking_lot 0.12.1",
- "quinn-proto",
+ "parking_lot 0.12.3",
+ "quinn 0.10.2",
  "rand",
- "rustls 0.20.9",
+ "ring 0.16.20",
+ "rustls 0.21.10",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.24.1"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffdb374267d42dc5ed5bc53f6e601d4a64ac5964779c6e40bb9e4f14c1e30d5"
+checksum = "d8e3b4d67870478db72bac87bfc260ee6641d0734e0e3e275798f089c3fecfd4"
 dependencies = [
  "async-trait",
  "futures",
@@ -5203,15 +6114,17 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
+ "log",
  "rand",
  "smallvec",
+ "void",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.42.2"
+version = "0.43.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903b3d592d7694e56204d211f29d31bc004be99386644ba8731fc3e3ef27b296"
+checksum = "580189e0074af847df90e75ef54f3f30059aedda37ea5a1659e8b9fca05c0141"
 dependencies = [
  "either",
  "fnv",
@@ -5222,6 +6135,8 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm-derive",
  "log",
+ "multistream-select",
+ "once_cell",
  "rand",
  "smallvec",
  "tokio",
@@ -5230,36 +6145,39 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fba456131824ab6acd4c7bf61e9c0f0a3014b5fc9868ccb8e10d344594cdc4f"
+checksum = "c4d5ec2a3df00c7836d7696c136274c9c59705bac69133253696a6c932cd1d74"
 dependencies = [
  "heck 0.4.1",
+ "proc-macro-warning 0.4.2",
+ "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.39.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d33698596d7722d85d3ab0c86c2c322254fce1241e91208e3679b4eb3026cf"
+checksum = "b558dd40d1bcd1aaaed9de898e9ec6a436019ecc2420dd0016e712fbb61c5508"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
+ "libp2p-identity",
  "log",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
 ]
 
 [[package]]
 name = "libp2p-tls"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08d13d0dc66e5e9ba6279c1de417b84fa0d0adc3b03e5732928c180ec02781"
+checksum = "8218d1d5482b122ccae396bbf38abdcb283ecc96fa54760e1dfd251f0546ac61"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -5267,51 +6185,69 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring 0.16.20",
- "rustls 0.20.9",
+ "rustls 0.21.10",
+ "rustls-webpki 0.101.7",
  "thiserror",
- "webpki",
- "x509-parser",
+ "x509-parser 0.15.1",
  "yasna",
 ]
 
 [[package]]
-name = "libp2p-wasm-ext"
-version = "0.39.0"
+name = "libp2p-upnp"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77dff9d32353a5887adb86c8afc1de1a94d9e8c3bc6df8b2201d7cdf5c848f43"
+checksum = "82775a47b34f10f787ad3e2a22e2c1541e6ebef4fe9f28f3ac553921554c94c1"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "igd-next",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "tokio",
+ "void",
+]
+
+[[package]]
+name = "libp2p-wasm-ext"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e5d8e3a9e07da0ef5b55a9f26c009c8fb3c725d492d8bb4b431715786eea79c"
 dependencies = [
  "futures",
  "js-sys",
  "libp2p-core",
- "parity-send-wrapper",
+ "send_wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.41.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111273f7b3d3510524c752e8b7a5314b7f7a1fee7e68161c01a7d72cbb06db9f"
+checksum = "004ee9c4a4631435169aee6aad2f62e3984dc031c43b6d29731e8e82a016c538"
 dependencies = [
  "either",
  "futures",
  "futures-rustls",
  "libp2p-core",
+ "libp2p-identity",
  "log",
- "parking_lot 0.12.1",
- "quicksink",
+ "parking_lot 0.12.3",
+ "pin-project-lite",
  "rw-stream-sink",
- "soketto",
+ "soketto 0.8.0",
+ "thiserror",
  "url",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.43.1"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd21d950662700a385d4c6d68e2f5f54d778e97068cdd718522222ef513bda"
+checksum = "8eedcb62824c4300efb9cfd4e2a6edaf3ca097b9e68b36dabe45a44469fd6a85"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -5326,7 +6262,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -5469,6 +6405,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "litep2p"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f46c51c205264b834ceed95c8b195026e700494bc3991aaba3b4ea9e20626d9"
+dependencies = [
+ "async-trait",
+ "bs58 0.4.0",
+ "bytes",
+ "cid 0.10.1",
+ "ed25519-dalek",
+ "futures",
+ "futures-timer",
+ "hex-literal",
+ "indexmap 2.2.6",
+ "libc",
+ "mockall 0.12.1",
+ "multiaddr 0.17.1",
+ "multihash 0.17.0",
+ "network-interface",
+ "nohash-hasher",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "prost 0.12.6",
+ "prost-build 0.11.9",
+ "quinn 0.9.4",
+ "rand",
+ "rcgen",
+ "ring 0.16.20",
+ "rustls 0.20.9",
+ "serde",
+ "sha2 0.10.8",
+ "simple-dns",
+ "smallvec",
+ "snow",
+ "socket2 0.5.7",
+ "static_assertions",
+ "str0m",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "trust-dns-resolver",
+ "uint",
+ "unsigned-varint 0.8.0",
+ "url",
+ "webpki",
+ "x25519-dalek",
+ "x509-parser 0.16.0",
+ "yasna",
+ "zeroize",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5495,18 +6486,18 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "lru"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
+
+[[package]]
+name = "lru"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "lru-cache"
@@ -5548,9 +6539,9 @@ dependencies = [
 
 [[package]]
 name = "macro_magic"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03844fc635e92f3a0067e25fa4bf3e3dbf3f2927bf3aa01bb7bc8f1c428949d"
+checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
 dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
@@ -5560,12 +6551,12 @@ dependencies = [
 
 [[package]]
 name = "macro_magic_core"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468155613a44cfd825f1fb0ffa532b018253920d404e6fca1e8d43155198a46d"
+checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
 dependencies = [
  "const-random",
- "derive-syn-parse 0.1.5",
+ "derive-syn-parse 0.2.0",
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
@@ -5574,9 +6565,9 @@ dependencies = [
 
 [[package]]
 name = "macro_magic_core_macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
+checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5585,20 +6576,14 @@ dependencies = [
 
 [[package]]
 name = "macro_magic_macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
+checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
  "syn 2.0.55",
 ]
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "match_cfg"
@@ -5736,7 +6721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -5756,7 +6741,7 @@ dependencies = [
  "hashlink",
  "lioness",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "rand",
  "rand_chacha 0.3.1",
  "rand_distr",
@@ -5767,38 +6752,38 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "30.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f62cddc29c17965ab16a051a745520d41c28d8b4c2b6188aaf661db056d67c9"
+checksum = "8f06f25f3b298799dbc20f7ffd40e667adc4fbd664cbb23ead5f7bbda52407ff"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-beefy",
- "sp-core",
- "sp-mmr-primitives",
- "sp-runtime",
+ "sp-consensus-beefy 20.0.0",
+ "sp-core 34.0.0",
+ "sp-mmr-primitives 33.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
 name = "mmr-rpc"
-version = "29.0.0"
+version = "35.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2634b45039e064c343a0a77ed45e03ca027c84e1b250b2f3988af7cde9b7e79e"
+checksum = "7f9a252b1e03418e99c18ff6e2d4d9748d195395ed3749c8bfd9ca2c7530a43d"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "parity-scale-codec",
  "serde",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
- "sp-core",
- "sp-mmr-primitives",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-mmr-primitives 33.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -5811,8 +6796,23 @@ dependencies = [
  "downcast",
  "fragile",
  "lazy_static",
- "mockall_derive",
- "predicates",
+ "mockall_derive 0.11.4",
+ "predicates 2.1.5",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive 0.12.1",
+ "predicates 3.1.2",
  "predicates-tree",
 ]
 
@@ -5829,6 +6829,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
 name = "multiaddr"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5843,7 +6861,26 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+ "url",
+]
+
+[[package]]
+name = "multiaddr"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b852bc02a2da5feed68cd14fa50d0774b92790a5bdbfa932a813926c8472070"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "libp2p-identity",
+ "multibase",
+ "multihash 0.19.1",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.7.2",
  "url",
 ]
 
@@ -5869,10 +6906,10 @@ dependencies = [
  "blake3",
  "core2",
  "digest 0.10.7",
- "multihash-derive 0.8.0",
+ "multihash-derive",
  "sha2 0.10.8",
  "sha3",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -5881,11 +6918,15 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
 dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
  "core2",
  "digest 0.10.7",
- "multihash-derive 0.8.0",
+ "multihash-derive",
  "sha2 0.10.8",
- "unsigned-varint",
+ "sha3",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -5895,27 +6936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
 dependencies = [
  "core2",
- "unsigned-varint",
-]
-
-[[package]]
-name = "multihash-codetable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d815ecb3c8238d00647f8630ede7060a642c9f704761cd6082cb4028af6935"
-dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
- "core2",
- "digest 0.10.7",
- "multihash-derive 0.9.0",
- "ripemd",
- "serde",
- "sha1",
- "sha2 0.10.8",
- "sha3",
- "strobe-rs",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -5929,32 +6950,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890e72cb7396cb99ed98c1246a97b243cc16394470d94e0bc8b0c2c11d84290e"
-dependencies = [
- "core2",
- "multihash 0.19.1",
- "multihash-derive-impl",
-]
-
-[[package]]
-name = "multihash-derive-impl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38685e08adb338659871ecfc6ee47ba9b22dcc8abcf6975d379cc49145c3040"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -5965,16 +6961,16 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multistream-select"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
 dependencies = [
  "bytes",
  "futures",
  "log",
  "pin-project",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -6086,6 +7082,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "network-interface"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+dependencies = [
+ "cc",
+ "libc",
+ "thiserror",
+ "winapi",
+]
+
+[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6098,14 +7106,21 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "no-std-net"
@@ -6136,18 +7151,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.4"
+name = "nu-ansi-term"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
- "autocfg",
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
  "num-integer",
  "num-traits",
 ]
@@ -6166,6 +7202,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
 
 [[package]]
 name = "num-format"
@@ -6219,12 +7266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6251,7 +7292,16 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
+dependencies = [
+ "asn1-rs 0.6.2",
 ]
 
 [[package]]
@@ -6273,10 +7323,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-src"
+version = "300.3.1+3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -6307,7 +7405,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eedb646674596266dc9bb2b5c7eea7c36b32ecc7777eba0d510196972d72c4fd"
 dependencies = [
- "expander 2.1.0",
+ "expander",
  "indexmap 2.2.6",
  "itertools 0.11.0",
  "petgraph",
@@ -6327,21 +7425,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "pallet-asset-conversion"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4079f12db3cf98daa717337ab5b7e5ef15aa3bec3b497f501dc715d129b500da"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-asset-conversion"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f726ebb59401c1844a4a8703047bdafcd99a1827cd5d8b2c82abeb8948a7f25b"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 33.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6351,13 +7475,13 @@ version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2019e84d65bf6c6105edb61cd6b6f4c6d9a1b347e05d9380e92b0dcf2a29fd7"
 dependencies = [
- "frame-support",
- "frame-system",
- "pallet-asset-conversion",
- "pallet-transaction-payment",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "pallet-asset-conversion 11.0.0",
+ "pallet-transaction-payment 29.0.2",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 32.0.0",
  "sp-std",
 ]
 
@@ -6367,13 +7491,29 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571ce57fd846911041749832b46a8c2b01f0b79ffebcd7585e3973865607036d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-asset-rate"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e806842bec955190ec64f8b2179f74f5355137c4cadf04f3269e6196cd19caf9"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6383,16 +7523,35 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed783679921ad8b96807d683d320c314e305753b230d5c04dc713bab7aca64c"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-transaction-payment",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "pallet-transaction-payment 29.0.2",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-asset-tx-payment"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "100a180dfbf30a1c872100ec2dae8a61c0f5e8b3f2d3a5cbb34093826293e2ab"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "pallet-transaction-payment 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6402,14 +7561,32 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46728a98a910af13f6a77033dd053456650773bb7adc71e0ba845bff7e31b33e"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-assets"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79ef6a7763fc08177f014052469ee12aefcdad0d99a747372360c2f648d2cc4"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6419,15 +7596,33 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a611bef3c8cf281e41a43f32a4153260bdc8b7b61b901e65c7a4442529224e11"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-timestamp",
+ "pallet-timestamp 28.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-consensus-aura",
- "sp-runtime",
+ "sp-application-crypto 31.0.0",
+ "sp-consensus-aura 0.33.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-aura"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0861b2a1ad6526948567bb59a3fdc4c7f02ee79b07be8b931a544350ec35ab0c"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-timestamp 35.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto 37.0.0",
+ "sp-consensus-aura 0.39.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6437,14 +7632,31 @@ version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd9a381c613e6538638391fb51f353fd13b16f849d0d1ac66a388326bd456f1"
 dependencies = [
- "frame-support",
- "frame-system",
- "pallet-session",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "pallet-session 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-authority-discovery",
- "sp-runtime",
+ "sp-application-crypto 31.0.0",
+ "sp-authority-discovery 27.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-authority-discovery"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2c3666a476132f5846fe4d5e1961a923a58a0f54d873d84566f24ffaa3684f"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "pallet-session 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto 37.0.0",
+ "sp-authority-discovery 33.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6454,12 +7666,27 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d83773e731a1760f99684b09961ed7b92acafe335f36f08ebb8313d3b9c72e2"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-authorship"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38885846dbcf03b025fdbd7edb3649046dbc68fa0b419ffe8837ef853a10d31f"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6469,22 +7696,47 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3f2020c52667a650d64e84a4bbb63388e25bc1c9bc872a8243d03bfcb285049"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-authorship",
- "pallet-session",
- "pallet-timestamp",
+ "pallet-authorship 29.0.0",
+ "pallet-session 29.0.0",
+ "pallet-timestamp 28.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-consensus-babe",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
+ "sp-application-crypto 31.0.0",
+ "sp-consensus-babe 0.33.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-session 28.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-babe"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23d2d814e3cb793659fcf84533f66fdf0ed9cccb66cb2225851f482843ed096"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-authorship 36.0.0",
+ "pallet-session 36.0.0",
+ "pallet-timestamp 35.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto 37.0.0",
+ "sp-consensus-babe 0.39.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
@@ -6496,19 +7748,42 @@ checksum = "dd27bfa4bfa5751652842b81241c7eff3e68f2806d9dacc17b03d2cb20a39756"
 dependencies = [
  "aquamarine",
  "docify",
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-election-provider-support 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-balances",
+ "pallet-balances 29.0.2",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 16.0.0",
+]
+
+[[package]]
+name = "pallet-bags-list"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af34fa3fb6a0abe3577e435988039a9e441f6705ae2d3ad627a23e3f705baa2d"
+dependencies = [
+ "aquamarine",
+ "docify",
+ "frame-benchmarking 36.0.0",
+ "frame-election-provider-support 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-balances 37.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
@@ -6518,13 +7793,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a54b5d0c7c4c3731883d6b1ac18aff44db20c3d0a3470c8861001a17afdc85"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-balances"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878e240962d3887f0e0654ac343a18845adb95ad493c9d4d5e803c015d4a4c3"
+dependencies = [
+ "docify",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6534,18 +7826,39 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bedd80e9d8b196f31ea134efd271fdc1b8380ca3aa2d8af6ea8b5a0dc4fa460"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-authorship",
- "pallet-session",
+ "pallet-authorship 29.0.0",
+ "pallet-session 29.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-consensus-beefy",
- "sp-runtime",
- "sp-session",
- "sp-staking",
+ "sp-consensus-beefy 14.0.0",
+ "sp-runtime 32.0.0",
+ "sp-session 28.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-beefy"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715dfcd1bf3f1f37af6335d4eb3cef921e746ac54721e2258c4fd968b61eb009"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-authorship 36.0.0",
+ "pallet-session 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-consensus-beefy 20.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
@@ -6555,23 +7868,49 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d334f24d3c0c016d16aa87d069485847d622e8ebebace18ec5cf56609ca3a67"
 dependencies = [
- "array-bytes 6.2.2",
- "binary-merkle-tree",
- "frame-support",
- "frame-system",
+ "array-bytes",
+ "binary-merkle-tree 14.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-beefy",
- "pallet-mmr",
- "pallet-session",
+ "pallet-beefy 29.0.0",
+ "pallet-mmr 28.0.0",
+ "pallet-session 29.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-consensus-beefy",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-api 27.0.1",
+ "sp-consensus-beefy 14.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-state-machine 0.36.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-beefy-mmr"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d70c6f872eb3f2635355ccbea944a4f9ea411c0aa25f6f1a15219e8da11ad2"
+dependencies = [
+ "array-bytes",
+ "binary-merkle-tree 15.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-beefy 36.0.0",
+ "pallet-mmr 35.0.0",
+ "pallet-session 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api 33.0.0",
+ "sp-consensus-beefy 20.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
  "sp-std",
 ]
 
@@ -6581,100 +7920,119 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4765879e96676c13cdbed746d66fd59dcde1e9e65fda1f064fa2fffa3bc5d597"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-treasury",
+ "pallet-treasury 28.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-bounties"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0566499e74ba4b7ccbd1b667eef0dab76ca28402a8d501e22b73a363717b05a9"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-treasury 35.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-bridge-grandpa"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085573f22a29f8108e2e374b4b4c90702a7449c21edc29d1d614889e9b0c8c0c"
+checksum = "61d30a4860bb12559dc28b2d46dd865e2066bce83239230f748e2c569a3cadf4"
 dependencies = [
- "bp-header-chain",
- "bp-runtime",
+ "bp-header-chain 0.15.0",
+ "bp-runtime 0.15.0",
  "bp-test-utils",
  "finality-grandpa",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-consensus-grandpa",
- "sp-runtime",
+ "sp-consensus-grandpa 20.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
- "sp-trie",
+ "sp-trie 36.0.0",
 ]
 
 [[package]]
 name = "pallet-bridge-messages"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0aac358f6781471f6fd667d5d5af6ee55c3eb11fc494de76787e942bc43726"
+checksum = "e3c0fcb1b9ae50ece73cbe36b72c2778f5d4637e4fb0cfac30cb16f7d4b61d5e"
 dependencies = [
- "bp-messages",
- "bp-runtime",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "bp-messages 0.15.0",
+ "bp-runtime 0.15.0",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
  "num-traits",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-bridge-parachains"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6976281a13460098827ef61a368ef5c26f07bb4bfaf81a9ee4105577a73fc488"
+checksum = "3974fb658cf1b9ca8c2d3c77bf080b2f94c054c2b466b709ef29f6d3726f2231"
 dependencies = [
- "bp-header-chain",
+ "bp-header-chain 0.15.0",
  "bp-parachains",
- "bp-polkadot-core",
- "bp-runtime",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "bp-polkadot-core 0.15.0",
+ "bp-runtime 0.15.0",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
  "pallet-bridge-grandpa",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "sp-std",
- "sp-trie",
+ "sp-trie 36.0.0",
 ]
 
 [[package]]
 name = "pallet-bridge-relayers"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc71ebc287106596ae4d6026d1bdea6448c4b26f08f4477e8e9a2620e5a7c24b"
+checksum = "2c92383f4c7d1eaced8413e39b948227a527a0136f705660580c57753dc11568"
 dependencies = [
- "bp-messages",
+ "bp-messages 0.15.0",
  "bp-relayers",
- "bp-runtime",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "bp-runtime 0.15.0",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
  "pallet-bridge-messages",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-runtime",
+ "sp-arithmetic 26.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6685,15 +8043,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "574c52fd629191c374c24a18036acac008ea92142309e5dd05e7f03149a667c3"
 dependencies = [
  "bitvec",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-runtime",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-broker"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0d652c399b6ed776ee3322e60f40e323f86b413719d7696eddb8f64c368ac0"
+dependencies = [
+ "bitvec",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 33.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6703,17 +8081,37 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00fd06f2d719f5bb16ab3e836c6b053bbd92631ba694f8c2bf810013b2548167"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-bounties",
- "pallet-treasury",
+ "pallet-bounties 28.0.0",
+ "pallet-treasury 28.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-child-bounties"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e351f103ebbdd1eb095da8c2379caccc82ebc59a740c2731693d2204286b83"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-bounties 35.0.0",
+ "pallet-treasury 35.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6723,77 +8121,99 @@ version = "10.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a36858c4275b7d19671b321e95f545e07c9643f97dffed1b333774cb391a4456"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-authorship",
- "pallet-balances",
- "pallet-session",
+ "pallet-authorship 29.0.0",
+ "pallet-balances 29.0.2",
+ "pallet-session 29.0.0",
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-collator-selection"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f660cc09f2f277a3976da2eef856b5c725ab7ad1192902ef7f4e4bafd992f04f"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-authorship 36.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-session 36.0.0",
+ "parity-scale-codec",
+ "rand",
+ "scale-info",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-collective"
-version = "29.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c362a0b8f30895c15ecc7d8c24b0d94bb586c4b9bbd37ac8053b4629d9cc80b"
+checksum = "771bf7f6c76c3ea5e965fee0bf1d8a8c79c8c52d75ead65ed3c4d385f333756f"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-contracts"
-version = "28.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b56fe53df97911ed3ecd90d631f8093cedd795c756d4e42d386110e9fe6614f"
+checksum = "3e6989ac82690f981959b0d38ac6d6d52fc06bf00a035548d62b9a2e9c220376"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances",
+ "pallet-balances 37.0.0",
  "pallet-contracts-proc-macro",
  "pallet-contracts-uapi",
  "parity-scale-codec",
+ "paste",
  "rand",
  "rand_pcg",
  "scale-info",
  "serde",
  "smallvec",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-api 33.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
  "wasm-instrument",
- "wasmi",
+ "wasmi 0.32.3",
 ]
 
 [[package]]
 name = "pallet-contracts-proc-macro"
-version = "19.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163c6bc21b55a0ccb74c546ba784d9c9e69beb9240c059d28a3052f4cbce509"
+checksum = "94226cbd48516b7c310eb5dae8d50798c1ce73a7421dc0977c55b7fc2237a283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6802,9 +8222,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-uapi"
-version = "6.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61eeda58538dc888c59ae6de2146f0e2f43e9ad0eb1d56c228e5cc7af90d4e52"
+checksum = "e1330375dcced95509e3cca7ef6b1c3fac648df995b86d39467d082ba981dc46"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -6820,33 +8240,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aee3a8b6fcde893f862993f9d45eb0fcd492dde0967fd56ef78d79fc7b53dc0"
 dependencies = [
  "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io",
- "sp-runtime",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-conviction-voting"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9033f0d23500bbc39298fd50c07b89a2f2d9f07300139b4df8005995ef683875"
+dependencies = [
+ "assert_matches",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-delegated-staking"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0596ec5ab55e02b1b5637b3ec2b99027d036fe97a1ab4733ae105474dfa727cf"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-democracy"
-version = "29.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa781d632063087bcd3ff46eb1a668f15647ab116f1c8a7c573b7168f62d72c3"
+checksum = "7ccd68a2bf5f2dfda2b810cbe1a779492d4c2e99338989fede4389d412ae325b"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6856,22 +8309,46 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b54d1d3fe9ae61a144d581147e699b7c3009169de0019a0f87cca0bed82681e7"
 dependencies = [
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-election-provider-support 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-election-provider-support-benchmarking",
+ "pallet-election-provider-support-benchmarking 28.0.0",
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-npos-elections",
- "sp-runtime",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-npos-elections 27.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
  "strum 0.24.1",
+]
+
+[[package]]
+name = "pallet-election-provider-multi-phase"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd1090fdc6ccdd8ff08c60000c970428baaaf0b33e7a6b01a91ec8b697a650a3"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-election-provider-support 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-election-provider-support-benchmarking 35.0.0",
+ "parity-scale-codec",
+ "rand",
+ "scale-info",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-npos-elections 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -6880,32 +8357,47 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46ec87816a1e32a1ab6deececa99e21e6684b111efe87b11b8298328dbbefd01"
 dependencies = [
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-election-provider-support 29.0.0",
+ "frame-system 29.0.0",
  "parity-scale-codec",
- "sp-npos-elections",
- "sp-runtime",
+ "sp-npos-elections 27.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-election-provider-support-benchmarking"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93475989d2f6900caf8f1c847a55d909295c156525a7510c5f1dde176ec7c714"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-election-provider-support 36.0.0",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "sp-npos-elections 33.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "30.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cb0158cc7461fda5db04c5791d0df34635bec37181763aca449bade677d12d"
+checksum = "9320d95c95e2d4d3ee24c9292b4ee8562ecb724b985613cfa7f274912bad2c9d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-npos-elections",
- "sp-runtime",
- "sp-staking",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-npos-elections 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
@@ -6916,16 +8408,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2222607a0dba10a9d57cab5360a6549b5fda925181c3c7af481246c0964998df"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-election-provider-support 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-fast-unstake"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155f4f762513e0287320411415c76a647152799ad33db1785c9b71c36a14575"
+dependencies = [
+ "docify",
+ "frame-benchmarking 36.0.0",
+ "frame-election-provider-support 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
@@ -6935,21 +8447,45 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b20be8592eed7ebca2ee661fc43450088552ebe0bd483d7b101cf5968ab12d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-authorship",
- "pallet-session",
+ "pallet-authorship 29.0.0",
+ "pallet-session 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
+ "sp-application-crypto 31.0.0",
+ "sp-consensus-grandpa 14.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-session 28.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-grandpa"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8244b686d5cae6a8af1557ed0f49db08f812f0e7942a8d2da554b4da8a69daf0"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-authorship 36.0.0",
+ "pallet-session 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto 37.0.0",
+ "sp-consensus-grandpa 20.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
@@ -6960,14 +8496,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "452bba25325b7f0148eeecbde13e7c26dfb677ad46b3f160b359d7643b44c94b"
 dependencies = [
  "enumflags2",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-identity"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4555795a3e0e3aa49ea432b7afecb9c71a7db8793a99c68bd8dd3a52a12571f3"
+dependencies = [
+ "enumflags2",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -6977,18 +8531,39 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598ea5c87351edc953d1f455f32ff456cf2f1daf7bbada1f1e03be8e384852ab"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-authorship",
+ "pallet-authorship 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-application-crypto 31.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-im-online"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa761292e95020304b58b50e5187f8bb82f557c8c2d013e3c96ab41d611873b0"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-authorship 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto 37.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
@@ -6998,33 +8573,51 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e880ebdb429ca76fb400b1b361ed7fce018a5ea2fc2da4764de5156fffdfa73"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-keyring",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-keyring 32.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-indices"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b183880ad5efae06afe6066e76f2bac5acf67f34b3cfab7352ceec46accf4b45"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-keyring 38.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-membership"
-version = "29.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad901cdf3de23daf23ff8b092ab318b13faebfc1aa4d84263f2fdc84feaf3e9b"
+checksum = "34006cf047f47edbef33874cc64895918e2c5d7562795209068d5fb388c53a30"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7035,18 +8628,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccb23dee70b184a214d729db550117a0965a69107d466d35181d60a6feede38"
 dependencies = [
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 28.0.0",
+]
+
+[[package]]
+name = "pallet-message-queue"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20e65a37881d1998546254a5e50a1f768b3f82deabe774e750f4ea95aba8030c"
+dependencies = [
+ "environmental",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -7055,16 +8669,35 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6f1f23a70764dad2b4094d8be12ebbb82df210f2e80dd36fa941a5ac191c6cd"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-mmr-primitives",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-mmr-primitives 27.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-mmr"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8ccec82827413f031689fef4c714fdb0213d58c7a6e208d33f5eab80483770"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-mmr-primitives 33.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7074,32 +8707,49 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176f6a5c170185f892a047c0ae189bc52eb390f2c0b94d4261ed0ebc7f82a548"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-multisig"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be58483d827602eb8353ecf36aed65c857f0974db5d27981831e5ebf853040bd"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nft-fractionalization"
-version = "11.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4225c31beb3a10235dd165c78f340c344ee78f6ebccd7c99d62a71fb76d2e39"
+checksum = "7dcaa330221f60feaf3b23d495cccc3bf2a3d6254c596b3c032273c2b46d4078"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
- "pallet-assets",
- "pallet-nfts",
+ "pallet-assets 37.0.0",
+ "pallet-nfts 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7110,15 +8760,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a8978bd9c43ac5ebaa7a26e5bd0c130b037d7cde97189e1a62fa64e5ee1ef1"
 dependencies = [
  "enumflags2",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-nfts"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1cd476809de3840e19091a083d5a79178af1f108ad489706e1f9e04c8836a4"
+dependencies = [
+ "enumflags2",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7128,26 +8797,38 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c412ca82207d43e651ef80a3be837220b82ad0d6c3174922c369ef301ea0e5af"
 dependencies = [
- "pallet-nfts",
+ "pallet-nfts 23.0.0",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 27.0.1",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-nfts-runtime-api"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ca7a0446d2d3c27f726a016c6366218df2e0bfef9ed35886b252cfa9757f6c"
+dependencies = [
+ "pallet-nfts 30.0.0",
+ "parity-scale-codec",
+ "sp-api 33.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nis"
-version = "29.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a64a0e80dec2c60d5962dd249061a47dc4356db440f26cdec50b8acaded1d3"
+checksum = "e77cba0e15749c8de2be65efffa51e02bd051b4e6fcf23360d43c3b6a859187c"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-runtime",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7157,18 +8838,38 @@ version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62091305ec7426e71c3da2b0944c2df5a804109ee4d2e8f4fe34865e049f8ac"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-balances",
+ "pallet-balances 29.0.2",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 16.0.0",
+]
+
+[[package]]
+name = "pallet-nomination-pools"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f8c994eb7298a394b58f98afd520b521b5d46f6f39eade4657eeaac9962471"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-balances 37.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
+ "sp-std",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
@@ -7177,18 +8878,40 @@ version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a1eba3078e2492cad15e4695f90eb3fc570386d9f71f8b81f709c7123fc6b5"
 dependencies = [
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
- "pallet-bags-list",
- "pallet-nomination-pools",
- "pallet-staking",
+ "frame-benchmarking 29.0.0",
+ "frame-election-provider-support 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "pallet-bags-list 28.0.0",
+ "pallet-nomination-pools 26.0.1",
+ "pallet-staking 29.0.3",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-staking",
+ "sp-runtime 32.0.0",
+ "sp-runtime-interface 25.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-nomination-pools-benchmarking"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ee599f2861e55fc6113c01e9b14d6e85fda46bac36a906b5dd5a951fa0455c"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-election-provider-support 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "pallet-bags-list 35.0.0",
+ "pallet-delegated-staking",
+ "pallet-nomination-pools 33.0.0",
+ "pallet-staking 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 38.0.1",
+ "sp-runtime-interface 28.0.0",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
@@ -7198,9 +8921,21 @@ version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5b35e6c471a669437b987ff02e11e2283412c9ebaeec5334dec3f73bcea652"
 dependencies = [
- "pallet-nomination-pools",
+ "pallet-nomination-pools 26.0.1",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 27.0.1",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-nomination-pools-runtime-api"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2906899d8f029780f0d9da77b90ae86f42bcfda5ac402c931406cd84852012ed"
+dependencies = [
+ "pallet-nomination-pools 33.0.0",
+ "parity-scale-codec",
+ "sp-api 33.0.0",
  "sp-std",
 ]
 
@@ -7210,15 +8945,33 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b5bcfdc4f6032d7570929094fd459de12d840c440c395fb4d365d679e13eda"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-balances",
+ "pallet-balances 29.0.2",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-offences"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4859e7bb2af46d2e0f137c2f777adf39f0e5d4d188226158d599f1cfcfb76b9e"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-balances 37.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
@@ -7228,22 +8981,66 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc33e3086c19235cb903cbbbde1bc1c4f428519ad4c23446dc84c75d0061582"
 dependencies = [
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-election-provider-support 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-babe",
- "pallet-balances",
- "pallet-grandpa",
- "pallet-im-online",
- "pallet-offences",
- "pallet-session",
- "pallet-staking",
+ "pallet-babe 29.0.0",
+ "pallet-balances 29.0.2",
+ "pallet-grandpa 29.0.0",
+ "pallet-im-online 28.0.0",
+ "pallet-offences 28.0.0",
+ "pallet-session 29.0.0",
+ "pallet-staking 29.0.3",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-offences-benchmarking"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4351b0edafcdf3240f0471c638b39d2c981bde9d17c0172536a0aa3b7c3097ef"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-election-provider-support 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-babe 36.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-grandpa 36.0.0",
+ "pallet-im-online 35.0.0",
+ "pallet-offences 35.0.0",
+ "pallet-session 36.0.0",
+ "pallet-staking 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-parameters"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58d9a81a93202105a660e6aa3d3f81638bdd109ca0497f3e528529cd52d034db"
+dependencies = [
+ "docify",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7253,15 +9050,33 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7344a30c304771beb90aec34604100185e47cdc0366e268ad18922de602a0c7e"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-preimage"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ac726abc5b1bcd6c8f783514b8e1a48be32c7d15e0b263e4bc28cc1e4e7763"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7271,49 +9086,65 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7aa31a0b91e8060b808c3e3407e4578a5e94503b174b9e99769147b24fb2c56"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-proxy"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e12680e176607815a78a0cd10a52af50790292cb950404f30a885e2a7229e9"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "29.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3733dbfc44d8f5e1a08287a9064e5794e9d0e92b1bd68cdad2e22202b1964528"
+checksum = "862ea8d386ed5737e859470c43cbfd9652c81398cad29e03ae7846c21aaee4c6"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-recovery"
-version = "29.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797b554ddc87082c18223440d61a81cf35ccab6573321ce473a099e7a709a760"
+checksum = "b24d4131bc79fee0b07550136ca6329faa84c1c3e76ae62a74aef6b1da0b95b4"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7324,32 +9155,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da850889e7101b63cadb980b7f39df67feb6d63bc6092769b9b708e9eb596db1"
 dependencies = [
  "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 24.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-referenda"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c906a9c4573eb58de4134ec7180bf12c6769df2b9859dae8adcbc5fce78add"
+dependencies = [
+ "assert_matches",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-arithmetic 26.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-root-testing"
-version = "5.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59171cbf2b823c13685b1b80dd3e1e84425680ff4e006d8016f8c14d2ec44974"
+checksum = "fa61642f7bdc1a393798aa1ff67bb8c29f8f184b6fce165e1079010d446a1e29"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7360,16 +9211,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e2a4ebe6a5f98b14a26deed8d7a1ea28bb2c2d3ad4d6dc129a725523a2042d"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 28.0.0",
+]
+
+[[package]]
+name = "pallet-scheduler"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b170d6aa191197d3f50b1193925546972ffc394376ead4d2739eb40909b73c85"
+dependencies = [
+ "docify",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -7378,21 +9248,44 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7412ac59247b300feee53709f7009a23d1c6f8c70528599f48f44e102d896d03"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-timestamp",
+ "pallet-timestamp 28.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-state-machine",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-session 28.0.0",
+ "sp-staking 27.0.0",
+ "sp-state-machine 0.36.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 30.0.0",
+]
+
+[[package]]
+name = "pallet-session"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c92b24c911c2cfa5351616edc7f2f93427ea6f4f95efdb13f0f5d51997939c3"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-timestamp 35.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-staking 33.0.0",
+ "sp-state-machine 0.42.0",
+ "sp-std",
+ "sp-trie 36.0.0",
 ]
 
 [[package]]
@@ -7401,34 +9294,52 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9c2731415381020db1e78db8b40207f8423a16099e78f2fde599cbcb57ea8db"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-session",
- "pallet-staking",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "pallet-session 29.0.0",
+ "pallet-staking 29.0.3",
  "parity-scale-codec",
  "rand",
- "sp-runtime",
- "sp-session",
+ "sp-runtime 32.0.0",
+ "sp-session 28.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-session-benchmarking"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd02aaf5f10734670346677042ece94fae20dcd5436eafeb9b429d8d6d5b6385"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "pallet-session 36.0.0",
+ "pallet-staking 36.0.0",
+ "parity-scale-codec",
+ "rand",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-society"
-version = "29.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba64f96619c25ae7a0b41f4a5111c2d3102e8b8c6cbce80ece6955e825f9de2"
+checksum = "66b60b1d726532317f9965bab4995aa49b73f9b7ca3b9a0f75d158bd84686c5f"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
  "parity-scale-codec",
- "rand_chacha 0.2.2",
+ "rand_chacha 0.3.1",
  "scale-info",
- "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 26.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7438,21 +9349,45 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061b00814eb794a40df4eca7972a7c67b26473cd85cc7c54f5816ae49ad6e11b"
 dependencies = [
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-election-provider-support 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-authorship",
- "pallet-session",
+ "pallet-authorship 29.0.0",
+ "pallet-session 29.0.0",
  "parity-scale-codec",
  "rand_chacha 0.2.2",
  "scale-info",
  "serde",
- "sp-application-crypto",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-application-crypto 31.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-staking"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbebdb060417654f215fc6f03675e5f44cfc83837d9e523e1b8fd9a4a2e1bdc2"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-election-provider-support 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-authorship 36.0.0",
+ "pallet-session 36.0.0",
+ "parity-scale-codec",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "serde",
+ "sp-application-crypto 37.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
@@ -7469,13 +9404,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-staking-reward-curve"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5e6b1d8ee9d3f6894c5abd8c3e17737ed738c9854f87bfd16239741b7f4d5d"
+dependencies = [
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "pallet-staking-reward-fn"
 version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "505d45e08bad052f55fb51f00a6b6244d23ee46ffdc8091f6cddf4e3a880319d"
 dependencies = [
  "log",
- "sp-arithmetic",
+ "sp-arithmetic 24.0.0",
+]
+
+[[package]]
+name = "pallet-staking-reward-fn"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "988a7ebeacc84d4bdb0b12409681e956ffe35438447d8f8bc78db547cffb6ebc"
+dependencies = [
+ "log",
+ "sp-arithmetic 26.0.0",
 ]
 
 [[package]]
@@ -7485,8 +9442,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e47c73850103db30b61ef170107afe1ef0dab6905c495bd6dfb57b3c1dd81bc7"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-staking",
+ "sp-api 27.0.1",
+ "sp-staking 27.0.0",
+]
+
+[[package]]
+name = "pallet-staking-runtime-api"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3350ef1795b832f4adc464e88fb6d44827bd3f98701b0b0bbee495267b444a92"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api 33.0.0",
+ "sp-staking 33.0.0",
 ]
 
 [[package]]
@@ -7495,15 +9463,33 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e52dedc146b7a9c3b7c5a6ff4c4c442a8ab8cc58ec30e90e1e98cdc51ad34"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-state-trie-migration"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e07f8626f4ff62ac79d6ad0bd01fab7645897ce35706ddb95fa084e75be9306d"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7514,13 +9500,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d02f7855d411913e77e57126f4a8b8a32d90d9bf47d0b747e367a1301729c3"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-sudo"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd2a8797c1bb3d3897b4f87a7716111da5eeb8561345277b6e6d70349ec8b35"
+dependencies = [
+ "docify",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7531,37 +9534,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b8810ddfb254c7fb8cd7698229cce513d309a43ff117b38798dae6120f477b"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
+ "sp-inherents 27.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-storage",
- "sp-timestamp",
+ "sp-storage 20.0.0",
+ "sp-timestamp 27.0.0",
+]
+
+[[package]]
+name = "pallet-timestamp"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae789d344be857679b0b98b28a67c747119724847f81d704d3fd03ee13fb6841"
+dependencies = [
+ "docify",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-storage 21.0.0",
+ "sp-timestamp 33.0.0",
 ]
 
 [[package]]
 name = "pallet-tips"
-version = "28.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca4b9921c9e9b59e8eeb64677ba6ec49743ef5fe98e0b63f77411b2b9f6cc99"
+checksum = "f7dfec7872ee9e071209ae860094569745e8bd47564bacdba739256ee52cf78c"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "log",
- "pallet-treasury",
+ "pallet-treasury 35.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7571,32 +9595,49 @@ version = "29.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5ba71f06f09e955b80dc313c333be3f8d9e8505b051558e0b7af4806b13310"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-transaction-payment"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fb6114223c8d967c3c2f21cbc845e8ea604ff7e21a8e59d119d5a9257ba886"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "31.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ef209d2d5d077e325bf49b024fd2eff109a5c2ca0d84ce0d50a65839e6b026"
+checksum = "a82898085607c7b00ef20fdce7c621790bf2b644c134918a172fe0a8f7f08e6c"
 dependencies = [
- "jsonrpsee",
- "pallet-transaction-payment-rpc-runtime-api",
+ "jsonrpsee 0.23.2",
+ "pallet-transaction-payment-rpc-runtime-api 36.0.0",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime",
- "sp-weights",
+ "sp-runtime 38.0.1",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -7605,11 +9646,24 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c78bcba80c7c61712b98a6b5640975ebd25ceb688c18e975af78a0fac81785b0"
 dependencies = [
- "pallet-transaction-payment",
+ "pallet-transaction-payment 29.0.2",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
- "sp-weights",
+ "sp-api 27.0.1",
+ "sp-runtime 32.0.0",
+ "sp-weights 28.0.0",
+]
+
+[[package]]
+name = "pallet-transaction-payment-rpc-runtime-api"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4bad1700ad7eb5ab254189e1df894d1d16b3626a3c4b9c45259ec4d9efc262c"
+dependencies = [
+ "pallet-transaction-payment 36.0.0",
+ "parity-scale-codec",
+ "sp-api 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -7619,16 +9673,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eca44990d0d759213744f2d1f6fe1fadec1079a3e4e4da40556d6b4e42abbcd"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "impl-trait-for-tuples",
- "pallet-balances",
+ "pallet-balances 29.0.2",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-treasury"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c502615bb4fdd02856a131cb2a612ad40c26435ec938f65f11cae4ff230812b"
+dependencies = [
+ "docify",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "impl-trait-for-tuples",
+ "pallet-balances 37.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7638,13 +9712,13 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac9449d6e2cdcc4456466eff97a065c43dde678620551f5fd79072dec3b9f560"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 32.0.0",
  "sp-std",
 ]
 
@@ -7654,14 +9728,31 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "954f15b98c3fdebb763bb5cea4ec6803fd180d540ec5b07a9fcb2c118251d52c"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-utility"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3238fe6ad00da6a137be115904c39cab97eb5c7f03da0bb1a20de1bef03f0c71"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7671,13 +9762,29 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4525f3038cdf078fea39d913c563ca626f09a615e7724f0c9eac97743c75ff44"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-vesting"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f7f0f4fe5e1d851e85d81e5e73b6f929f0c35af786ce8be9c9e3363717c136"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7687,13 +9794,29 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0ad4ce05688bdddcdb682cbed2f3edff0ee5349f0b745ebacc27d179582432"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-whitelist"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4f27640279229eb73fde0cb06e98b799305e6b0bc724f4dfbef2001ab4ad00"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 33.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -7704,21 +9827,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba9138b04168b07b1aff4a2079f5514753c31dddba40e5fb471b9cda7da27ad6"
 dependencies = [
  "bounded-collections 0.2.0",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-balances",
+ "pallet-balances 29.0.2",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 8.0.1",
+ "staging-xcm-builder 8.0.3",
+ "staging-xcm-executor 8.0.2",
+]
+
+[[package]]
+name = "pallet-xcm"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7409458b7fedc5c7d46459da154ccc2dc22a843ce08e8ab6c1743ef5cf972c"
+dependencies = [
+ "bounded-collections 0.2.0",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-balances 37.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "staging-xcm-executor 15.0.0",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -7727,18 +9875,38 @@ version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c10e1c92086ce2069a3d2387d9431f48660b6ec92054c4d0a4e30a9f54e7ad3"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 8.0.1",
+ "staging-xcm-builder 8.0.3",
+ "staging-xcm-executor 8.0.2",
+]
+
+[[package]]
+name = "pallet-xcm-benchmarks"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f177a171203cc0bec3cff1bdd5d3b926abfbd0ecf347e044b147194e664f717"
+dependencies = [
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "staging-xcm-executor 15.0.0",
 ]
 
 [[package]]
@@ -7747,18 +9915,38 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5bd3947da7f031c86904f12b6690bbecd2efa122906a8dd838499150fe4322"
 dependencies = [
- "bp-xcm-bridge-hub-router",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "bp-xcm-bridge-hub-router 0.7.0",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm 8.0.1",
+ "staging-xcm-builder 8.0.3",
+]
+
+[[package]]
+name = "pallet-xcm-bridge-hub-router"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48bd38d4061a51f263f4c08021e66100e16cbda9978fba163d2544637b31dab"
+dependencies = [
+ "bp-xcm-bridge-hub-router 0.13.0",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
 ]
 
 [[package]]
@@ -7767,61 +9955,107 @@ version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711a4c073e7c83aac7e414ba16c7c641d6d9e22e6d32f9775ff35b2464ffd7ff"
 dependencies = [
- "cumulus-primitives-core",
- "cumulus-primitives-utility",
- "frame-support",
- "frame-system",
+ "cumulus-primitives-core 0.8.0",
+ "cumulus-primitives-utility 0.8.1",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "log",
- "pallet-asset-tx-payment",
- "pallet-assets",
- "pallet-authorship",
- "pallet-balances",
- "pallet-collator-selection",
- "pallet-message-queue",
- "pallet-xcm",
+ "pallet-asset-tx-payment 29.0.0",
+ "pallet-assets 30.0.0",
+ "pallet-authorship 29.0.0",
+ "pallet-balances 29.0.2",
+ "pallet-collator-selection 10.0.3",
+ "pallet-message-queue 32.0.0",
+ "pallet-xcm 8.0.5",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 8.0.1",
  "scale-info",
- "sp-consensus-aura",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-consensus-aura 0.33.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-parachain-info",
- "staging-xcm",
- "staging-xcm-executor",
- "substrate-wasm-builder",
+ "staging-parachain-info 0.8.0",
+ "staging-xcm 8.0.1",
+ "staging-xcm-executor 8.0.2",
+ "substrate-wasm-builder 18.0.1",
+]
+
+[[package]]
+name = "parachains-common"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9319e656eebdf161666e54a4d8e24f73137f702f01600247f7be650bc4d46167"
+dependencies = [
+ "cumulus-primitives-core 0.14.0",
+ "cumulus-primitives-utility 0.15.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "log",
+ "pallet-asset-tx-payment 36.0.0",
+ "pallet-assets 37.0.0",
+ "pallet-authorship 36.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-collator-selection 17.0.0",
+ "pallet-message-queue 39.0.0",
+ "pallet-xcm 15.0.0",
+ "parity-scale-codec",
+ "polkadot-primitives 14.0.0",
+ "scale-info",
+ "sp-consensus-aura 0.39.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "staging-parachain-info 0.15.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-executor 15.0.0",
+ "substrate-wasm-builder 23.0.0",
 ]
 
 [[package]]
 name = "parachains-runtimes-test-utils"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d295b9c391ce15f68ddcd7b0d428eb2d3338643a4d1f471b3dd8a15538865e17"
+checksum = "c778447d2e71a418b083c0458579d0f8d13872f43c63142d9e5157edea000bdd"
 dependencies = [
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-pallet-parachain-system 0.15.0",
+ "cumulus-pallet-xcmp-queue 0.15.0",
+ "cumulus-primitives-core 0.14.0",
+ "cumulus-primitives-parachain-inherent 0.14.0",
  "cumulus-test-relay-sproof-builder",
- "frame-support",
- "frame-system",
- "pallet-balances",
- "pallet-collator-selection",
- "pallet-session",
- "pallet-xcm",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-collator-selection 17.0.0",
+ "pallet-session 36.0.0",
+ "pallet-timestamp 35.0.0",
+ "pallet-xcm 15.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
- "sp-consensus-aura",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "polkadot-parachain-primitives 13.0.0",
+ "sp-consensus-aura 0.39.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
- "sp-tracing",
- "staging-parachain-info",
- "staging-xcm",
- "staging-xcm-executor",
- "substrate-wasm-builder",
+ "sp-tracing 17.0.0",
+ "staging-parachain-info 0.15.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-executor 15.0.0",
+ "substrate-wasm-builder 23.0.0",
+]
+
+[[package]]
+name = "parity-bip39"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
+dependencies = [
+ "bitcoin_hashes 0.13.0",
+ "rand",
+ "rand_core 0.6.4",
+ "serde",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -7844,7 +10078,7 @@ dependencies = [
  "log",
  "lz4",
  "memmap2 0.5.10",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "rand",
  "siphasher",
  "snap",
@@ -7879,12 +10113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-send-wrapper"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
-
-[[package]]
 name = "parity-util-mem"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7896,7 +10124,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "lru 0.8.1",
  "parity-util-mem-derive",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "primitive-types",
  "smallvec",
  "winapi",
@@ -7910,7 +10138,7 @@ checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -7938,9 +10166,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core 0.9.9",
@@ -7984,94 +10212,94 @@ name = "paseo-runtime"
 version = "1.2.5"
 source = "git+https://github.com/paseo-network/runtimes/?tag=v1.2.5-system-chains#e7265b10b28d8b82c3146e72c98895dac2b55729"
 dependencies = [
- "binary-merkle-tree",
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-executive",
- "frame-metadata-hash-extension",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
+ "binary-merkle-tree 14.0.0",
+ "frame-benchmarking 29.0.0",
+ "frame-election-provider-support 29.0.0",
+ "frame-executive 29.0.0",
+ "frame-metadata-hash-extension 0.1.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "frame-system-benchmarking 29.0.0",
+ "frame-system-rpc-runtime-api 27.0.0",
+ "frame-try-runtime 0.35.0",
  "log",
- "pallet-asset-rate",
- "pallet-authority-discovery",
- "pallet-authorship",
- "pallet-babe",
- "pallet-bags-list",
- "pallet-balances",
- "pallet-beefy",
- "pallet-beefy-mmr",
- "pallet-bounties",
- "pallet-child-bounties",
- "pallet-conviction-voting",
- "pallet-election-provider-multi-phase",
- "pallet-election-provider-support-benchmarking",
- "pallet-fast-unstake",
- "pallet-grandpa",
- "pallet-identity",
- "pallet-indices",
- "pallet-message-queue",
- "pallet-mmr",
- "pallet-multisig",
- "pallet-nomination-pools",
- "pallet-nomination-pools-benchmarking",
- "pallet-nomination-pools-runtime-api",
- "pallet-offences",
- "pallet-offences-benchmarking",
- "pallet-preimage",
- "pallet-proxy",
- "pallet-referenda",
- "pallet-scheduler",
- "pallet-session",
- "pallet-session-benchmarking",
- "pallet-staking",
- "pallet-staking-reward-curve",
- "pallet-staking-reward-fn",
- "pallet-staking-runtime-api",
- "pallet-state-trie-migration",
- "pallet-sudo",
- "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-treasury",
- "pallet-utility",
- "pallet-vesting",
- "pallet-whitelist",
- "pallet-xcm",
- "pallet-xcm-benchmarks",
+ "pallet-asset-rate 8.0.0",
+ "pallet-authority-discovery 29.0.1",
+ "pallet-authorship 29.0.0",
+ "pallet-babe 29.0.0",
+ "pallet-bags-list 28.0.0",
+ "pallet-balances 29.0.2",
+ "pallet-beefy 29.0.0",
+ "pallet-beefy-mmr 29.0.0",
+ "pallet-bounties 28.0.0",
+ "pallet-child-bounties 28.0.0",
+ "pallet-conviction-voting 29.0.0",
+ "pallet-election-provider-multi-phase 28.0.0",
+ "pallet-election-provider-support-benchmarking 28.0.0",
+ "pallet-fast-unstake 28.0.0",
+ "pallet-grandpa 29.0.0",
+ "pallet-identity 29.0.1",
+ "pallet-indices 29.0.0",
+ "pallet-message-queue 32.0.0",
+ "pallet-mmr 28.0.0",
+ "pallet-multisig 29.0.0",
+ "pallet-nomination-pools 26.0.1",
+ "pallet-nomination-pools-benchmarking 27.0.0",
+ "pallet-nomination-pools-runtime-api 24.0.0",
+ "pallet-offences 28.0.0",
+ "pallet-offences-benchmarking 29.0.0",
+ "pallet-preimage 29.0.0",
+ "pallet-proxy 29.0.0",
+ "pallet-referenda 29.0.0",
+ "pallet-scheduler 30.0.0",
+ "pallet-session 29.0.0",
+ "pallet-session-benchmarking 29.0.0",
+ "pallet-staking 29.0.3",
+ "pallet-staking-reward-curve 11.0.0",
+ "pallet-staking-reward-fn 20.0.0",
+ "pallet-staking-runtime-api 15.0.1",
+ "pallet-state-trie-migration 30.0.0",
+ "pallet-sudo 29.0.0",
+ "pallet-timestamp 28.0.0",
+ "pallet-transaction-payment 29.0.2",
+ "pallet-transaction-payment-rpc-runtime-api 29.0.0",
+ "pallet-treasury 28.0.1",
+ "pallet-utility 29.0.0",
+ "pallet-vesting 29.0.0",
+ "pallet-whitelist 28.0.0",
+ "pallet-xcm 8.0.5",
+ "pallet-xcm-benchmarks 8.0.2",
  "parity-scale-codec",
  "paseo-runtime-constants",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-primitives 8.0.1",
+ "polkadot-runtime-common 8.0.3",
+ "polkadot-runtime-parachains 8.0.3",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-authority-discovery",
- "sp-block-builder",
- "sp-consensus-babe",
- "sp-consensus-beefy",
- "sp-core",
+ "sp-api 27.0.1",
+ "sp-application-crypto 31.0.0",
+ "sp-arithmetic 24.0.0",
+ "sp-authority-discovery 27.0.0",
+ "sp-block-builder 27.0.0",
+ "sp-consensus-babe 0.33.0",
+ "sp-consensus-beefy 14.0.0",
+ "sp-core 29.0.0",
  "sp-debug-derive",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-npos-elections",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-staking",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 27.0.0",
+ "sp-io 31.0.0",
+ "sp-npos-elections 27.0.0",
+ "sp-offchain 27.0.0",
+ "sp-runtime 32.0.0",
+ "sp-session 28.0.0",
+ "sp-staking 27.0.0",
  "sp-std",
- "sp-storage",
- "sp-transaction-pool",
- "sp-version",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
- "substrate-wasm-builder",
+ "sp-storage 20.0.0",
+ "sp-transaction-pool 27.0.0",
+ "sp-version 30.0.0",
+ "staging-xcm 8.0.1",
+ "staging-xcm-builder 8.0.3",
+ "staging-xcm-executor 8.0.2",
+ "substrate-wasm-builder 18.0.1",
 ]
 
 [[package]]
@@ -8079,14 +10307,25 @@ name = "paseo-runtime-constants"
 version = "1.0.0"
 source = "git+https://github.com/paseo-network/runtimes/?tag=v1.2.5-system-chains#e7265b10b28d8b82c3146e72c98895dac2b55729"
 dependencies = [
- "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "frame-support 29.0.2",
+ "polkadot-primitives 8.0.1",
+ "polkadot-runtime-common 8.0.3",
  "smallvec",
- "sp-core",
- "sp-runtime",
- "sp-weights",
- "staging-xcm-builder",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+ "sp-weights 28.0.0",
+ "staging-xcm-builder 8.0.3",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle 2.5.0",
 ]
 
 [[package]]
@@ -8111,6 +10350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
+ "password-hash",
 ]
 
 [[package]]
@@ -8211,12 +10451,6 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
-
-[[package]]
-name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
@@ -8262,30 +10496,30 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdfa52beecc446ccf733dede1a0089e6396d3df13401004d27c0ce2530816bc"
+checksum = "61d39d6552d00ade2d668b8171aa7d6a1f5da4c7ebff402b5a9877b5d1e45b4e"
 dependencies = [
  "bitvec",
  "futures",
  "futures-timer",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "polkadot-node-jaeger",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "rand",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ffc856dfbdb31178625760824ae320ddb7dd5694b217f489bd2832b8de15a5"
+checksum = "cd0a8b5280959524f84b09c27ef0dbceeced6d19537f8fd43d03a08414f8b93d"
 dependencies = [
  "always-assert",
  "futures",
@@ -8293,16 +10527,16 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "rand",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d05c26cc8d6fa0f5f432d9de880f20ad0d24ca51a618834ea6612d1bd96ab1"
+checksum = "adfe520a9c8dbe6c5db06c0b919c53441927babc1c02b9df76718fc4b80c5c4f"
 dependencies = [
  "derive_more",
  "fatality",
@@ -8313,20 +10547,21 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "rand",
+ "sc-network",
  "schnellru",
- "sp-core",
- "sp-keystore",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d77e0b979f43861ab4c78c216c2729644bb12812f9bc859858bd3b8fc56b4d6"
+checksum = "727f02306a3a51eb0b8efca3e1e14c5efa2daf921c9be7c46d9c5d68670a9b51"
 dependencies = [
  "async-trait",
  "fatality",
@@ -8337,7 +10572,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "rand",
  "sc-network",
  "schnellru",
@@ -8347,10 +10582,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkadot-cli"
-version = "8.0.0"
+name = "polkadot-ckb-merkle-mountain-range"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef362c44280e3883a39ca452acc4a4fb61a18250d634d68578b22df7edd8290c"
+checksum = "a4b44320e5f7ce2c18227537a3032ae5b2c476a7e8eddba45333e1011fc31b92"
+dependencies = [
+ "cfg-if",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "polkadot-cli"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "141a62da626bba7c4a29b8e5d20a975efa6439095a352ebfc47f068e4dfd82fd"
 dependencies = [
  "cfg-if",
  "clap",
@@ -8366,20 +10611,20 @@ dependencies = [
  "sc-storage-monitor",
  "sc-sysinfo",
  "sc-tracing",
- "sp-core",
- "sp-io",
- "sp-keyring",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-keyring 38.0.0",
  "sp-maybe-compressed-blob",
+ "sp-runtime 38.0.1",
  "substrate-build-script-utils",
  "thiserror",
- "try-runtime-cli",
 ]
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507391f1be9f9b9a8fbf28ca13b0ab3f04947a54a1115d423d115aacf8889bf4"
+checksum = "75bd07cc8a0bfabe6464d40072e30bd87f52730fbc26c733f0a8ffa97918c0a8"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8389,10 +10634,10 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "polkadot-primitives 14.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
  "thiserror",
  "tokio-util",
  "tracing-gum",
@@ -8406,16 +10651,29 @@ checksum = "b6a08e4e014c853b252ecbbe3ccd67b2d33d78e46988d309b8cccf4ac06e25ef"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-core-primitives"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c72ee63bcf920f963cd7ac066759b0b649350c8ab3781a85a6aac87b1488f2"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae32e83ef6bc0ec2874c76c19dff8f3795832ccc27f0abc587a7137994c42d26"
+checksum = "09c49e68add45aa6c2b85e97f0d09b81f26b1428117bdc9284eaa74a1eb63daf"
 dependencies = [
  "derive_more",
  "fatality",
@@ -8428,58 +10686,58 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sc-network",
  "schnellru",
- "sp-application-crypto",
- "sp-keystore",
+ "sp-application-crypto 37.0.0",
+ "sp-keystore 0.40.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "8.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b10514ace3272d38b602e1795a5a340b265285c4af875473d682a5c9d6c831c"
+checksum = "6a39a54a269817e09d602b4e9c527905f9e367ff7c6337b1b3e1e048515f6b59"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "reed-solomon-novelpoly",
- "sp-core",
- "sp-trie",
+ "sp-core 34.0.0",
+ "sp-trie 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f05f7f60022d4beb30414f1f7c7e4ae728fea02086a4a0f8ff0a73e73ea4aa"
+checksum = "53b56e8fe08e4ed30af0d296870b12b5a7411695f2b79b3c5842d04b9a347200"
 dependencies = [
  "futures",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "rand",
  "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 37.0.0",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-keystore",
+ "sp-keystore 0.40.0",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049ec1298ac6e96bcf4d980cd5864aceeee73b3298ab5d6dd7a3193d47578abc"
+checksum = "178b92197936c23ae8a936ec74b83a15a9fe0978c7f3de677db141ba9c524a63"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -8487,12 +10745,12 @@ dependencies = [
  "fatality",
  "futures",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sc-network",
  "sp-consensus",
  "thiserror",
@@ -8501,9 +10759,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f1211ab8b154c2e2b4b89c64f57f96056c881e4fcfa2ce29b6e5cbc978e74f1"
+checksum = "869534f66d5a38443acf4b9fec3a4919f59f293e6fdee4177cd7cece1c4a85ef"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -8511,8 +10769,8 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
- "sp-core",
+ "polkadot-primitives 14.0.0",
+ "sp-core 34.0.0",
  "sp-maybe-compressed-blob",
  "thiserror",
  "tracing-gum",
@@ -8520,15 +10778,15 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a17b7e4edd3b73afbe0c6e8b5369bf3b721361a232baf11fb1698077067a4"
+checksum = "ed3629b2d93b5f152bc75437fb68326ebf9267885ff89f2abede9b8a050e9288"
 dependencies = [
  "bitvec",
  "derive_more",
  "futures",
  "futures-timer",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "kvdb",
  "merlin",
  "parity-scale-codec",
@@ -8537,26 +10795,26 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "rand",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto",
+ "sp-application-crypto 37.0.0",
  "sp-consensus",
- "sp-consensus-slots",
- "sp-runtime",
+ "sp-consensus-slots 0.39.0",
+ "sp-runtime 38.0.1",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b334f06423ff701e4b807d6832741ec24e0e97ebc13b560fc99bc0652926c0"
+checksum = "8487c45eedaaf535ccc78bf4f459eae9443c4c9cfcca31dc3838950f3a3426e3"
 dependencies = [
  "bitvec",
  "futures",
@@ -8569,7 +10827,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sp-consensus",
  "thiserror",
  "tracing-gum",
@@ -8577,9 +10835,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "8.0.1"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07f8840f3f2f0bee6264c18ce471c99c925f9afb65952e1d584b6d773cf4115"
+checksum = "b493dff8562ce2675dbb0e5c8594e145085a4536de435f5061f577bdaba2195e"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8588,25 +10846,25 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "polkadot-statement-table",
  "schnellru",
- "sp-keystore",
+ "sp-keystore 0.40.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0687006f843d6da8687eb24da735a04cbdcf4c3a98d82055b9b3a9047537e17e"
+checksum = "5946d61086be5096e8dafd731d0881fa41e12f21a1f3a8b9d7ff6f1294914b98"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
- "sp-keystore",
+ "polkadot-primitives 14.0.0",
+ "sp-keystore 0.40.0",
  "thiserror",
  "tracing-gum",
  "wasm-timer",
@@ -8614,9 +10872,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3035acf9069801e980b91b5178591f8a7052b4409de13824db7a6c798b36b98"
+checksum = "389b6d8da9a7cf825f97ff4da4ef754a1371de0358e896fbec973f4ff1dfe011"
 dependencies = [
  "async-trait",
  "futures",
@@ -8628,17 +10886,17 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
  "sp-maybe-compressed-blob",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c990b9ffdde6725fe79f55e3b7c4c32ce2134a06103708476fa595a4ac652e95"
+checksum = "29086798f24839c9dc1c8b080ffc68bbfe2a5fdc5f29de557b9d224a45011094"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -8651,9 +10909,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451965f3ace786d392c407872d61324765061b87027890b02ffd625554531f97"
+checksum = "79c8bcae78a4562bc8b3b786e08cb1b3c96c29554da7d57b6806a6723b1540b0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8662,16 +10920,16 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13ea9d5b4aa43b5b1f718c3ec951adff0b0d74909cb1fe28206f5d88492247d"
+checksum = "459e1da76e61c2f5636123ae7c19097067dcc1d07e0d5e77eae4eb87e5cb999d"
 dependencies = [
  "fatality",
  "futures",
@@ -8680,7 +10938,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sc-keystore",
  "schnellru",
  "thiserror",
@@ -8689,27 +10947,27 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6574c0bda4e10d722f761d4b8ab5d1708f0f963e5840370aa9cee8f559c90a23"
+checksum = "18e4d2b44748657a68c8ff2995b0b39609f5186bc4b07040ebb6b389dbf1047b"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sp-blockchain",
- "sp-inherents",
+ "sp-inherents 33.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "7.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160f80a11b9d2b8e36e510ea54ce5b06e77179c0c502f7e19e5a5809bc1523ee"
+checksum = "756205c36293216422775c6fa1be9fc4bdb99fa5cafd86b96e7feae13e669e79"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8718,16 +10976,16 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "8.0.1"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d0a64371700537c3dc15b3956536e4541f093b7c38ac21737ea9fea3562a83"
+checksum = "d6f090dc90bbe0b452a57a3129b53a6129e357ff4607e9db27a54b291d7a747b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8736,39 +10994,36 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
+ "schnellru",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bbb1b5f4b966f21a0336e94c0a0222958d2f3cba451da1157af271d07f9748"
+checksum = "2eea57cb8ce66c2952b87b2476b46d6316ae58342f198abd09c391827ed5402d"
 dependencies = [
  "always-assert",
- "array-bytes 6.2.2",
+ "array-bytes",
  "blake3",
  "cfg-if",
  "futures",
  "futures-timer",
- "is_executable",
- "libc",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 14.0.0",
  "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
  "rand",
  "slotmap",
- "sp-core",
- "sp-maybe-compressed-blob",
- "sp-wasm-interface",
+ "sp-core 34.0.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -8777,96 +11032,96 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ab4a91e62a9f7e67cf400931578f2505417cc43a32ac29458163604f2b277b"
+checksum = "6483e6db611d96b14deb298bcf877c44905ba2b45207183d62d0fda9c2fcfec2"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives",
- "sp-keystore",
+ "polkadot-primitives 14.0.0",
+ "sp-keystore 0.40.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "8.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003981d3b63e4f527ef7f03cbe280e41ec649d9be365668887f0b107610640f4"
+checksum = "d0eca24abc74c0c3f02f9986edbda12b3e8b6d294c39b238cf39e94e246aa2b9"
 dependencies = [
- "cfg-if",
  "cpu-time",
  "futures",
  "landlock",
  "libc",
- "nix 0.27.1",
+ "nix 0.28.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
  "sc-executor",
  "sc-executor-common",
  "sc-executor-wasmtime",
  "seccompiler",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-externalities",
- "sp-io",
- "sp-tracing",
+ "sp-externalities 0.29.0",
+ "sp-io 37.0.0",
+ "sp-tracing 17.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6ea6a03f297b7387fc59c41c3c32285803971cb27e81d7e9ca696824d6773"
+checksum = "0024b2f4e4a03e4fda348183bbfe5eb51dd6e90b57eabc83596ee4d0079fd0e8"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "schnellru",
- "sp-consensus-babe",
+ "sp-consensus-babe 0.39.0",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d113b48e7b6126964c3a790b101d99e17fd3cb75a92e94d54587ce1340df21"
+checksum = "b671c3407a7e325264af798664ca60c985873c04f54f53cc8f02aa81512fd40a"
 dependencies = [
  "lazy_static",
  "log",
  "mick-jaeger",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sc-network",
- "sp-core",
+ "sc-network-types",
+ "sp-core 34.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef2e2a934f0d0d606fcfc53fc26f4cacd8b9f18fb2118829203fa813af2cdae"
+checksum = "bae429c6a40f782a615d7ec863c4eda83c36bee5f6b542bcf86f754342f97b5a"
 dependencies = [
  "bs58 0.5.1",
  "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "prioritized-metered-channel",
  "sc-cli",
  "sc-service",
@@ -8877,9 +11132,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f9e67b0f25d695947a15b6fe8ee6f8e83f3dfcbca124a13281c0edd0dc4703"
+checksum = "cf88dcc39ac21e12a65c255707b89933ddf3dadfb2c422d9f0fd8ff644229e77"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8891,44 +11146,46 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "rand",
  "sc-authority-discovery",
  "sc-network",
- "strum 0.24.1",
+ "sc-network-types",
+ "sp-runtime 38.0.1",
+ "strum 0.26.3",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "8.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375744eee7a53576387e14856e1c65be8ecef8b449567bb2cff85706266c8912"
+checksum = "779833f70a1563ed042d3c6b831a45c5ea0f80caa8f4ede487f7bee3130168fb"
 dependencies = [
  "bitvec",
  "bounded-vec",
  "futures",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto",
- "sp-consensus-babe",
- "sp-core",
- "sp-keystore",
+ "sp-application-crypto 37.0.0",
+ "sp-consensus-babe 0.39.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "thiserror",
  "zstd 0.12.4",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d6c226cdbcd48ab1e506d8512f0fb01839f9a72eec2fc0cf7771f6d3352171"
+checksum = "6a338e574c2416135b0004ebef226be22db13c44532e2a0f33b67648afb3ca12"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8937,50 +11194,53 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1404525da0ab9d44bac1041449bf0c5576240f9031b305dc41654567e98b6021"
+checksum = "b0df39c7eef657b1e28917529f0b0c2aa5f0b013f4f298cfb3620b54449f0c95"
 dependencies = [
  "async-trait",
  "bitvec",
  "derive_more",
+ "fatality",
  "futures",
  "orchestra",
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "polkadot-statement-table",
  "sc-client-api",
  "sc-network",
+ "sc-network-types",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api",
- "sp-authority-discovery",
+ "sp-api 33.0.0",
+ "sp-authority-discovery 33.0.0",
  "sp-blockchain",
- "sp-consensus-babe",
- "sp-runtime",
+ "sp-consensus-babe 0.39.0",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a7d101f28bf718d15f01a060ed8cf7a7e2d8d5705c494b49ece696cada0adf"
+checksum = "a55a268e05c8c39aeb81b9ad59dfd18a7a711c8f8fa19bf83c75025de25466b7"
 dependencies = [
  "async-trait",
  "derive_more",
  "fatality",
  "futures",
  "futures-channel",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "kvdb",
  "parity-db",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "pin-project",
+ "polkadot-erasure-coding",
  "polkadot-node-jaeger",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
@@ -8988,37 +11248,37 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "prioritized-metered-channel",
  "rand",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
+ "sp-application-crypto 37.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-overseer"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5ed988deffeddf440473586f62efc5dd498f6016e6650881db09dd60b3b24f"
+checksum = "c2456c1b2d176550e91e2e1ddb092390b00e20898e5c4fd9b5978d56ab1bbf24"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "orchestra",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem-types",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sc-client-api",
- "sp-api",
- "sp-core",
+ "sp-api 33.0.0",
+ "sp-core 34.0.0",
  "tikv-jemalloc-ctl",
  "tracing-gum",
 ]
@@ -9032,13 +11292,31 @@ dependencies = [
  "bounded-collections 0.2.0",
  "derive_more",
  "parity-scale-codec",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 8.0.0",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 28.0.0",
+]
+
+[[package]]
+name = "polkadot-parachain-primitives"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61070d0ff28f596890def0e0d03c231860796130b2a43e293106fa86a50c9a9"
+dependencies = [
+ "bounded-collections 0.2.0",
+ "derive_more",
+ "parity-scale-codec",
+ "polkadot-core-primitives 14.0.0",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -9051,34 +11329,62 @@ dependencies = [
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-core-primitives 8.0.0",
+ "polkadot-parachain-primitives 7.0.0",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-authority-discovery",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-api 27.0.1",
+ "sp-application-crypto 31.0.0",
+ "sp-arithmetic 24.0.0",
+ "sp-authority-discovery 27.0.0",
+ "sp-consensus-slots 0.33.0",
+ "sp-core 29.0.0",
+ "sp-inherents 27.0.0",
+ "sp-io 31.0.0",
+ "sp-keystore 0.35.0",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-primitives"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a4879609f4340138930c3c7313256941104a3ff6f7ecb2569d15223da9b35b2"
+dependencies = [
+ "bitvec",
+ "hex-literal",
+ "log",
+ "parity-scale-codec",
+ "polkadot-core-primitives 14.0.0",
+ "polkadot-parachain-primitives 13.0.0",
+ "scale-info",
+ "serde",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-authority-discovery 33.0.0",
+ "sp-consensus-slots 0.39.0",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "polkadot-rpc"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4747cb8faa532e8446b38b74266fd626d6b660fe6b00776dd6c4543cc0457f"
+checksum = "0dc80e33ff0a7155588d7b6cadffbbad7e8e489c2275f6f49ce61cb5cdfedca7"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "mmr-rpc",
  "pallet-transaction-payment-rpc",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus-babe",
@@ -9092,13 +11398,15 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api",
- "sp-block-builder",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-block-builder 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe",
- "sp-keystore",
- "sp-runtime",
+ "sp-consensus-babe 0.39.0",
+ "sp-consensus-beefy 20.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
@@ -9110,48 +11418,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12a70422ca43d30457e2d9502a5e4af35e20fa2ff3f7cd46e0d2997c784f2665"
 dependencies = [
  "bitvec",
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-election-provider-support 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
- "pallet-asset-rate",
- "pallet-authorship",
- "pallet-babe",
- "pallet-balances",
- "pallet-broker",
- "pallet-election-provider-multi-phase",
- "pallet-fast-unstake",
- "pallet-identity",
- "pallet-session",
- "pallet-staking",
- "pallet-staking-reward-fn",
- "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-treasury",
- "pallet-vesting",
+ "pallet-asset-rate 8.0.0",
+ "pallet-authorship 29.0.0",
+ "pallet-babe 29.0.0",
+ "pallet-balances 29.0.2",
+ "pallet-broker 0.7.2",
+ "pallet-election-provider-multi-phase 28.0.0",
+ "pallet-fast-unstake 28.0.0",
+ "pallet-identity 29.0.1",
+ "pallet-session 29.0.0",
+ "pallet-staking 29.0.3",
+ "pallet-staking-reward-fn 20.0.0",
+ "pallet-timestamp 28.0.0",
+ "pallet-transaction-payment 29.0.2",
+ "pallet-treasury 28.0.1",
+ "pallet-vesting 29.0.0",
  "parity-scale-codec",
- "polkadot-primitives",
- "polkadot-runtime-parachains",
+ "polkadot-primitives 8.0.1",
+ "polkadot-runtime-parachains 8.0.3",
  "rustc-hex",
  "scale-info",
  "serde",
  "serde_derive",
- "slot-range-helper",
- "sp-api",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-npos-elections",
- "sp-runtime",
- "sp-session",
- "sp-staking",
+ "slot-range-helper 8.0.0",
+ "sp-api 27.0.1",
+ "sp-core 29.0.0",
+ "sp-inherents 27.0.0",
+ "sp-io 31.0.0",
+ "sp-npos-elections 27.0.0",
+ "sp-runtime 32.0.0",
+ "sp-session 28.0.0",
+ "sp-staking 27.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 8.0.1",
+ "staging-xcm-builder 8.0.3",
+ "staging-xcm-executor 8.0.2",
+ "static_assertions",
+]
+
+[[package]]
+name = "polkadot-runtime-common"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28fdcb41bb21c7b14d0341a9a17364ccc04ad34de05d41e7938cb03acbc11066"
+dependencies = [
+ "bitvec",
+ "frame-benchmarking 36.0.0",
+ "frame-election-provider-support 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "impl-trait-for-tuples",
+ "libsecp256k1",
+ "log",
+ "pallet-asset-rate 15.0.0",
+ "pallet-authorship 36.0.0",
+ "pallet-babe 36.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-broker 0.15.0",
+ "pallet-election-provider-multi-phase 35.0.0",
+ "pallet-fast-unstake 35.0.0",
+ "pallet-identity 36.0.0",
+ "pallet-session 36.0.0",
+ "pallet-staking 36.0.0",
+ "pallet-staking-reward-fn 22.0.0",
+ "pallet-timestamp 35.0.0",
+ "pallet-transaction-payment 36.0.0",
+ "pallet-treasury 35.0.0",
+ "pallet-vesting 36.0.0",
+ "parity-scale-codec",
+ "polkadot-primitives 14.0.0",
+ "polkadot-runtime-parachains 15.0.1",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "serde_derive",
+ "slot-range-helper 14.0.0",
+ "sp-api 33.0.0",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-npos-elections 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-staking 33.0.0",
+ "sp-std",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "staging-xcm-executor 15.0.0",
  "static_assertions",
 ]
 
@@ -9162,11 +11522,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3566c6fd0c21b5dd555309427c984cf506f875ee90f710acea295b478fecbe0"
 dependencies = [
  "bs58 0.5.1",
- "frame-benchmarking",
+ "frame-benchmarking 29.0.0",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 8.0.1",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 16.0.0",
+]
+
+[[package]]
+name = "polkadot-runtime-metrics"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac75b3fea8464e5681b44733ed11cf09e22ff1e956f6703b918b637bd40e7427"
+dependencies = [
+ "bs58 0.5.1",
+ "frame-benchmarking 36.0.0",
+ "parity-scale-codec",
+ "polkadot-primitives 14.0.0",
+ "sp-std",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
@@ -9178,59 +11552,108 @@ dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-authority-discovery",
- "pallet-authorship",
- "pallet-babe",
- "pallet-balances",
- "pallet-broker",
- "pallet-message-queue",
- "pallet-session",
- "pallet-staking",
- "pallet-timestamp",
- "pallet-vesting",
+ "pallet-authority-discovery 29.0.1",
+ "pallet-authorship 29.0.0",
+ "pallet-babe 29.0.0",
+ "pallet-balances 29.0.2",
+ "pallet-broker 0.7.2",
+ "pallet-message-queue 32.0.0",
+ "pallet-session 29.0.0",
+ "pallet-staking 29.0.3",
+ "pallet-timestamp 28.0.0",
+ "pallet-vesting 29.0.0",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
- "polkadot-runtime-metrics",
+ "polkadot-core-primitives 8.0.0",
+ "polkadot-parachain-primitives 7.0.0",
+ "polkadot-primitives 8.0.1",
+ "polkadot-runtime-metrics 8.0.0",
  "rand",
  "rand_chacha 0.3.1",
  "rustc-hex",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-session",
- "sp-staking",
+ "sp-api 27.0.1",
+ "sp-application-crypto 31.0.0",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-inherents 27.0.0",
+ "sp-io 31.0.0",
+ "sp-keystore 0.35.0",
+ "sp-runtime 32.0.0",
+ "sp-session 28.0.0",
+ "sp-staking 27.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm 8.0.1",
+ "staging-xcm-executor 8.0.2",
+ "static_assertions",
+]
+
+[[package]]
+name = "polkadot-runtime-parachains"
+version = "15.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df740bff0b29ba4cd8c8874d7f8fb90e5722c24a7354d2e96d15e7121c1525e"
+dependencies = [
+ "bitflags 1.3.2",
+ "bitvec",
+ "derive_more",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-authority-discovery 36.0.0",
+ "pallet-authorship 36.0.0",
+ "pallet-babe 36.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-broker 0.15.0",
+ "pallet-message-queue 39.0.0",
+ "pallet-session 36.0.0",
+ "pallet-staking 36.0.0",
+ "pallet-timestamp 35.0.0",
+ "pallet-vesting 36.0.0",
+ "parity-scale-codec",
+ "polkadot-core-primitives 14.0.0",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
+ "polkadot-runtime-metrics 15.0.0",
+ "rand",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "serde",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-staking 33.0.0",
+ "sp-std",
+ "staging-xcm 14.1.0",
+ "staging-xcm-executor 15.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "polkadot-service"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fd665185877bec296588c7cf1ec0ef75e0545050b5e1d42d94240a284149da"
+checksum = "fa560fb67981865b895082845c4ec43fabb206da5bf583ec5ef3561a8e3fc333"
 dependencies = [
  "async-trait",
- "frame-benchmarking",
+ "frame-benchmarking 36.0.0",
  "frame-benchmarking-cli",
- "frame-support",
- "frame-system",
- "frame-system-rpc-runtime-api",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "frame-system-rpc-runtime-api 33.0.0",
  "futures",
  "hex-literal",
  "is_executable",
@@ -9238,20 +11661,19 @@ dependencies = [
  "kvdb-rocksdb",
  "log",
  "mmr-gadget",
- "pallet-babe",
- "pallet-im-online",
- "pallet-staking",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-babe 36.0.0",
+ "pallet-staking 36.0.0",
+ "pallet-transaction-payment 36.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 36.0.0",
  "parity-db",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "polkadot-approval-distribution",
  "polkadot-availability-bitfield-distribution",
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 14.0.0",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
@@ -9276,10 +11698,10 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
  "polkadot-rpc",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 15.0.1",
  "polkadot-statement-distribution",
  "rococo-runtime",
  "sc-authority-discovery",
@@ -9308,40 +11730,42 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
- "sp-authority-discovery",
- "sp-block-builder",
+ "sp-api 33.0.0",
+ "sp-authority-discovery 33.0.0",
+ "sp-block-builder 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe",
- "sp-consensus-beefy",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keyring",
- "sp-keystore",
- "sp-mmr-primitives",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-state-machine",
- "sp-storage",
- "sp-timestamp",
- "sp-transaction-pool",
- "sp-version",
- "sp-weights",
+ "sp-consensus-babe 0.39.0",
+ "sp-consensus-beefy 20.0.0",
+ "sp-consensus-grandpa 20.0.0",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-keyring 38.0.0",
+ "sp-keystore 0.40.0",
+ "sp-mmr-primitives 33.0.0",
+ "sp-offchain 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-state-machine 0.42.0",
+ "sp-storage 21.0.0",
+ "sp-timestamp 33.0.0",
+ "sp-transaction-pool 33.0.0",
+ "sp-version 36.0.0",
+ "sp-weights 31.0.0",
+ "staging-xcm 14.1.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tracing-gum",
  "westend-runtime",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff6d16cbd994987f48a9f107f12e4c7fff26cdd71df6288e9521adc7cff3427"
+checksum = "16020ecadd1826ffbce2693ba1490123a0f7ca74d233c9bc8c0cbfc23bb4df2a"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -9354,52 +11778,107 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
- "sp-keystore",
- "sp-staking",
+ "polkadot-primitives 14.0.0",
+ "sp-keystore 0.40.0",
+ "sp-staking 33.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-statement-table"
-version = "8.0.1"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e010da3c6a65d8f263d0f825a04d995ffc8a37f886f674fcbbc73bf158d01"
+checksum = "947e9e3c8f71b9678f39a01f371a808b574823967dd9da187e6f886f5f08691c"
 dependencies = [
  "parity-scale-codec",
- "polkadot-primitives",
- "sp-core",
+ "polkadot-primitives 14.0.0",
+ "sp-core 34.0.0",
  "tracing-gum",
 ]
 
 [[package]]
-name = "polkavm-common"
-version = "0.5.0"
+name = "polkavm"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b4e215c80fe876147f3d58158d5dfeae7dabdd6047e175af77095b78d0035c"
+checksum = "8a3693e5efdb2bf74e449cd25fd777a28bd7ed87e41f5d5da75eb31b4de48b94"
+dependencies = [
+ "libc",
+ "log",
+ "polkavm-assembler",
+ "polkavm-common",
+ "polkavm-linux-raw",
+]
+
+[[package]]
+name = "polkavm-assembler"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa96d6d868243acc12de813dd48e756cbadcc8e13964c70d272753266deadc1"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "polkavm-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "polkavm-derive"
-version = "0.5.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6380dbe1fb03ecc74ad55d841cfc75480222d153ba69ddcb00977866cbdabdb8"
+checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
 dependencies = [
- "polkavm-derive-impl",
- "syn 2.0.55",
+ "polkavm-derive-impl-macro",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.5.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8211b3365bbafb2fb32057d68b0e1ca55d079f5cf6f9da9b98079b94b3987d"
+checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
 dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
  "syn 2.0.55",
 ]
+
+[[package]]
+name = "polkavm-derive-impl-macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
+dependencies = [
+ "polkavm-derive-impl",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "polkavm-linker"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7be503e60cf56c0eb785f90aaba4b583b36bff00e93997d93fef97f9553c39"
+dependencies = [
+ "gimli 0.28.1",
+ "hashbrown 0.14.3",
+ "log",
+ "object 0.32.2",
+ "polkavm-common",
+ "regalloc2 0.9.3",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "polkavm-linux-raw"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26e85d3456948e650dff0cfc85603915847faf893ed1e66b020bb82ef4557120"
 
 [[package]]
 name = "polling"
@@ -9413,7 +11892,7 @@ dependencies = [
  "concurrent-queue",
  "libc",
  "log",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
  "windows-sys 0.48.0",
 ]
 
@@ -9426,7 +11905,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
  "rustix 0.38.32",
  "tracing",
  "windows-sys 0.52.0",
@@ -9467,19 +11946,19 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-consensus-proposer",
  "cumulus-client-service",
- "cumulus-primitives-aura",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-aura 0.14.0",
+ "cumulus-primitives-core 0.14.0",
+ "cumulus-primitives-parachain-inherent 0.14.0",
  "cumulus-relay-chain-interface",
- "frame-benchmarking",
+ "frame-benchmarking 36.0.0",
  "frame-benchmarking-cli",
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.20.3",
  "log",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
  "polkadot-cli",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "pop-runtime-common",
  "pop-runtime-devnet",
  "pop-runtime-testnet",
@@ -9501,19 +11980,19 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api",
- "sp-block-builder",
+ "sp-api 33.0.0",
+ "sp-block-builder 33.0.0",
  "sp-blockchain",
- "sp-consensus-aura",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-timestamp",
- "sp-transaction-pool",
- "staging-xcm",
+ "sp-consensus-aura 0.39.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-keystore 0.40.0",
+ "sp-offchain 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-timestamp 33.0.0",
+ "sp-transaction-pool 33.0.0",
+ "staging-xcm 14.1.0",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -9532,12 +12011,12 @@ dependencies = [
 name = "pop-runtime-common"
 version = "0.0.0"
 dependencies = [
- "frame-support",
- "parachains-common",
+ "frame-support 36.0.1",
+ "parachains-common 15.0.0",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -9545,146 +12024,146 @@ dependencies = [
 name = "pop-runtime-devnet"
 version = "0.1.0"
 dependencies = [
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-aura",
- "cumulus-primitives-core",
- "cumulus-primitives-utility",
+ "cumulus-pallet-aura-ext 0.15.0",
+ "cumulus-pallet-parachain-system 0.15.0",
+ "cumulus-pallet-session-benchmarking 17.0.0",
+ "cumulus-pallet-xcm 0.15.0",
+ "cumulus-pallet-xcmp-queue 0.15.0",
+ "cumulus-primitives-aura 0.14.0",
+ "cumulus-primitives-core 0.14.0",
+ "cumulus-primitives-utility 0.15.0",
  "enumflags2",
  "env_logger 0.11.3",
- "frame-benchmarking",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
+ "frame-benchmarking 36.0.0",
+ "frame-executive 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "frame-system-benchmarking 36.0.0",
+ "frame-system-rpc-runtime-api 33.0.0",
+ "frame-try-runtime 0.42.0",
  "hex",
  "hex-literal",
  "log",
- "pallet-assets",
- "pallet-aura",
- "pallet-authorship",
- "pallet-balances",
- "pallet-collator-selection",
+ "pallet-assets 37.0.0",
+ "pallet-aura 35.0.0",
+ "pallet-authorship 36.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-collator-selection 17.0.0",
  "pallet-contracts",
- "pallet-message-queue",
- "pallet-multisig",
+ "pallet-message-queue 39.0.0",
+ "pallet-multisig 36.0.0",
  "pallet-nft-fractionalization",
- "pallet-nfts",
- "pallet-nfts-runtime-api",
- "pallet-preimage",
- "pallet-proxy",
- "pallet-scheduler",
- "pallet-session",
- "pallet-sudo",
- "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-utility",
- "pallet-xcm",
- "parachains-common",
+ "pallet-nfts 30.0.0",
+ "pallet-nfts-runtime-api 22.0.0",
+ "pallet-preimage 36.0.0",
+ "pallet-proxy 36.0.0",
+ "pallet-scheduler 37.0.0",
+ "pallet-session 36.0.0",
+ "pallet-sudo 36.0.0",
+ "pallet-timestamp 35.0.0",
+ "pallet-transaction-payment 36.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 36.0.0",
+ "pallet-utility 36.0.0",
+ "pallet-xcm 15.0.0",
+ "parachains-common 15.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-runtime-common",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-runtime-common 15.0.0",
  "pop-primitives",
  "pop-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
+ "sp-api 33.0.0",
+ "sp-block-builder 33.0.0",
+ "sp-consensus-aura 0.39.0",
+ "sp-core 34.0.0",
+ "sp-genesis-builder 0.14.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-offchain 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
  "sp-std",
- "sp-transaction-pool",
- "sp-version",
- "staging-parachain-info",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
- "substrate-wasm-builder",
+ "sp-transaction-pool 33.0.0",
+ "sp-version 36.0.0",
+ "staging-parachain-info 0.15.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "staging-xcm-executor 15.0.0",
+ "substrate-wasm-builder 23.0.0",
 ]
 
 [[package]]
 name = "pop-runtime-testnet"
 version = "0.2.0"
 dependencies = [
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-aura",
- "cumulus-primitives-core",
- "cumulus-primitives-utility",
+ "cumulus-pallet-aura-ext 0.15.0",
+ "cumulus-pallet-parachain-system 0.15.0",
+ "cumulus-pallet-session-benchmarking 17.0.0",
+ "cumulus-pallet-xcm 0.15.0",
+ "cumulus-pallet-xcmp-queue 0.15.0",
+ "cumulus-primitives-aura 0.14.0",
+ "cumulus-primitives-core 0.14.0",
+ "cumulus-primitives-utility 0.15.0",
  "enumflags2",
  "env_logger 0.11.3",
- "frame-benchmarking",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
+ "frame-benchmarking 36.0.0",
+ "frame-executive 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "frame-system-benchmarking 36.0.0",
+ "frame-system-rpc-runtime-api 33.0.0",
+ "frame-try-runtime 0.42.0",
  "hex",
  "hex-literal",
  "log",
- "pallet-assets",
- "pallet-aura",
- "pallet-authorship",
- "pallet-balances",
- "pallet-collator-selection",
+ "pallet-assets 37.0.0",
+ "pallet-aura 35.0.0",
+ "pallet-authorship 36.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-collator-selection 17.0.0",
  "pallet-contracts",
- "pallet-message-queue",
- "pallet-multisig",
+ "pallet-message-queue 39.0.0",
+ "pallet-multisig 36.0.0",
  "pallet-nft-fractionalization",
- "pallet-nfts",
- "pallet-nfts-runtime-api",
- "pallet-preimage",
- "pallet-proxy",
- "pallet-scheduler",
- "pallet-session",
- "pallet-sudo",
- "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-utility",
- "pallet-xcm",
- "parachains-common",
+ "pallet-nfts 30.0.0",
+ "pallet-nfts-runtime-api 22.0.0",
+ "pallet-preimage 36.0.0",
+ "pallet-proxy 36.0.0",
+ "pallet-scheduler 37.0.0",
+ "pallet-session 36.0.0",
+ "pallet-sudo 36.0.0",
+ "pallet-timestamp 35.0.0",
+ "pallet-transaction-payment 36.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 36.0.0",
+ "pallet-utility 36.0.0",
+ "pallet-xcm 15.0.0",
+ "parachains-common 15.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-runtime-common",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-runtime-common 15.0.0",
  "pop-primitives",
  "pop-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
+ "sp-api 33.0.0",
+ "sp-block-builder 33.0.0",
+ "sp-consensus-aura 0.39.0",
+ "sp-core 34.0.0",
+ "sp-genesis-builder 0.14.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-offchain 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
  "sp-std",
- "sp-transaction-pool",
- "sp-version",
- "staging-parachain-info",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
- "substrate-wasm-builder",
+ "sp-transaction-pool 33.0.0",
+ "sp-version 36.0.0",
+ "staging-parachain-info 0.15.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "staging-xcm-executor 15.0.0",
+ "substrate-wasm-builder 23.0.0",
 ]
 
 [[package]]
@@ -9717,6 +12196,16 @@ dependencies = [
  "normalize-line-endings",
  "predicates-core",
  "regex",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "predicates-core",
 ]
 
 [[package]]
@@ -9841,6 +12330,17 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-warning"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "proc-macro-warning"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
@@ -9869,19 +12369,19 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "thiserror",
 ]
 
 [[package]]
 name = "prometheus-client"
-version = "0.19.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
+checksum = "3c99afa9a01501019ac3a14d71d9f94050346f55ca471ce90c799a15c58f61e2"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "prometheus-client-derive-encode",
 ]
 
@@ -9908,12 +12408,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
+ "prost-derive 0.12.6",
 ]
 
 [[package]]
@@ -9931,11 +12431,32 @@ dependencies = [
  "petgraph",
  "prettyplease 0.1.11",
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
  "regex",
  "syn 1.0.109",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+dependencies = [
+ "bytes",
+ "heck 0.5.0",
+ "itertools 0.11.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease 0.2.17",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "regex",
+ "syn 2.0.55",
+ "tempfile",
 ]
 
 [[package]]
@@ -9953,9 +12474,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -9974,12 +12495,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost 0.12.6",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -9999,26 +12544,51 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1693116345026436eb2f10b677806169c1a1260c1c60eaaffe3fb5a29ae23d8b"
+checksum = "f8ededb1cd78531627244d51dd0c7139fbe736c7d57af0092a76f0ffb2f56e98"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
-name = "quicksink"
-version = "0.1.2"
+name = "quinn"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77de3c815e5a160b1539c6592796801df2043ae35e123b46d73380cfa57af858"
+checksum = "2e8b432585672228923edbbf64b8b12c14e1112f62e88737655b4a083dbcd78e"
 dependencies = [
- "futures-core",
- "futures-sink",
- "pin-project-lite 0.1.12",
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto 0.9.6",
+ "quinn-udp 0.3.2",
+ "rustc-hash",
+ "rustls 0.20.9",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki",
+]
+
+[[package]]
+name = "quinn"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
+dependencies = [
+ "bytes",
+ "futures-io",
+ "pin-project-lite",
+ "quinn-proto 0.10.6",
+ "quinn-udp 0.4.1",
+ "rustc-hash",
+ "rustls 0.21.10",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -10037,6 +12607,49 @@ dependencies = [
  "tinyvec",
  "tracing",
  "webpki",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring 0.16.20",
+ "rustc-hash",
+ "rustls 0.21.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
+dependencies = [
+ "libc",
+ "quinn-proto 0.9.6",
+ "socket2 0.4.10",
+ "tracing",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
+dependencies = [
+ "bytes",
+ "libc",
+ "socket2 0.5.7",
+ "tracing",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10090,9 +12703,6 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -10100,7 +12710,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
 ]
 
 [[package]]
@@ -10120,6 +12730,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -10184,7 +12803,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
  "libredox",
  "thiserror",
 ]
@@ -10229,6 +12848,19 @@ checksum = "80535183cae11b149d618fbd3c37e38d7cda589d82d7769e196ca9a9042d7621"
 dependencies = [
  "fxhash",
  "log",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+dependencies = [
+ "hashbrown 0.13.2",
+ "log",
+ "rustc-hash",
  "slice-group-by",
  "smallvec",
 ]
@@ -10320,20 +12952,11 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "ripemd"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -10358,117 +12981,121 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "8.0.1"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa4cc054efdd3bfbec965da01b1ae16475031308c109c173347717091f6e3a5"
+checksum = "0874c053846cd50170370d88244fd00ed299d3d3833804f0929371a9ed836137"
 dependencies = [
- "binary-merkle-tree",
- "frame-benchmarking",
- "frame-executive",
- "frame-metadata-hash-extension",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
+ "binary-merkle-tree 15.0.0",
+ "bitvec",
+ "frame-benchmarking 36.0.0",
+ "frame-executive 36.0.0",
+ "frame-metadata-hash-extension 0.4.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "frame-system-benchmarking 36.0.0",
+ "frame-system-rpc-runtime-api 33.0.0",
+ "frame-try-runtime 0.42.0",
  "hex-literal",
  "log",
- "pallet-asset-rate",
- "pallet-authority-discovery",
- "pallet-authorship",
- "pallet-babe",
- "pallet-balances",
- "pallet-beefy",
- "pallet-beefy-mmr",
- "pallet-bounties",
- "pallet-child-bounties",
+ "pallet-asset-rate 15.0.0",
+ "pallet-authority-discovery 36.0.0",
+ "pallet-authorship 36.0.0",
+ "pallet-babe 36.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-beefy 36.0.0",
+ "pallet-beefy-mmr 36.0.0",
+ "pallet-bounties 35.0.0",
+ "pallet-child-bounties 35.0.0",
  "pallet-collective",
- "pallet-conviction-voting",
+ "pallet-conviction-voting 36.0.0",
  "pallet-democracy",
  "pallet-elections-phragmen",
- "pallet-grandpa",
- "pallet-identity",
- "pallet-im-online",
- "pallet-indices",
+ "pallet-grandpa 36.0.0",
+ "pallet-identity 36.0.0",
+ "pallet-indices 36.0.0",
  "pallet-membership",
- "pallet-message-queue",
- "pallet-mmr",
- "pallet-multisig",
+ "pallet-message-queue 39.0.0",
+ "pallet-mmr 35.0.0",
+ "pallet-multisig 36.0.0",
  "pallet-nis",
- "pallet-offences",
- "pallet-preimage",
- "pallet-proxy",
+ "pallet-offences 35.0.0",
+ "pallet-parameters",
+ "pallet-preimage 36.0.0",
+ "pallet-proxy 36.0.0",
  "pallet-ranked-collective",
  "pallet-recovery",
- "pallet-referenda",
+ "pallet-referenda 36.0.0",
  "pallet-root-testing",
- "pallet-scheduler",
- "pallet-session",
+ "pallet-scheduler 37.0.0",
+ "pallet-session 36.0.0",
  "pallet-society",
- "pallet-staking",
- "pallet-state-trie-migration",
- "pallet-sudo",
- "pallet-timestamp",
+ "pallet-staking 36.0.0",
+ "pallet-state-trie-migration 37.0.0",
+ "pallet-sudo 36.0.0",
+ "pallet-timestamp 35.0.0",
  "pallet-tips",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-treasury",
- "pallet-utility",
- "pallet-vesting",
- "pallet-whitelist",
- "pallet-xcm",
- "pallet-xcm-benchmarks",
+ "pallet-transaction-payment 36.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 36.0.0",
+ "pallet-treasury 35.0.0",
+ "pallet-utility 36.0.0",
+ "pallet-vesting 36.0.0",
+ "pallet-whitelist 35.0.0",
+ "pallet-xcm 15.0.0",
+ "pallet-xcm-benchmarks 15.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
+ "polkadot-runtime-common 15.0.0",
+ "polkadot-runtime-parachains 15.0.1",
  "rococo-runtime-constants",
  "scale-info",
  "serde",
  "serde_derive",
+ "serde_json",
  "smallvec",
- "sp-api",
- "sp-arithmetic",
- "sp-authority-discovery",
- "sp-block-builder",
- "sp-consensus-babe",
- "sp-consensus-beefy",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-mmr-primitives",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-staking",
+ "sp-api 33.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-authority-discovery 33.0.0",
+ "sp-block-builder 33.0.0",
+ "sp-consensus-babe 0.39.0",
+ "sp-consensus-beefy 20.0.0",
+ "sp-consensus-grandpa 20.0.0",
+ "sp-core 34.0.0",
+ "sp-genesis-builder 0.14.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-mmr-primitives 33.0.0",
+ "sp-offchain 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-staking 33.0.0",
  "sp-std",
- "sp-storage",
- "sp-transaction-pool",
- "sp-version",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "sp-storage 21.0.0",
+ "sp-transaction-pool 33.0.0",
+ "sp-version 36.0.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "staging-xcm-executor 15.0.0",
  "static_assertions",
- "substrate-wasm-builder",
+ "substrate-wasm-builder 23.0.0",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b45c21ccb0f8777512a65510c106aeee4b59682944b9a5cb31cd7b8ed4ccb47"
+checksum = "2ef330dc0657ac9e4ff93ff320e2ee1a120493bceb91010c7ef7b08fe8e27950"
 dependencies = [
- "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "frame-support 36.0.1",
+ "polkadot-primitives 14.0.0",
+ "polkadot-runtime-common 15.0.0",
  "smallvec",
- "sp-core",
- "sp-runtime",
- "sp-weights",
- "staging-xcm",
- "staging-xcm-builder",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "sp-weights 31.0.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
 ]
 
 [[package]]
@@ -10583,7 +13210,7 @@ version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.13",
@@ -10596,7 +13223,6 @@ version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
- "log",
  "ring 0.16.20",
  "sct",
  "webpki",
@@ -10610,8 +13236,23 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.6",
+ "subtle 2.5.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -10621,7 +13262,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -10636,12 +13290,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93bda3f493b9abe5b93b3e7e3ecde0df292f2bd28c0296b90586ee0055ff5123"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.12",
+ "rustls-native-certs 0.7.1",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.102.6",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-roots 0.26.3",
+ "winapi",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -10664,9 +13372,9 @@ dependencies = [
 
 [[package]]
 name = "rw-stream-sink"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
 dependencies = [
  "futures",
  "pin-project",
@@ -10699,51 +13407,52 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "24.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357127c91373ed6d1ae582f6e3300ab5b13bcde43bbf270a891f44194ef48b70"
+checksum = "b975ee3a95eaacb611e7b415737a7fa2db4d8ad7b880cc1b97371b04e95c7903"
 dependencies = [
  "log",
- "sp-core",
- "sp-wasm-interface",
+ "sp-core 34.0.0",
+ "sp-wasm-interface 21.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.35.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb3c14cb8022844835a6f7209196b8c6544d389fe5d2972d8df2ae4ca75afbe"
+checksum = "7ae99d03b5cf657754241180c4aedd14c4851a08f3fa56814106b3cc02083d2c"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "ip_network",
  "libp2p",
+ "linked_hash_set",
  "log",
- "multihash 0.18.1",
- "multihash-codetable",
+ "multihash 0.19.1",
  "parity-scale-codec",
- "prost 0.12.3",
- "prost-build",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
  "rand",
  "sc-client-api",
  "sc-network",
- "sp-api",
- "sp-authority-discovery",
+ "sc-network-types",
+ "sp-api 33.0.0",
+ "sp-authority-discovery 33.0.0",
  "sp-blockchain",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.35.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724c3a6eee5f0829a1b79a15e12d63ed81b33281b14004a6331a8883b2fd8fd1"
+checksum = "5c31a124aa02343a17cb86cc714bc2b66ce18c7f17530178767388de8a37b152"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10753,38 +13462,38 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-block-builder"
-version = "0.34.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8b0640994965c6ff3afa13242d95a61611b83da21fd86ac2b1ebd03e241a02"
+checksum = "d6345fb862e10aaa7d88d6689a7c247448c40ae465253c83566dc76a17ec1426"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-block-builder",
+ "sp-api 33.0.0",
+ "sp-block-builder 33.0.0",
  "sp-blockchain",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-trie 36.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "28.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f73880050f8b04fed7f6301279ef3899df13a3891bd06156d56f9a1c50fefba"
+checksum = "e04100ec7ff9cf1f2052b05086c77cc216ff7268b8c4fe41007de420bc1f70be"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "docify",
  "log",
  "memmap2 0.9.4",
@@ -10797,19 +13506,20 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-genesis-builder",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-genesis-builder 0.14.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e80fbdaea194762d4b4b0eec389037c25ad102676203b42d684774ae3019b8"
+checksum = "b18cef11d2c69703e0d7c3528202ef4ed1cd2b47a6f063e9e17cad8255b1fa94"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -10819,20 +13529,20 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.37.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a284c10ea92b1fe789b9f0e5815d393f3a1e3bf6a4adaa884f24e36143b83b"
+checksum = "23a50b5a5de473b38de8a909b125b9747a30158900159e59251bb716f80d6d22"
 dependencies = [
- "array-bytes 6.2.2",
- "bip39",
+ "array-bytes",
  "chrono",
  "clap",
  "fdlimit",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "libp2p-identity",
  "log",
  "names",
+ "parity-bip39",
  "parity-scale-codec",
  "rand",
  "regex",
@@ -10849,49 +13559,49 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core",
- "sp-keyring",
- "sp-keystore",
+ "sp-core 34.0.0",
+ "sp-keyring 38.0.0",
+ "sp-keystore 0.40.0",
  "sp-panic-handler",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 38.0.1",
+ "sp-version 36.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "sc-client-api"
-version = "29.0.0"
+version = "35.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e914dfadaaf384d8869ae47f3ec783bf6a1ac24e7827f5fec2e0e649a450a91"
+checksum = "1bb517f4418644aeefd7c29bbe34bfc56ba8b5ea56e0b661a48a4d4d6afef40b"
 dependencies = [
  "fnv",
  "futures",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-database",
- "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sp-externalities 0.29.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
  "sp-statement-store",
- "sp-storage",
- "sp-trie",
+ "sp-storage 21.0.0",
+ "sp-trie 36.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.36.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f08c4f29e6d2b8915bab6435b8817fa39ef7708c04a7cf6226f803e133b017c"
+checksum = "2e3c685871877f39df000ec446f65fc8d502a7cecfc437cdac59866349642dc3"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10901,50 +13611,49 @@ dependencies = [
  "log",
  "parity-db",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "sc-client-api",
  "sc-state-db",
  "schnellru",
- "sp-arithmetic",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
+ "sp-trie 36.0.0",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e1ac2c698b828073982b6f5b1a466fcc345a452983356af74254ade8e9987d"
+checksum = "2b2927954d83d4c055a8699cad8ae093fc921ce73694da6773bd06d195e9a8dd"
 dependencies = [
  "async-trait",
  "futures",
- "futures-timer",
- "libp2p-identity",
  "log",
- "mockall",
- "parking_lot 0.12.1",
+ "mockall 0.11.4",
+ "parking_lot 0.12.3",
  "sc-client-api",
+ "sc-network-types",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.35.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16fd09794291795ad43ea1df7190083f9a47fc0a73e9b8ec0ae98fbe53a2b34"
+checksum = "017320849a7fce8200da88ccf07785d461c4d144032788f09eb4316742649a38"
 dependencies = [
  "async-trait",
  "futures",
@@ -10955,26 +13664,26 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-block-builder 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
+ "sp-consensus-aura 0.39.0",
+ "sp-consensus-slots 0.39.0",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.35.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ec3dc31f8fd024684d1306488836680558b680a8ec38219e19f20854811f02"
+checksum = "91c28b231f19a90917fde889a5077a796e2f9cb4dc6b62f861a8d859437a54cc"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10984,83 +13693,83 @@ dependencies = [
  "num-rational",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-epochs",
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-block-builder 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe",
- "sp-consensus-slots",
- "sp-core",
+ "sp-consensus-babe 0.39.0",
+ "sp-consensus-slots 0.39.0",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
+ "sp-inherents 33.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.35.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf2b3004672f9eea0d9af6c9b944fa3ef0bc72fd88cea9075cdf6dc96d1439ac"
+checksum = "879efb0d8d0bd363d38ca314fbe4c44363dc1bdcab0ba1c21e78d9a68fd4398b"
 dependencies = [
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-consensus-babe 0.39.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "14.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ce3ee15eff7fa642791966d427f185184df3c7f4e58893705f3e7781da8ef5"
+checksum = "5ddcd779375dc2aa4abfb2ff8e001d0901593b58e5c70e1720472a001fe13105"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "fnv",
  "futures",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
  "sc-network-gossip",
  "sc-network-sync",
+ "sc-network-types",
  "sc-utils",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-beefy",
- "sp-core",
+ "sp-consensus-beefy 20.0.0",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-keystore",
- "sp-mmr-primitives",
- "sp-runtime",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11069,46 +13778,47 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "14.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1ed5e8ac2cb53c6a248c8f469353f55bd23c72f23fe371ac19c1d46618de1a"
+checksum = "54e88abb3353e3ed98bcb8ab829dc84dfdf9d17f5312568bdf2361a1bde7ce0a"
 dependencies = [
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "sc-consensus-beefy",
  "sc-rpc",
  "serde",
- "sp-consensus-beefy",
- "sp-core",
- "sp-runtime",
+ "sp-application-crypto 37.0.0",
+ "sp-consensus-beefy 20.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f68ddb91626f901578515eed93c7919f739660161f4e9f7b9407e2d0ede981"
+checksum = "8c983798bfea80e629ffa4faa7c299f8522d382703cd32f7a299beaf69631586"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.20.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae91e5b5a120be4d13a59eaf94fd85d7c7af528482b8e21d861fa1167df3083"
+checksum = "c7c6c62a03b54973f1a608a405908af0fe957fefaf77483cce96bd213eee7ed0"
 dependencies = [
  "ahash 0.8.11",
- "array-bytes 6.2.2",
+ "array-bytes",
  "async-trait",
  "dyn-clone",
  "finality-grandpa",
@@ -11117,7 +13827,7 @@ dependencies = [
  "futures-timer",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "rand",
  "sc-block-builder",
  "sc-chain-spec",
@@ -11127,33 +13837,34 @@ dependencies = [
  "sc-network-common",
  "sc-network-gossip",
  "sc-network-sync",
+ "sc-network-types",
  "sc-telemetry",
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-grandpa",
- "sp-core",
+ "sp-consensus-grandpa 20.0.0",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-keystore",
- "sp-runtime",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.20.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697cbd528516561dbc818a8990d5477169e86d9335a0b29207cf6f6a90269e7c"
+checksum = "9ef329f23bdafaeb57e131b81cc479a85b6ecb25e42435b6a6a544d048207685"
 dependencies = [
  "finality-grandpa",
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -11161,16 +13872,16 @@ dependencies = [
  "sc-rpc",
  "serde",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567bddd65d52951fb9bc7a7e05d1dfdfc47ff2c594ec5ca9756d27e7226635bb"
+checksum = "4dca112d43c7785193362b33aa7941947bb84d65db9187abe72f1f7a969474c0"
 dependencies = [
  "async-trait",
  "futures",
@@ -11180,76 +13891,90 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-telemetry",
- "sp-arithmetic",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-consensus-slots 0.39.0",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2ac6c356538d67987bbb867e11a12a84ba87250c70fd50005b6d74f570a4f7"
+checksum = "39f5767bf6a6bad29365d6d08fcf940ee453d31457ed034cf14f0392877daafd"
 dependencies = [
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "sc-executor-common",
+ "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api",
- "sp-core",
- "sp-externalities",
- "sp-io",
+ "sp-api 33.0.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-io 37.0.0",
  "sp-panic-handler",
- "sp-runtime-interface",
- "sp-trie",
- "sp-version",
- "sp-wasm-interface",
+ "sp-runtime-interface 28.0.0",
+ "sp-trie 36.0.0",
+ "sp-version 36.0.0",
+ "sp-wasm-interface 21.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
-version = "0.30.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07498138dee3ddf2c71299ca372d8449880bb3a8a8a299a483094e9c26b0823e"
+checksum = "0c3b703a33dcb7cddf19176fdf12294b9a6408125836b0f4afee3e6969e7f190"
 dependencies = [
+ "polkavm",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface",
+ "sp-wasm-interface 21.0.0",
  "thiserror",
  "wasm-instrument",
 ]
 
 [[package]]
-name = "sc-executor-wasmtime"
-version = "0.30.0"
+name = "sc-executor-polkavm"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a387779ab54ec1ffce0bf3a6631faada079459d42796c1895683767918a642"
+checksum = "26fe58d9cacfab73e5595fa84b80f7bd03efebe54a0574daaeb221a1d1f7ab80"
+dependencies = [
+ "log",
+ "polkavm",
+ "sc-executor-common",
+ "sp-wasm-interface 21.0.0",
+]
+
+[[package]]
+name = "sc-executor-wasmtime"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd498f2f77ec1f861c30804f5bfd796d4afcc8ce44ea1f11bfbe2847551d161"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface",
- "sp-wasm-interface",
+ "sp-runtime-interface 28.0.0",
+ "sp-wasm-interface 21.0.0",
  "wasmtime",
 ]
 
 [[package]]
 name = "sc-informant"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb603a0a703f1bc10a4e6462bec1036d8fb8b3e3eff5513a9c07f98ccb8d662d"
+checksum = "74c3751acd690bc469b859d0ad899b076642db9b107e31c28cbd99749b6ecb91"
 dependencies = [
  "ansi_term",
  "futures",
@@ -11260,65 +13985,66 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
 name = "sc-keystore"
-version = "26.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc4f6a558dd23e3bae2e9f195da822465258b9aaf211c34360d7f6efb944e54"
+checksum = "267c8cfaceaeecb25484bad8668c17036016e46053a23509d44486474dbf44d3"
 dependencies = [
- "array-bytes 6.2.2",
- "parking_lot 0.12.1",
+ "array-bytes",
+ "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
+ "sp-application-crypto 37.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-mixnet"
-version = "0.5.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fb213c15679fe5b87c383815d7fb758c70d3e7c573948bd7fe26ff344d2272"
+checksum = "a5a72a92dc72572a0facd73b410855d7f6edf38b32aef46c4798c74f25e595d5"
 dependencies = [
- "array-bytes 4.2.0",
+ "array-bytes",
  "arrayvec 0.7.4",
  "blake2 0.10.6",
  "bytes",
  "futures",
  "futures-timer",
- "libp2p-identity",
  "log",
  "mixnet",
- "multiaddr",
+ "multiaddr 0.18.1",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "sc-client-api",
  "sc-network",
+ "sc-network-types",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-consensus",
- "sp-core",
- "sp-keystore",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "sp-mixnet",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.35.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f231c7d5e749ec428b4cfa669d759ae76cd3da4f50d7352a2d711acdc7532891"
+checksum = "04be75f35cea819bae84be99cde138872b17494acf0e54f5f0ae8b0ed3fbe51a"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "asynchronous-codec",
  "bytes",
+ "cid 0.9.0",
  "either",
  "fnv",
  "futures",
@@ -11326,120 +14052,107 @@ dependencies = [
  "ip_network",
  "libp2p",
  "linked_hash_set",
+ "litep2p",
  "log",
- "mockall",
+ "mockall 0.11.4",
+ "once_cell",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "partial_sort",
  "pin-project",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
  "rand",
  "sc-client-api",
  "sc-network-common",
+ "sc-network-types",
  "sc-utils",
+ "schnellru",
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
  "tokio-stream",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+ "void",
  "wasm-timer",
  "zeroize",
 ]
 
 [[package]]
-name = "sc-network-bitswap"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f89b0134738cb3d982b6e625ca93ae8dbe83ce2a06e4b6a396e4df09ed3499"
-dependencies = [
- "async-channel 1.9.0",
- "cid",
- "futures",
- "libp2p-identity",
- "log",
- "prost 0.12.3",
- "prost-build",
- "sc-client-api",
- "sc-network",
- "sp-blockchain",
- "sp-runtime",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
 name = "sc-network-common"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3504bbff5ab016948dbab0f21a8be26324810b76eff3627ce744adb5bfc1b3ce"
+checksum = "2ec0c3c5629a418fb26b56963d40c5ca3fd02dd94eb5753e9eb72cea5c2eeb2f"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "futures",
  "libp2p-identity",
  "parity-scale-codec",
- "prost-build",
+ "prost-build 0.12.6",
  "sc-consensus",
+ "sc-network-types",
  "sp-consensus",
- "sp-consensus-grandpa",
- "sp-runtime",
+ "sp-consensus-grandpa 20.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.35.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad02cf809c34b53614fa61377e3289064edf6c78eb11df071d11fbf7546d7e9"
+checksum = "0ae1836528495b6aa5140da39ed0278f5086c21ce530c37964db1b2e2c101ab1"
 dependencies = [
  "ahash 0.8.11",
  "futures",
  "futures-timer",
- "libp2p",
  "log",
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
+ "sc-network-types",
  "schnellru",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "sc-network-light"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84ef0b212c775f58e0304ec09166089f6b09afddf559b7c2b5702933b3be4"
+checksum = "f5e6deda277664336c26ea251cc1ebff7a165df0e3ad4ae23113380d9863ea40"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "async-channel 1.9.0",
  "futures",
- "libp2p-identity",
  "log",
  "parity-scale-codec",
- "prost 0.12.3",
- "prost-build",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
  "sc-client-api",
  "sc-network",
+ "sc-network-types",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network-sync"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa9377059deece4e7d419d9ec456f657268c0c603e1cf98df4a920f6da83461"
+checksum = "ee9ab31b84534c487b9fb84e83db47890fcbd350f354b1e6484892d3d42d0020"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "fork-tree",
@@ -11447,23 +14160,24 @@ dependencies = [
  "futures-timer",
  "libp2p",
  "log",
- "mockall",
+ "mockall 0.11.4",
  "parity-scale-codec",
- "prost 0.12.3",
- "prost-build",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
  "sc-network-common",
+ "sc-network-types",
  "sc-utils",
  "schnellru",
  "smallvec",
- "sp-arithmetic",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-runtime",
+ "sp-consensus-grandpa 20.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11472,64 +14186,82 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c9cad4baf348725bd82eadcd1747fc112ec49c76b863755ce79c588fa73fe4"
+checksum = "7c2eb55e29b0ca52ad3e209fe569b72dfe6b44cc1da7d722446d5a8333dff8e1"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "futures",
- "libp2p",
  "log",
  "parity-scale-codec",
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
+ "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
-name = "sc-offchain"
-version = "30.0.0"
+name = "sc-network-types"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aee89f2abd406356bfd688bd7a51155dc963259e4b752bb85d1f8a061a194fd"
+checksum = "0c372dbda66644a1df0daa8c0d99c36b6f74db7dca213d2416cd84f507125224"
 dependencies = [
- "array-bytes 6.2.2",
+ "bs58 0.5.1",
+ "ed25519-dalek",
+ "libp2p-identity",
+ "litep2p",
+ "log",
+ "multiaddr 0.18.1",
+ "multihash 0.19.1",
+ "rand",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "sc-offchain"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038d77ad5f923ec4183d6b31c7432fdb56d12ee69cad2cff17d4a39caf933bcb"
+dependencies = [
+ "array-bytes",
  "bytes",
  "fnv",
  "futures",
  "futures-timer",
- "hyper",
+ "hyper 0.14.28",
  "hyper-rustls",
- "libp2p",
  "log",
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "rand",
  "sc-client-api",
  "sc-network",
  "sc-network-common",
+ "sc-network-types",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
- "sp-offchain",
- "sp-runtime",
+ "sp-api 33.0.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-keystore 0.40.0",
+ "sp-offchain 33.0.0",
+ "sp-runtime 38.0.1",
  "threadpool",
  "tracing",
 ]
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8dadb2ae5a316e4d08cad6aacd5de1dec792f3bd94e3960795ff7ffd07211c"
+checksum = "f680a0bed67dab19898624246376ba85d5f70a89859ba030830aacd079c28d3c"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11537,15 +14269,15 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "30.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5acf6d89f062d1334a0c5b67e9dea97666cd47a49acb2696eab55ff1a1bf74"
+checksum = "ca9cb792ddb5d0c3df89018e80290de4c769315fa59271bda0a0d29b2d182fdc"
 dependencies = [
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -11555,26 +14287,26 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
- "sp-core",
- "sp-keystore",
- "sp-offchain",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-offchain 33.0.0",
  "sp-rpc",
- "sp-runtime",
- "sp-session",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
  "sp-statement-store",
- "sp-version",
+ "sp-version 36.0.0",
  "tokio",
 ]
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9db6aaabfa7e0c27ec15d0f0a11b994cd4bcf86e362f0d9732b4a414d793f0f"
+checksum = "57b8adf62a207985cf7534abf0d940b335fda0a68eb902da05b7270ee30a6293"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-mixnet",
@@ -11582,22 +14314,29 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 38.0.1",
+ "sp-version 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-rpc-server"
-version = "12.0.0"
+version = "16.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691440bbaddd3bc2675309c965cc75f8bf694f51e0a28039bfc9658299fbc394"
+checksum = "3c14c236a01e03f55f16b92d89fd902cf2e4e9887357a3c36827a1e39b799c6b"
 dependencies = [
- "http",
- "jsonrpsee",
+ "forwarded-header-value",
+ "futures",
+ "governor",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "ip_network",
+ "jsonrpsee 0.23.2",
  "log",
+ "serde",
  "serde_json",
  "substrate-prometheus-endpoint",
  "tokio",
@@ -11607,30 +14346,32 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.35.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f10275c62296a785f6e2ac716521e3b6e0fae470416fdf86491cbbfcc2e23d"
+checksum = "4242d30df623f68d5b937ae264cce85e734c35922e0bf196d7a59b8e7f7843c2"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "futures",
  "futures-util",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
+ "rand",
  "sc-chain-spec",
  "sc-client-api",
  "sc-rpc",
  "sc-transaction-pool-api",
  "sc-utils",
+ "schnellru",
  "serde",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 38.0.1",
+ "sp-version 36.0.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -11638,19 +14379,19 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.36.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ea779b8c5bdb0d0199c8beebcf1fdc5641e468c480e1c4684be660c8c90af"
+checksum = "718b7e3a3963b09c2ab18ce13dbc43c0afa8b53169b67372fbcc4c4147b77e05"
 dependencies = [
  "async-trait",
  "directories",
  "exit-future",
  "futures",
  "futures-timer",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "pin-project",
  "rand",
  "sc-chain-spec",
@@ -11661,11 +14402,11 @@ dependencies = [
  "sc-informant",
  "sc-keystore",
  "sc-network",
- "sc-network-bitswap",
  "sc-network-common",
  "sc-network-light",
  "sc-network-sync",
  "sc-network-transactions",
+ "sc-network-types",
  "sc-rpc",
  "sc-rpc-server",
  "sc-rpc-spec-v2",
@@ -11675,22 +14416,23 @@ dependencies = [
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "sc-utils",
+ "schnellru",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime",
- "sp-session",
- "sp-state-machine",
- "sp-storage",
- "sp-transaction-pool",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-state-machine 0.42.0",
+ "sp-storage 21.0.0",
+ "sp-transaction-pool 33.0.0",
  "sp-transaction-storage-proof",
- "sp-trie",
- "sp-version",
+ "sp-trie 36.0.0",
+ "sp-version 36.0.0",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -11702,37 +14444,37 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.31.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa842052c41ad379eaecdfddc0d5c953d57e311ae688233f68f461b91d38da0a"
+checksum = "f689d0b97c1bbdb2ca31b5f202bda195947f85c7fef990651cad202b99de896b"
 dependencies = [
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
- "sp-core",
+ "parking_lot 0.12.3",
+ "sp-core 34.0.0",
 ]
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.17.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26cb401aad6732700c8d866cbbef1175b9aeb8230908aff27059ef14bd058ef3"
+checksum = "1d117c3945c524b9c0e30966359895f5ad551c2cd4ccbb677b53917fbad5039a"
 dependencies = [
  "clap",
  "fs4",
  "log",
- "sp-core",
+ "sp-core 34.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.35.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc382c7d997f4531eee5e5d57f970eaf2761d722298d7747385a4ad69fa6b12"
+checksum = "58fca6421f003249095557d97b674a27bf4bbf1f301406eb04c42878a43fc715"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-client-api",
@@ -11742,15 +14484,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-sysinfo"
-version = "28.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d2ab8f15021916a07cfbe7a08be484c5dc7d57f07bc0e2aa03260b55a5632f"
+checksum = "7c00ab3d8f51c1905cc3c53cf441b9d94403c67f27968002ff7765248b0f3e6b"
 dependencies = [
  "derive_more",
  "futures",
@@ -11762,25 +14504,26 @@ dependencies = [
  "sc-telemetry",
  "serde",
  "serde_json",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-io",
+ "sp-io 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "16.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0673a93aa0684b606abfc5fce6c882ada7bb5fad8a2ddc66a09a42bcc9664d91"
+checksum = "b1fc8e8ad7f84f2ca864ee361b6207fe21e18c8182c60f209732b2a7c0dcbd31"
 dependencies = [
  "chrono",
  "futures",
  "libp2p",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "pin-project",
  "rand",
+ "sc-network",
  "sc-utils",
  "serde",
  "serde_json",
@@ -11790,9 +14533,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "29.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77b4fdb4f359f19c395ba862430f3ca0efb50b0310b09753caaa06997edd606"
+checksum = "61151f2d6b7ce3d7174484414dbc4e2f64b05a144c8f0a59ea02284e6c748a19"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -11801,22 +14544,22 @@ dependencies = [
  "libc",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "regex",
  "rustc-hash",
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime",
- "sp-tracing",
+ "sp-runtime 38.0.1",
+ "sp-tracing 17.0.0",
  "thiserror",
  "tracing",
- "tracing-log 0.1.4",
- "tracing-subscriber 0.2.25",
+ "tracing-log 0.2.0",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -11833,9 +14576,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "29.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326dc8ea417c53b6787bd1bb27431d44768504451f5ce4efdde0c15877c7c121"
+checksum = "800e35d0d2f2b8e17170ec961d58756fe7891026b19d889be388b9585cb12f90"
 dependencies = [
  "async-trait",
  "futures",
@@ -11843,27 +14586,27 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "sc-client-api",
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-runtime",
- "sp-tracing",
- "sp-transaction-pool",
+ "sp-runtime 38.0.1",
+ "sp-tracing 17.0.0",
+ "sp-transaction-pool 33.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "29.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ae888ce3491acb1b489c3dba930d0c46c7ef9f9893ba0ab8af9125362f3d14"
+checksum = "b3de6f60df6706970061e225e87d77aab9a764b258fe151b896a700419bc6b9d"
 dependencies = [
  "async-trait",
  "futures",
@@ -11871,25 +14614,25 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-utils"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b1a238f5baa56405db4e440e2d2f697583736fa2e2f1aac345c438a42975f1"
+checksum = "acf1bad736c230f16beb1cf48af9e69564df23b13aca9e5751a61266340b4bb5"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
  "futures-timer",
  "lazy_static",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "prometheus",
- "sp-arithmetic",
+ "sp-arithmetic 26.0.0",
 ]
 
 [[package]]
@@ -11996,6 +14739,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sctp-proto"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6220f78bb44c15f326b0596113305f6101097a18755d53727a575c97e09fb24"
+dependencies = [
+ "bytes",
+ "crc",
+ "fxhash",
+ "log",
+ "rand",
+ "slab",
+ "thiserror",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12005,6 +14763,7 @@ dependencies = [
  "der",
  "generic-array 0.14.7",
  "pkcs8",
+ "serdect",
  "subtle 2.5.0",
  "zeroize",
 ]
@@ -12047,22 +14806,23 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
+ "num-bigint",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -12091,6 +14851,12 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -12151,6 +14917,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12164,6 +14940,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+ "sha1-asm",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12172,6 +14960,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -12256,6 +15053,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-dns"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae9a3fcdadafb6d97f4c0e007e4247b114ee0f119f650c3cbf3a8b3a1479694"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "simple-mermaid"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12291,7 +15097,20 @@ dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "slot-range-helper"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d67aa9b1ccfd746c8529754c4ce06445b1d48e189567402ef856340a3a6b14"
+dependencies = [
+ "enumn",
+ "parity-scale-codec",
+ "paste",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -12374,10 +15193,10 @@ dependencies = [
  "siphasher",
  "slab",
  "smallvec",
- "soketto",
+ "soketto 0.7.1",
  "twox-hash",
- "wasmi",
- "x25519-dalek 2.0.1",
+ "wasmi 0.31.2",
+ "x25519-dalek",
  "zeroize",
 ]
 
@@ -12404,7 +15223,7 @@ dependencies = [
  "log",
  "lru 0.11.1",
  "no-std-net",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "pin-project",
  "rand",
  "rand_chacha 0.3.1",
@@ -12457,8 +15276,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a73ef707257064bc4ecce8323cdb7c30e8ecd1ce74aa89a6e82e81fa8b9970"
 dependencies = [
  "byte-slice-cast",
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "hex",
  "parity-scale-codec",
  "rlp",
@@ -12466,9 +15285,9 @@ dependencies = [
  "serde",
  "snowbridge-ethereum",
  "snowbridge-milagro-bls",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
  "ssz_rs",
  "ssz_rs_derive",
@@ -12482,21 +15301,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3e2e3b94bfcfc8f363e21a6c5a1d3c67eb4592ada672c868a3236ad1dd563b"
 dependencies = [
  "ethabi-decode",
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "hex-literal",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 7.0.0",
  "scale-info",
  "serde",
  "snowbridge-beacon-primitives",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm 8.0.1",
+ "staging-xcm-builder 8.0.3",
 ]
 
 [[package]]
@@ -12516,9 +15335,9 @@ dependencies = [
  "scale-info",
  "serde",
  "serde-big-array",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
 ]
 
@@ -12544,21 +15363,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee5cc8e156f033971c5435676be92ab6f70a926b3497ca9c28c0dde9697b8da9"
 dependencies = [
  "ethabi-decode",
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "hex-literal",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "snowbridge-core",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 8.0.1",
+ "staging-xcm-builder 8.0.3",
+ "staging-xcm-executor 8.0.2",
 ]
 
 [[package]]
@@ -12573,9 +15392,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -12589,13 +15408,28 @@ checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
  "base64 0.13.1",
  "bytes",
- "flate2",
  "futures",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand",
- "sha-1",
+ "sha-1 0.9.8",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
 ]
 
 [[package]]
@@ -12608,15 +15442,38 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro",
- "sp-core",
- "sp-externalities",
- "sp-metadata-ir",
- "sp-runtime",
- "sp-state-machine",
+ "sp-api-proc-macro 15.0.1",
+ "sp-core 29.0.0",
+ "sp-externalities 0.26.0",
+ "sp-metadata-ir 0.6.0",
+ "sp-runtime 32.0.0",
+ "sp-state-machine 0.36.0",
  "sp-std",
- "sp-trie",
- "sp-version",
+ "sp-trie 30.0.0",
+ "sp-version 30.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-api"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e43fbf034e9dbaa8ffc6a238a22808777eb38c580f66fc6736d8511631789e"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api-proc-macro 20.0.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-metadata-ir 0.7.0",
+ "sp-runtime 38.0.1",
+ "sp-runtime-interface 28.0.0",
+ "sp-state-machine 0.42.0",
+ "sp-std",
+ "sp-trie 36.0.0",
+ "sp-version 36.0.0",
  "thiserror",
 ]
 
@@ -12628,7 +15485,22 @@ checksum = "0301e2f77afb450fbf2b093f8b324c7ad88cc82e5e69bd5dc8658a1f068b2a96"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
- "expander 2.1.0",
+ "expander",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "sp-api-proc-macro"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9aadf9e97e694f0e343978aa632938c5de309cbcc8afed4136cb71596737278"
+dependencies = [
+ "Inflector",
+ "blake2 0.10.6",
+ "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
@@ -12644,8 +15516,22 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d96d1fc0f1c741bbcbd0dd5470eff7b66f011708cc1942b088ebf0d4efb3d93"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
  "sp-std",
 ]
 
@@ -12665,6 +15551,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-arithmetic"
+version = "26.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d0d0a4c591c421d3231ddd5e27d828618c24456d51445d21a1f79fcee97c23"
+dependencies = [
+ "docify",
+ "integer-sqrt",
+ "num-traits",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-std",
+ "static_assertions",
+]
+
+[[package]]
 name = "sp-authority-discovery"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12672,10 +15574,23 @@ checksum = "c92b177c72b5d2973c36d60f6ef942d791d9fd91eae8b08c71882e4118d4fbfc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-application-crypto 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-authority-discovery"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a4a1e45abc3277f18484ee0b0f9808e4206eb696ad38500c892c72f33480d69"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -12684,44 +15599,55 @@ version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b36ce171caa7eb2bbe682c089f755fdefa71d3702e4fb1ba30d10146aef99d5"
 dependencies = [
- "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-inherents 27.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
 ]
 
 [[package]]
-name = "sp-blockchain"
-version = "29.0.0"
+name = "sp-block-builder"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31303e766d2e53812641bbc1f1cec03a85793fc9e627e55f0a6854b28708758"
+checksum = "2cf199dc4f9f77abd3fd91c409759118159ce6ffcd8bc90b229b684ccc8c981f"
+dependencies = [
+ "sp-api 33.0.0",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
+]
+
+[[package]]
+name = "sp-blockchain"
+version = "35.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27eb18b6ddf7d663f4886f7edba3eb73bd102d68cf10802c1f862e3b3db32ab"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "schnellru",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-consensus",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-consensus"
-version = "0.33.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6e512b862c4ff7a26cdcd364898cc42e181ff5cb35fbb226ff27d88c81569a"
+checksum = "ab094e8a7e9e5c7f05f8d90592aa1d1cf9b3f547d0dd401daff7ed98af942e12"
 dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
  "thiserror",
 ]
 
@@ -12734,13 +15660,30 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-application-crypto 31.0.0",
+ "sp-consensus-slots 0.33.0",
+ "sp-inherents 27.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-timestamp",
+ "sp-timestamp 27.0.0",
+]
+
+[[package]]
+name = "sp-consensus-aura"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ebb90bf00f331b898eb729a1f707251846c1d5582d7467f083884799a69b89"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-consensus-slots 0.39.0",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-timestamp 33.0.0",
 ]
 
 [[package]]
@@ -12753,14 +15696,33 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-application-crypto 31.0.0",
+ "sp-consensus-slots 0.33.0",
+ "sp-core 29.0.0",
+ "sp-inherents 27.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-timestamp",
+ "sp-timestamp 27.0.0",
+]
+
+[[package]]
+name = "sp-consensus-babe"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa2de4c7100a3279658d8dd4affd8f92487528deae5cb4b40322717b9175ed5"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-consensus-slots 0.39.0",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-timestamp 33.0.0",
 ]
 
 [[package]]
@@ -12773,15 +15735,36 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
+ "sp-api 27.0.1",
+ "sp-application-crypto 31.0.0",
+ "sp-core 29.0.0",
  "sp-crypto-hashing",
- "sp-io",
- "sp-mmr-primitives",
- "sp-runtime",
+ "sp-io 31.0.0",
+ "sp-mmr-primitives 27.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
  "strum 0.24.1",
+]
+
+[[package]]
+name = "sp-consensus-beefy"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b277bc109da8e1c3768d3a046e1cd1ab687aabac821c976c5f510deb6f0bc8d3"
+dependencies = [
+ "lazy_static",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing",
+ "sp-io 37.0.0",
+ "sp-keystore 0.40.0",
+ "sp-mmr-primitives 33.0.0",
+ "sp-runtime 38.0.1",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -12795,12 +15778,30 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-application-crypto 31.0.0",
+ "sp-core 29.0.0",
+ "sp-keystore 0.35.0",
+ "sp-runtime 32.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-consensus-grandpa"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dd06bf366c60f69411668b26d6ab3c55120aa6d423e6af0373ec23d8957300"
+dependencies = [
+ "finality-grandpa",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -12813,7 +15814,19 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-std",
- "sp-timestamp",
+ "sp-timestamp 27.0.0",
+]
+
+[[package]]
+name = "sp-consensus-slots"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ca60d713f8ddb03bbebcc755d5e6463fdc0b6259fabfc4221b20a5f1e428fd"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-timestamp 33.0.0",
 ]
 
 [[package]]
@@ -12822,7 +15835,7 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c33c7a1568175250628567d50c4e1c54a6ac5bc1190413b9be29a9e810cbe73"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "bip39",
  "bitflags 1.3.2",
  "blake2 0.10.6",
@@ -12839,7 +15852,7 @@ dependencies = [
  "log",
  "merlin",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "paste",
  "primitive-types",
  "rand",
@@ -12850,12 +15863,59 @@ dependencies = [
  "serde",
  "sp-crypto-hashing",
  "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
+ "sp-externalities 0.26.0",
+ "sp-runtime-interface 25.0.0",
  "sp-std",
- "sp-storage",
+ "sp-storage 20.0.0",
  "ss58-registry",
- "substrate-bip39",
+ "substrate-bip39 0.4.6",
+ "thiserror",
+ "tracing",
+ "w3f-bls",
+ "zeroize",
+]
+
+[[package]]
+name = "sp-core"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c961a5e33fb2962fa775c044ceba43df9c6f917e2c35d63bfe23738468fa76a7"
+dependencies = [
+ "array-bytes",
+ "bitflags 1.3.2",
+ "blake2 0.10.6",
+ "bounded-collections 0.2.0",
+ "bs58 0.5.1",
+ "dyn-clonable",
+ "ed25519-zebra 4.0.3",
+ "futures",
+ "hash-db",
+ "hash256-std-hasher",
+ "impl-serde",
+ "itertools 0.11.0",
+ "k256",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "parity-bip39",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "paste",
+ "primitive-types",
+ "rand",
+ "scale-info",
+ "schnorrkel 0.11.4",
+ "secp256k1",
+ "secrecy",
+ "serde",
+ "sp-crypto-hashing",
+ "sp-debug-derive",
+ "sp-externalities 0.29.0",
+ "sp-runtime-interface 28.0.0",
+ "sp-std",
+ "sp-storage 21.0.0",
+ "ss58-registry",
+ "substrate-bip39 0.6.0",
  "thiserror",
  "tracing",
  "w3f-bls",
@@ -12894,7 +15954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722cbecdbf5b94578137dbd07feb51e95f7de221be0c1ff4dcfe0bb4cd986929"
 dependencies = [
  "kvdb",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
@@ -12917,7 +15977,18 @@ dependencies = [
  "environmental",
  "parity-scale-codec",
  "sp-std",
- "sp-storage",
+ "sp-storage 20.0.0",
+]
+
+[[package]]
+name = "sp-externalities"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a904407d61cb94228c71b55a9d3708e9d6558991f9e83bd42bd91df37a159d30"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "sp-storage 21.0.0",
 ]
 
 [[package]]
@@ -12927,9 +15998,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd865540ec19479c7349b584ccd78cc34c3f3a628a2a69dbb6365ceec36295ee"
 dependencies = [
  "serde_json",
- "sp-api",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-runtime 32.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-genesis-builder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcd065854d96fd81521c103d0aaa287d4f08b9b15c9fae2a3bfb208b0812bf44"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde_json",
+ "sp-api 33.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -12942,8 +16026,22 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 32.0.0",
  "sp-std",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53407ba38ec22ca4a16381722c4bd0b559a0428bc1713079b0d5163ada63186a"
+dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 38.0.1",
  "thiserror",
 ]
 
@@ -12960,15 +16058,42 @@ dependencies = [
  "parity-scale-codec",
  "rustversion",
  "secp256k1",
- "sp-core",
+ "sp-core 29.0.0",
  "sp-crypto-hashing",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface",
- "sp-state-machine",
+ "sp-externalities 0.26.0",
+ "sp-keystore 0.35.0",
+ "sp-runtime-interface 25.0.0",
+ "sp-state-machine 0.36.0",
  "sp-std",
- "sp-tracing",
- "sp-trie",
+ "sp-tracing 16.0.0",
+ "sp-trie 30.0.0",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "sp-io"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5036cad2e48d41f5caf6785226c8be1a7db15bec14a9fd7aa6cca84f34cf689f"
+dependencies = [
+ "bytes",
+ "ed25519-dalek",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "polkavm-derive",
+ "rustversion",
+ "secp256k1",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing",
+ "sp-externalities 0.29.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime-interface 28.0.0",
+ "sp-state-machine 0.42.0",
+ "sp-std",
+ "sp-tracing 17.0.0",
+ "sp-trie 36.0.0",
  "tracing",
  "tracing-core",
 ]
@@ -12979,9 +16104,20 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cf0a2f881958466fc92bc9b39bbc2c0d815ded4a21f8f953372b0ac2e11b02"
 dependencies = [
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
  "strum 0.24.1",
+]
+
+[[package]]
+name = "sp-keyring"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03536e1ff3ec2bd8181eeaa26c0d682ebdcbd01548a055cf591077188b8c3f0"
+dependencies = [
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -12991,10 +16127,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444f2d53968b1ce5e908882710ff1f3873fcf3e95f59d57432daf685bbacb959"
 dependencies = [
  "parity-scale-codec",
- "parking_lot 0.12.1",
- "sp-core",
- "sp-externalities",
+ "parking_lot 0.12.3",
+ "sp-core 29.0.0",
+ "sp-externalities 0.26.0",
  "thiserror",
+]
+
+[[package]]
+name = "sp-keystore"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0248b4d784cb4a01472276928977121fa39d977a5bb24793b6b15e64b046df42"
+dependencies = [
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
 ]
 
 [[package]]
@@ -13020,16 +16168,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-mixnet"
-version = "0.5.0"
+name = "sp-metadata-ir"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bebd44b915c65aeb7e7eeaea466aba3b27cdd915c83ea83d4643c54f21ffbbf"
+checksum = "a616fa51350b35326682a472ee8e6ba742fdacb18babac38ecd46b3e05ead869"
+dependencies = [
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "sp-mixnet"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f65a570519da820ce3dc35053497a65f9fbd3f5a7dc81fa03078ca263e9311e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-std",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
 ]
 
 [[package]]
@@ -13043,11 +16201,29 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-core",
+ "sp-api 27.0.1",
+ "sp-core 29.0.0",
  "sp-debug-derive",
- "sp-runtime",
+ "sp-runtime 32.0.0",
  "sp-std",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-mmr-primitives"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47412a2d2e988430d5f59d7fec1473f229e1ef5ce24c1ea4f601b4b3679cac52"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "polkadot-ckb-merkle-mountain-range",
+ "scale-info",
+ "serde",
+ "sp-api 33.0.0",
+ "sp-core 34.0.0",
+ "sp-debug-derive",
+ "sp-runtime 38.0.1",
  "thiserror",
 ]
 
@@ -13060,10 +16236,24 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic",
- "sp-core",
- "sp-runtime",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-npos-elections"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0c51a7b60cd663f2661e6949069eb316b092f22c239691d5272a4d0cfca0fb"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -13072,9 +16262,20 @@ version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d83b955dce0b6d143bec3f60571311168f362b1c16cf044da7037a407b66c19"
 dependencies = [
- "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
+]
+
+[[package]]
+name = "sp-offchain"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbe721c367760bddf10fcfa24fb48edd64c442f71db971f043c8ac73f51aa6e9"
+dependencies = [
+ "sp-api 33.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -13090,13 +16291,13 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "27.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af4b73fe7ddd88b1641cca90048c4e525e721763199e6fd29c4f590884f4d16"
+checksum = "45458f0955870a92b3969098d4f1f4e9b55b4282d9f1dc112a51bb5bb6584900"
 dependencies = [
  "rustc-hash",
  "serde",
- "sp-core",
+ "sp-core 34.0.0",
 ]
 
 [[package]]
@@ -13116,12 +16317,39 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
+ "sp-application-crypto 31.0.0",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 28.0.0",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "38.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5273900f0b0bef48b2e1ff9c4fb5e188b8168ee5891418a427f4be2af92ee40f"
+dependencies = [
+ "docify",
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "num-traits",
+ "parity-scale-codec",
+ "paste",
+ "rand",
+ "scale-info",
+ "serde",
+ "simple-mermaid",
+ "sp-application-crypto 37.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-std",
+ "sp-weights 31.0.0",
+ "tracing",
 ]
 
 [[package]]
@@ -13134,12 +16362,32 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities",
- "sp-runtime-interface-proc-macro",
+ "sp-externalities 0.26.0",
+ "sp-runtime-interface-proc-macro 17.0.0",
  "sp-std",
- "sp-storage",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-storage 20.0.0",
+ "sp-tracing 16.0.0",
+ "sp-wasm-interface 20.0.0",
+ "static_assertions",
+]
+
+[[package]]
+name = "sp-runtime-interface"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985eb981f40c689c6a0012c937b68ed58dabb4341d06f2dfe4dfd5ed72fa4017"
+dependencies = [
+ "bytes",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "polkavm-derive",
+ "primitive-types",
+ "sp-externalities 0.29.0",
+ "sp-runtime-interface-proc-macro 18.0.0",
+ "sp-std",
+ "sp-storage 21.0.0",
+ "sp-tracing 17.0.0",
+ "sp-wasm-interface 21.0.0",
  "static_assertions",
 ]
 
@@ -13150,7 +16398,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfaf6e85b2ec12a4b99cd6d8d57d083e30c94b7f1b0d8f93547121495aae6f0c"
 dependencies = [
  "Inflector",
- "expander 2.1.0",
+ "expander",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "sp-runtime-interface-proc-macro"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0195f32c628fee3ce1dfbbf2e7e52a30ea85f3589da9fe62a8b816d70fc06294"
+dependencies = [
+ "Inflector",
+ "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
@@ -13165,12 +16427,27 @@ checksum = "3b86531090cc04d2ab3535df07146258e2fb3ab6257b0a77ef14aa08282c3d4a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-api 27.0.1",
+ "sp-core 29.0.0",
+ "sp-keystore 0.35.0",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-session"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4daf2e40ffc7e7e8de08efb860eb9534faf614a49c53dc282f430faedb4aed13"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 33.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
 ]
 
 [[package]]
@@ -13183,9 +16460,23 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-staking"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0b7abfe66c07a3b6eb99e1286dfa9b6f3b057b0e986e7da2ccbf707f6c781a"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -13197,24 +16488,45 @@ dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "rand",
  "smallvec",
- "sp-core",
- "sp-externalities",
+ "sp-core 29.0.0",
+ "sp-externalities 0.26.0",
  "sp-panic-handler",
  "sp-std",
- "sp-trie",
+ "sp-trie 30.0.0",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.28.0",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "211e528aa6e902261a343f7b40840aa3d66fe4ad3aadbd04a035f10baf96dbc5"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand",
+ "smallvec",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-panic-handler",
+ "sp-trie 36.0.0",
+ "thiserror",
+ "tracing",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
 name = "sp-statement-store"
-version = "11.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309a9ae4e8134bbed8ffc510cf4d461a4a651f9250b556de782cedd876abe1ff"
+checksum = "b03aa86b1b46549889d32348bc85a8135c725665115567507231a6d85712aaac"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
@@ -13224,16 +16536,15 @@ dependencies = [
  "rand",
  "scale-info",
  "sha2 0.10.8",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-externalities",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-std",
+ "sp-externalities 0.29.0",
+ "sp-runtime 38.0.1",
+ "sp-runtime-interface 28.0.0",
  "thiserror",
- "x25519-dalek 2.0.1",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -13257,6 +16568,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-storage"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c82989b3a4979a7e1ad848aad9f5d0b4388f1f454cc131766526601ab9e8f8"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "ref-cast",
+ "serde",
+ "sp-debug-derive",
+]
+
+[[package]]
 name = "sp-timestamp"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13264,9 +16588,22 @@ checksum = "249cd06624f2edb53b25af528ab216a508dc9d0870e158b43caac3a97e86699f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 27.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-timestamp"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78becf144a76f6fd108dfe94a90e20a185b38c0b310dc5482328196143c8266b"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
  "thiserror",
 ]
 
@@ -13284,29 +16621,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-tracing"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b3decf116db9f1dfaf1f1597096b043d0e12c952d3bcdc018c6d6b77deec7e"
+dependencies = [
+ "parity-scale-codec",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
 name = "sp-transaction-pool"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9742861c5330bdcb42856a6eed3d3745b58ee1c92ca4c9260032ff4e6c387165"
 dependencies = [
- "sp-api",
- "sp-runtime",
+ "sp-api 27.0.1",
+ "sp-runtime 32.0.0",
+]
+
+[[package]]
+name = "sp-transaction-pool"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c9d1604aadc15b70e95f4388d0b1aa380215520b7ddfd372531a6d8262269c"
+dependencies = [
+ "sp-api 33.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "27.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece8e22a5419c7a336a2544654e1389fec8cac19b93081a30912842b44e8167f"
+checksum = "5b5a891cb913015bb99401e372255193cc3848c6fe5c2f6fe2383ef9588cb190"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
- "sp-trie",
+ "sp-core 34.0.0",
+ "sp-inherents 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-trie 36.0.0",
 ]
 
 [[package]]
@@ -13321,16 +16679,40 @@ dependencies = [
  "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "rand",
  "scale-info",
  "schnellru",
- "sp-core",
- "sp-externalities",
+ "sp-core 29.0.0",
+ "sp-externalities 0.26.0",
  "sp-std",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.28.0",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-trie"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d717c0f465f5371569e6fdc25b6f32d47c15d6e4c92b3b779e1c9b18b951d"
+dependencies = [
+ "ahash 0.8.11",
+ "hash-db",
+ "lazy_static",
+ "memory-db",
+ "nohash-hasher",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand",
+ "scale-info",
+ "schnellru",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "thiserror",
+ "tracing",
+ "trie-db 0.29.1",
  "trie-root",
 ]
 
@@ -13346,9 +16728,27 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-version-proc-macro",
+ "sp-version-proc-macro 13.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-version"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bccf96fefae339dee7c4453f91be64eb28cce4c2fe82130445cf096b18b2c081"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "parity-wasm",
+ "scale-info",
+ "serde",
+ "sp-crypto-hashing-proc-macro",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-version-proc-macro 14.0.0",
  "thiserror",
 ]
 
@@ -13357,6 +16757,18 @@ name = "sp-version-proc-macro"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9bc3fed32d6dacbbbfb28dd1fe0224affbb737cb6cbfca1d9149351c2b69a7d"
+dependencies = [
+ "parity-scale-codec",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "sp-version-proc-macro"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aee8f6730641a65fcf0c8f9b1e448af4b3bb083d08058b47528188bccc7b7a7"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -13379,6 +16791,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-wasm-interface"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b04b919e150b4736d85089d49327eab65507deb1485eec929af69daa2278eb3"
+dependencies = [
+ "anyhow",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "wasmtime",
+]
+
+[[package]]
 name = "sp-weights"
 version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13389,9 +16814,24 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic",
+ "sp-arithmetic 24.0.0",
  "sp-debug-derive",
  "sp-std",
+]
+
+[[package]]
+name = "sp-weights"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93cdaf72a1dad537bbb130ba4d47307ebe5170405280ed1aa31fa712718a400e"
+dependencies = [
+ "bounded-collections 0.2.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "smallvec",
+ "sp-arithmetic 26.0.0",
+ "sp-debug-derive",
 ]
 
 [[package]]
@@ -13407,14 +16847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "spinners"
-version = "4.1.1"
+name = "spinning_top"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ef947f358b9c238923f764c72a4a9d42f2d637c46e059dbd319d6e7cfb4f82"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
- "lazy_static",
- "maplit",
- "strum 0.24.1",
+ "lock_api",
 ]
 
 [[package]]
@@ -13477,12 +16915,27 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7dc139d104f676a18c13380a09c3f72d59450a7471116387cbf8cb5f845a0e"
 dependencies = [
- "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "cumulus-primitives-core 0.8.0",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "staging-parachain-info"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd00d586b0dac4f42736bdd0ad52213a891b240e011ea82b38938263dd821c25"
+dependencies = [
+ "cumulus-primitives-core 0.14.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
@@ -13492,7 +16945,7 @@ version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fa328b87de3466bc38cc9a07244c42c647b7755b81115e1dfeb47cc13fc6e6"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes",
  "bounded-collections 0.2.0",
  "derivative",
  "environmental",
@@ -13501,8 +16954,27 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-weights",
- "xcm-procedural",
+ "sp-weights 28.0.0",
+ "xcm-procedural 8.0.0",
+]
+
+[[package]]
+name = "staging-xcm"
+version = "14.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b7b5f531c6bf9629514ef8e5fda0e9e80dd84516957f710940d0e01d3fb36c"
+dependencies = [
+ "array-bytes",
+ "bounded-collections 0.2.0",
+ "derivative",
+ "environmental",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-weights 31.0.0",
+ "xcm-procedural 10.1.0",
 ]
 
 [[package]]
@@ -13511,21 +16983,44 @@ version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b7447c38be3ca9fb21c7434de2243aa6ac74acde8944cda7bb6e2a4f765801"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 29.0.2",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 7.0.0",
  "scale-info",
- "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 24.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-weights",
- "staging-xcm",
- "staging-xcm-executor",
+ "sp-weights 28.0.0",
+ "staging-xcm 8.0.1",
+ "staging-xcm-executor 8.0.2",
+]
+
+[[package]]
+name = "staging-xcm-builder"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847fa2afe1bed2751eaabf7b91fa4043037947f17653d7cc59ea202cc44c6bb8"
+dependencies = [
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-transaction-payment 36.0.0",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives 13.0.0",
+ "scale-info",
+ "sp-arithmetic 26.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-weights 31.0.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-executor 15.0.0",
 ]
 
 [[package]]
@@ -13535,19 +17030,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b5c5f2a1d610c5e20e5fae2680c9a28380f305afafeed62f341bfbce57b79a"
 dependencies = [
  "environmental",
- "frame-benchmarking",
- "frame-support",
+ "frame-benchmarking 29.0.0",
+ "frame-support 29.0.2",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
- "sp-weights",
- "staging-xcm",
+ "sp-weights 28.0.0",
+ "staging-xcm 8.0.1",
+]
+
+[[package]]
+name = "staging-xcm-executor"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b98d8219449eaf02e71a7edf1a14b14d4c713dd01d9df66fde1ce30dba4d6d"
+dependencies = [
+ "environmental",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-weights 31.0.0",
+ "staging-xcm 14.1.0",
 ]
 
 [[package]]
@@ -13585,16 +17102,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "strobe-rs"
-version = "0.8.1"
+name = "str0m"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabb238a1cccccfa4c4fb703670c0d157e1256c1ba695abf1b93bd2bb14bab2d"
+checksum = "6706347e49b13373f7ddfafad47df7583ed52083d6fc8a594eb2c80497ef959d"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "keccak",
- "subtle 2.5.0",
- "zeroize",
+ "combine",
+ "crc",
+ "fastrand 2.0.2",
+ "hmac 0.12.1",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "sctp-proto",
+ "serde",
+ "sha-1 0.10.1",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "string-interner"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -13617,6 +17152,15 @@ name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
 
 [[package]]
 name = "strum_macros"
@@ -13645,6 +17189,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "substrate-bip39"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13658,6 +17215,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-bip39"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2 0.12.2",
+ "schnorrkel 0.11.4",
+ "sha2 0.10.8",
+ "zeroize",
+]
+
+[[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13665,22 +17235,23 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "29.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f903d2f34703204f0003136c9abbc569d691028279996a1daf8f248a7369f"
+checksum = "02b8837de37f5ea6316846a63dc48489b63ebde05df73ba7d7077b3135487560"
 dependencies = [
- "frame-system-rpc-runtime-api",
+ "docify",
+ "frame-system-rpc-runtime-api 33.0.0",
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "log",
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api",
- "sp-block-builder",
+ "sp-api 33.0.0",
+ "sp-block-builder 33.0.0",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -13689,7 +17260,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8fe06b03b8a291c09507c42f92a2c2c10dd3d62975d02c7f64a92d87bfe09b"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "log",
  "prometheus",
  "thiserror",
@@ -13697,35 +17268,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-rpc-client"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e5235d8460ec81e9a382345aa80d75e2943f224a332559847344bb62fa13b3"
-dependencies = [
- "async-trait",
- "jsonrpsee",
- "log",
- "sc-rpc-api",
- "serde",
- "sp-runtime",
-]
-
-[[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "28.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5768a5d3c76eebfdf94c23a3fde6c832243a043d60561e5ac1a2b475b9ad09f3"
+checksum = "df246ac77a641b23068e8c49cff4dfbaefc78405f80c9589a10909e02d525141"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
  "serde",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
- "trie-db",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "sp-state-machine 0.42.0",
+ "sp-trie 36.0.0",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
@@ -13741,6 +17298,26 @@ dependencies = [
  "parity-wasm",
  "sp-maybe-compressed-blob",
  "strum 0.24.1",
+ "tempfile",
+ "toml 0.8.12",
+ "walkdir",
+ "wasm-opt",
+]
+
+[[package]]
+name = "substrate-wasm-builder"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dc993ad871b63fbba60362f3ea86583f5e7e1256e8fdcb3b5b249c9ead354bf"
+dependencies = [
+ "build-helper",
+ "cargo_metadata",
+ "console",
+ "filetime",
+ "parity-wasm",
+ "polkavm-linker",
+ "sp-maybe-compressed-blob",
+ "strum 0.26.3",
  "tempfile",
  "toml 0.8.12",
  "walkdir",
@@ -13800,6 +17377,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13825,13 +17413,13 @@ name = "system-parachains-constants"
 version = "1.0.0"
 source = "git+https://github.com/paseo-network/runtimes/?tag=v1.2.5-system-chains#e7265b10b28d8b82c3146e72c98895dac2b55729"
 dependencies = [
- "frame-support",
- "parachains-common",
+ "frame-support 29.0.2",
+ "parachains-common 8.0.1",
  "paseo-runtime-constants",
- "polkadot-core-primitives",
- "polkadot-primitives",
+ "polkadot-core-primitives 8.0.0",
+ "polkadot-primitives 8.0.1",
  "smallvec",
- "sp-runtime",
+ "sp-runtime 32.0.0",
 ]
 
 [[package]]
@@ -13885,9 +17473,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
@@ -13914,9 +17502,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14048,10 +17636,10 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
- "pin-project-lite 0.2.13",
+ "parking_lot 0.12.3",
+ "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -14068,17 +17656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14089,30 +17666,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.12",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.10"
+name = "tokio-tungstenite"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.21.10",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -14189,7 +17791,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -14197,18 +17800,16 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite 0.2.13",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]
@@ -14232,7 +17833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
- "pin-project-lite 0.2.13",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -14270,12 +17871,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "8.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9690af7fe11d125786fa1b5ca802192f631b61a4411277865c8e0581c887e286"
+checksum = "d07f52b2b1a1c1c21094bd0b6fdcf1b7dbe785b937b30e82dba688d55d988efb"
 dependencies = [
  "coarsetime",
- "polkadot-primitives",
+ "polkadot-primitives 14.0.0",
  "tracing",
  "tracing-gum-proc-macro",
 ]
@@ -14286,7 +17887,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f074568687ffdfd0adb6005aa8d1d96840197f2c159f80471285f08694cf0ce"
 dependencies = [
- "expander 2.1.0",
+ "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
@@ -14335,7 +17936,6 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers 0.0.1",
- "parking_lot 0.11.2",
  "regex",
  "serde",
  "serde_json",
@@ -14355,9 +17955,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers 0.1.0",
+ "nu-ansi-term",
  "once_cell",
+ "parking_lot 0.12.3",
  "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -14372,6 +17975,18 @@ checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c992b4f40c234a074d48a757efeabb1a6be88af84c0c23f7ca158950cb0ae7f"
+dependencies = [
+ "hash-db",
  "log",
  "rustc-hex",
  "smallvec",
@@ -14395,7 +18010,7 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "futures-channel",
  "futures-io",
  "futures-util",
@@ -14413,23 +18028,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-resolver"
-version = "0.22.0"
+name = "trust-dns-proto"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner 0.6.0",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
 dependencies = [
  "cfg-if",
  "futures-util",
  "ipconfig",
- "lazy_static",
  "lru-cache",
- "parking_lot 0.12.1",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "rand",
  "resolv-conf",
  "smallvec",
  "thiserror",
  "tokio",
  "tracing",
- "trust-dns-proto",
+ "trust-dns-proto 0.23.2",
 ]
 
 [[package]]
@@ -14439,47 +18080,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "try-runtime-cli"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9454e1af0a0be675f837d63080ef8f43510c05df8c059570622386a0cf40b548"
-dependencies = [
- "async-trait",
- "clap",
- "frame-remote-externalities",
- "frame-try-runtime",
- "hex",
- "log",
- "parity-scale-codec",
- "sc-cli",
- "sc-executor",
- "serde",
- "serde_json",
- "sp-api",
- "sp-consensus-aura",
- "sp-consensus-babe",
- "sp-core",
- "sp-debug-derive",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-rpc",
- "sp-runtime",
- "sp-state-machine",
- "sp-timestamp",
- "sp-transaction-storage-proof",
- "sp-version",
- "sp-weights",
- "substrate-rpc-client",
- "zstd 0.12.4",
-]
-
-[[package]]
 name = "tt-call"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "rand",
+ "rustls 0.21.10",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tuplex"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "676ac81d5454c4dcf37955d34fa8626ede3490f744b86ca14a7b90168d2a08aa"
 
 [[package]]
 name = "twox-hash"
@@ -14573,6 +18203,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+dependencies = [
+ "bytes",
+ "tokio-util",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14594,6 +18234,12 @@ dependencies = [
  "idna 0.5.0",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -14676,12 +18322,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -14692,7 +18332,7 @@ version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
 dependencies = [
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -14834,7 +18474,24 @@ dependencies = [
  "smallvec",
  "spin 0.9.8",
  "wasmi_arena",
- "wasmi_core",
+ "wasmi_core 0.13.0",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "wasmi"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
+dependencies = [
+ "arrayvec 0.7.4",
+ "multi-stash",
+ "num-derive",
+ "num-traits",
+ "smallvec",
+ "spin 0.9.8",
+ "wasmi_collections",
+ "wasmi_core 0.32.3",
  "wasmparser-nostd",
 ]
 
@@ -14845,10 +18502,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
+name = "wasmi_collections"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c128c039340ffd50d4195c3f8ce31aac357f06804cfc494c8b9508d4b30dca4"
+dependencies = [
+ "ahash 0.8.11",
+ "hashbrown 0.14.3",
+ "string-interner",
+]
+
+[[package]]
 name = "wasmi_core"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23b3a7f6c8c3ceeec6b83531ee61f0013c56e51cbf2b14b0f213548b23a4b41"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -14868,9 +18548,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser-nostd"
-version = "0.100.1"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
 ]
@@ -15092,135 +18772,142 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
- "webpki",
+ "rustls-pki-types",
 ]
 
 [[package]]
 name = "westend-runtime"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2a5cebb4c678a0d1291bb21f9d44ddebceae044b0fb5200fa3bed108a31595"
+checksum = "56b8918bb9fe4938757d4f003b7fa26598a632e350feac4e7477bb6b36e2f2af"
 dependencies = [
- "binary-merkle-tree",
+ "binary-merkle-tree 15.0.0",
  "bitvec",
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
+ "frame-benchmarking 36.0.0",
+ "frame-election-provider-support 36.0.0",
+ "frame-executive 36.0.0",
+ "frame-metadata-hash-extension 0.4.0",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
+ "frame-system-benchmarking 36.0.0",
+ "frame-system-rpc-runtime-api 33.0.0",
+ "frame-try-runtime 0.42.0",
  "hex-literal",
  "log",
- "pallet-asset-rate",
- "pallet-authority-discovery",
- "pallet-authorship",
- "pallet-babe",
- "pallet-bags-list",
- "pallet-balances",
- "pallet-beefy",
- "pallet-beefy-mmr",
+ "pallet-asset-rate 15.0.0",
+ "pallet-authority-discovery 36.0.0",
+ "pallet-authorship 36.0.0",
+ "pallet-babe 36.0.0",
+ "pallet-bags-list 35.0.0",
+ "pallet-balances 37.0.0",
+ "pallet-beefy 36.0.0",
+ "pallet-beefy-mmr 36.0.0",
  "pallet-collective",
- "pallet-conviction-voting",
+ "pallet-conviction-voting 36.0.0",
+ "pallet-delegated-staking",
  "pallet-democracy",
- "pallet-election-provider-multi-phase",
- "pallet-election-provider-support-benchmarking",
+ "pallet-election-provider-multi-phase 35.0.0",
+ "pallet-election-provider-support-benchmarking 35.0.0",
  "pallet-elections-phragmen",
- "pallet-fast-unstake",
- "pallet-grandpa",
- "pallet-identity",
- "pallet-im-online",
- "pallet-indices",
+ "pallet-fast-unstake 35.0.0",
+ "pallet-grandpa 36.0.0",
+ "pallet-identity 36.0.0",
+ "pallet-indices 36.0.0",
  "pallet-membership",
- "pallet-message-queue",
- "pallet-mmr",
- "pallet-multisig",
- "pallet-nomination-pools",
- "pallet-nomination-pools-benchmarking",
- "pallet-nomination-pools-runtime-api",
- "pallet-offences",
- "pallet-offences-benchmarking",
- "pallet-preimage",
- "pallet-proxy",
+ "pallet-message-queue 39.0.0",
+ "pallet-mmr 35.0.0",
+ "pallet-multisig 36.0.0",
+ "pallet-nomination-pools 33.0.0",
+ "pallet-nomination-pools-benchmarking 34.0.0",
+ "pallet-nomination-pools-runtime-api 31.0.0",
+ "pallet-offences 35.0.0",
+ "pallet-offences-benchmarking 36.0.0",
+ "pallet-preimage 36.0.0",
+ "pallet-proxy 36.0.0",
  "pallet-recovery",
- "pallet-referenda",
+ "pallet-referenda 36.0.0",
  "pallet-root-testing",
- "pallet-scheduler",
- "pallet-session",
- "pallet-session-benchmarking",
+ "pallet-scheduler 37.0.0",
+ "pallet-session 36.0.0",
+ "pallet-session-benchmarking 36.0.0",
  "pallet-society",
- "pallet-staking",
- "pallet-staking-reward-curve",
- "pallet-staking-runtime-api",
- "pallet-state-trie-migration",
- "pallet-sudo",
- "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-treasury",
- "pallet-utility",
- "pallet-vesting",
- "pallet-whitelist",
- "pallet-xcm",
- "pallet-xcm-benchmarks",
+ "pallet-staking 36.0.0",
+ "pallet-staking-reward-curve 12.0.0",
+ "pallet-staking-runtime-api 21.0.0",
+ "pallet-state-trie-migration 37.0.0",
+ "pallet-sudo 36.0.0",
+ "pallet-timestamp 35.0.0",
+ "pallet-transaction-payment 36.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 36.0.0",
+ "pallet-treasury 35.0.0",
+ "pallet-utility 36.0.0",
+ "pallet-vesting 36.0.0",
+ "pallet-whitelist 35.0.0",
+ "pallet-xcm 15.0.0",
+ "pallet-xcm-benchmarks 15.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
- "rustc-hex",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
+ "polkadot-runtime-common 15.0.0",
+ "polkadot-runtime-parachains 15.0.1",
  "scale-info",
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-authority-discovery",
- "sp-block-builder",
- "sp-consensus-babe",
- "sp-consensus-beefy",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-mmr-primitives",
- "sp-npos-elections",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-staking",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-authority-discovery 33.0.0",
+ "sp-block-builder 33.0.0",
+ "sp-consensus-babe 0.39.0",
+ "sp-consensus-beefy 20.0.0",
+ "sp-core 34.0.0",
+ "sp-genesis-builder 0.14.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
+ "sp-mmr-primitives 33.0.0",
+ "sp-npos-elections 33.0.0",
+ "sp-offchain 33.0.0",
+ "sp-runtime 38.0.1",
+ "sp-session 34.0.0",
+ "sp-staking 33.0.0",
  "sp-std",
- "sp-storage",
- "sp-transaction-pool",
- "sp-version",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
- "substrate-wasm-builder",
+ "sp-storage 21.0.0",
+ "sp-transaction-pool 33.0.0",
+ "sp-version 36.0.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
+ "staging-xcm-executor 15.0.0",
+ "substrate-wasm-builder 23.0.0",
  "westend-runtime-constants",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "westend-runtime-constants"
-version = "8.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b080c193714605ce1033311d85035247adca170181cd68a3ad7e3ca87755a14"
+checksum = "8c7a91c27c398b11f7633cc2382cbba53b02e7196ebe8fff13c170e54a54e9d8"
 dependencies = [
- "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "frame-support 36.0.1",
+ "polkadot-primitives 14.0.0",
+ "polkadot-runtime-common 15.0.0",
  "smallvec",
- "sp-core",
- "sp-runtime",
- "sp-weights",
- "staging-xcm",
- "staging-xcm-builder",
+ "sp-core 34.0.0",
+ "sp-runtime 38.0.1",
+ "sp-weights 31.0.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-builder 15.0.0",
 ]
 
 [[package]]
@@ -15299,6 +18986,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -15538,17 +19240,6 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
@@ -15561,17 +19252,33 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
 dependencies = [
- "asn1-rs",
- "base64 0.13.1",
+ "asn1-rs 0.5.2",
  "data-encoding",
- "der-parser",
+ "der-parser 8.2.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.6.1",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.7.0",
  "rusticata-macros",
  "thiserror",
  "time",
@@ -15579,37 +19286,37 @@ dependencies = [
 
 [[package]]
 name = "xcm-emulator"
-version = "0.6.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b49681988880dd6d08a4d5f6b7cb612a0f12172270349655c1e2f870b3526fd"
+checksum = "be630e9b41c5d19d227162afe4cf642be24058b179fb1edbfe132f6328c7bde8"
 dependencies = [
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-pallet-parachain-system 0.15.0",
+ "cumulus-pallet-xcmp-queue 0.15.0",
+ "cumulus-primitives-core 0.14.0",
+ "cumulus-primitives-parachain-inherent 0.14.0",
  "cumulus-test-relay-sproof-builder",
- "frame-support",
- "frame-system",
+ "frame-support 36.0.1",
+ "frame-system 36.0.0",
  "impl-trait-for-tuples",
  "lazy_static",
  "log",
- "pallet-balances",
- "pallet-message-queue",
- "parachains-common",
+ "pallet-balances 37.0.0",
+ "pallet-message-queue 39.0.0",
+ "parachains-common 15.0.0",
  "parity-scale-codec",
  "paste",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
- "polkadot-runtime-parachains",
- "sp-arithmetic",
- "sp-core",
+ "polkadot-parachain-primitives 13.0.0",
+ "polkadot-primitives 14.0.0",
+ "polkadot-runtime-parachains 15.0.1",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-io",
- "sp-runtime",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
- "sp-tracing",
- "staging-xcm",
- "staging-xcm-executor",
+ "sp-tracing 17.0.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-executor 15.0.0",
 ]
 
 [[package]]
@@ -15625,15 +19332,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "yamux"
-version = "0.10.2"
+name = "xcm-procedural"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
+checksum = "87fb4f14094d65c500a59bcf540cf42b99ee82c706edd6226a92e769ad60563e"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "xcm-runtime-apis"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30fffcd9128a46abd836c37dd001c2cbe122aeb8904cd7b9bac8358564fb7b56"
+dependencies = [
+ "frame-support 36.0.1",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 33.0.0",
+ "sp-std",
+ "sp-weights 31.0.0",
+ "staging-xcm 14.1.0",
+ "staging-xcm-executor 15.0.0",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539a77ee7c0de333dcc6da69b177380a0b81e0dacfa4f7344c465a36871ee601"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
+name = "yamux"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
+ "pin-project",
  "rand",
  "static_assertions",
 ]
@@ -15669,9 +19420,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,18 +22,19 @@ members = [
     "integration-tests",
     "primitives",
 ]
-exclude = [
-    "pop-api",
-    "tests/contracts"
-]
+exclude = ["pop-api", "tests/contracts"]
 
 resolver = "2"
 
 [workspace.dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+] }
 hex-literal = "0.4.1"
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = [
+    "derive",
+] }
 smallvec = "1.11.0"
 serde = "1.0.195"
 clap = { version = "4.4.18", features = ["derive"] }
@@ -46,117 +47,121 @@ subxt-signer = "0.34.0"
 tokio = { version = "1.36", features = ["macros", "time", "rt-multi-thread"] }
 
 # Build
-substrate-wasm-builder = "18.0.1"
+substrate-wasm-builder = "23.0.0"
 substrate-build-script-utils = "11.0.0"
 
 # Local
-pop-runtime-devnet = { path = "runtime/devnet", default-features = true, features = ["experimental"] } # default-features=true required for `-p pop-node` builds
-pop-runtime-testnet = { path = "runtime/testnet", default-features = true, features = ["experimental"] } # default-features=true required for `-p pop-node` builds
+pop-runtime-devnet = { path = "runtime/devnet", default-features = true, features = [
+    "experimental",
+] } # default-features=true required for `-p pop-node` builds
+pop-runtime-testnet = { path = "runtime/testnet", default-features = true, features = [
+    "experimental",
+] } # default-features=true required for `-p pop-node` builds
 pop-runtime-common = { path = "runtime/common", default-features = false }
 pop-primitives = { path = "./primitives", default-features = false }
 
 # Substrate
-sc-basic-authorship = "0.35.0"
-sc-chain-spec = "28.0.0"
-sc-cli = "0.37.0"
-sc-client-api = "29.0.0"
-sc-offchain = "30.0.0"
-sc-consensus = "0.34.0"
-sc-executor = "0.33.0"
-sc-network = "0.35.0"
-sc-network-sync = "0.34.0"
-sc-rpc = "30.0.0"
-sc-service = "0.36.0"
-sc-sysinfo = "28.0.0"
-sc-telemetry = "16.0.0"
-sc-tracing = "29.0.0"
-sc-transaction-pool = "29.0.0"
-sc-transaction-pool-api = "29.0.0"
-frame-benchmarking = { version = "29.0.0", default-features = false }
-frame-benchmarking-cli = "33.0.0"
-frame-executive = { version = "29.0.0", default-features = false }
-frame-support = { version = "29.0.2", default-features = false }
-frame-system = { version = "29.0.0", default-features = false }
-frame-system-benchmarking = { version = "29.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "27.0.0", default-features = false }
-frame-try-runtime = { version = "0.35.0", default-features = false }
-pallet-aura = { version = "28.0.0", default-features = false }
-pallet-authorship = { version = "29.0.0", default-features = false }
-pallet-assets = { version = "30.0.0", default-features = false }
-pallet-balances = { version = "29.0.2", default-features = false }
-pallet-contracts = { version = "28.0.0", default-features = false }
-pallet-message-queue = { version = "32.0.0", default-features = false }
-pallet-multisig = { version = "29.0.0", default-features = false }
-pallet-nft-fractionalization = { version = "11.0.0", default-features = false }
-pallet-nfts = { version = "23.0.0", default-features = false }
-pallet-nfts-runtime-api = { version = "15.0.0", default-features = false }
-pallet-preimage = { version = "29.0.0", default-features = false }
-pallet-proxy = { version = "29.0.0", default-features = false }
-pallet-scheduler = { version = "30.0.0", default-features = false }
-pallet-session = { version = "29.0.0", default-features = false }
-pallet-sudo = { version = "29.0.0", default-features = false }
-pallet-timestamp = { version = "28.0.0", default-features = false }
-pallet-transaction-payment = { version = "29.0.2", default-features = false }
-pallet-transaction-payment-rpc = "31.0.0"
-pallet-transaction-payment-rpc-runtime-api = { version = "29.0.0", default-features = false }
-pallet-utility = { version = "29.0.0", default-features = false }
-sp-api = { version = "27.0.1", default-features = false }
-sp-authority-discovery = { version = "27.0.0", default-features = false }
-sp-block-builder = { version = "27.0.0", default-features = false }
-sp-blockchain = "29.0.0"
-sp-consensus-aura = { version = "0.33.0", default-features = false }
-sp-consensus-babe = { version = "0.33.0", default-features = false }
-sp-consensus-beefy = { version = "14.0.0", default-features = false }
-sp-consensus-grandpa = { version = "14.0.0", default-features = false }
-sp-core = { version = "29.0.0", default-features = false }
-sp-keystore = "0.35.0"
-sp-io = { version = "31.0.0", default-features = false }
-sp-genesis-builder = { version = "0.8.0", default-features = false }
-sp-inherents = { version = "27.0.0", default-features = false }
-sp-offchain = { version = "27.0.0", default-features = false }
-sp-runtime = { version = "32.0.0", default-features = false }
-sp-timestamp = "27.0.0"
-substrate-frame-rpc-system = "29.0.0"
+sc-basic-authorship = "0.42.0"
+sc-chain-spec = "35.0.0"
+sc-cli = "0.44.0"
+sc-client-api = "35.1.0"
+sc-offchain = "37.0.0"
+sc-consensus = "0.41.0"
+sc-executor = "0.39.0"
+sc-network = "0.42.0"
+sc-network-sync = "0.41.0"
+sc-rpc = "37.0.0"
+sc-service = "0.43.0"
+sc-sysinfo = "35.0.0"
+sc-telemetry = "22.0.0"
+sc-tracing = "35.0.0"
+sc-transaction-pool = "35.0.0"
+sc-transaction-pool-api = "35.0.0"
+frame-benchmarking = { version = "36.0.0", default-features = false }
+frame-benchmarking-cli = "40.0.0"
+frame-executive = { version = "36.0.0", default-features = false }
+frame-support = { version = "36.0.0", default-features = false }
+frame-system = { version = "36.0.0", default-features = false }
+frame-system-benchmarking = { version = "36.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "33.0.0", default-features = false }
+frame-try-runtime = { version = "0.42.0", default-features = false }
+pallet-aura = { version = "35.0.0", default-features = false }
+pallet-authorship = { version = "36.0.0", default-features = false }
+pallet-assets = { version = "37.0.0", default-features = false }
+pallet-balances = { version = "37.0.0", default-features = false }
+pallet-contracts = { version = "35.0.0", default-features = false }
+pallet-message-queue = { version = "39.0.0", default-features = false }
+pallet-multisig = { version = "36.0.0", default-features = false }
+pallet-nft-fractionalization = { version = "18.0.0", default-features = false }
+pallet-nfts = { version = "30.0.0", default-features = false }
+pallet-nfts-runtime-api = { version = "22.0.0", default-features = false }
+pallet-preimage = { version = "36.0.0", default-features = false }
+pallet-proxy = { version = "36.0.0", default-features = false }
+pallet-scheduler = { version = "37.0.0", default-features = false }
+pallet-session = { version = "36.0.0", default-features = false }
+pallet-sudo = { version = "36.0.0", default-features = false }
+pallet-timestamp = { version = "35.0.0", default-features = false }
+pallet-transaction-payment = { version = "36.0.0", default-features = false }
+pallet-transaction-payment-rpc = "38.0.0"
+pallet-transaction-payment-rpc-runtime-api = { version = "36.0.0", default-features = false }
+pallet-utility = { version = "36.0.0", default-features = false }
+sp-api = { version = "33.0.0", default-features = false }
+sp-authority-discovery = { version = "33.0.0", default-features = false }
+sp-block-builder = { version = "33.0.0", default-features = false }
+sp-blockchain = "35.1.0"
+sp-consensus-aura = { version = "0.39.0", default-features = false }
+sp-consensus-babe = { version = "0.39.0", default-features = false }
+sp-consensus-beefy = { version = "20.0.0", default-features = false }
+sp-consensus-grandpa = { version = "20.0.0", default-features = false }
+sp-core = { version = "34.0.0", default-features = false }
+sp-keystore = "0.40.0"
+sp-io = { version = "37.0.0", default-features = false }
+sp-genesis-builder = { version = "0.14.0", default-features = false }
+sp-inherents = { version = "33.0.0", default-features = false }
+sp-offchain = { version = "33.0.0", default-features = false }
+sp-runtime = { version = "38.0.0", default-features = false }
+sp-timestamp = "33.0.0"
+substrate-frame-rpc-system = "36.0.0"
 substrate-prometheus-endpoint = "0.17.0"
-sp-session = { version = "28.0.0", default-features = false }
+sp-session = { version = "34.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
-sp-transaction-pool = { version = "27.0.0", default-features = false }
-sp-version = { version = "30.0.0", default-features = false }
+sp-transaction-pool = { version = "33.0.0", default-features = false }
+sp-version = { version = "36.0.0", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "8.0.5", default-features = false }
-polkadot-cli = "8.0.0"
-polkadot-parachain-primitives = { version = "7.0.0", default-features = false }
-polkadot-runtime-parachains = { version = "8.0.3", default-features = false }
-polkadot-primitives = { version = "8.0.1", default-features = false }
-polkadot-runtime-common = { version = "8.0.3", default-features = false }
-xcm = { package = "staging-xcm", version = "8.0.1", default-features = false }
-xcm-builder = { package = "staging-xcm-builder", version = "8.0.3", default-features = false }
-xcm-executor = { package = "staging-xcm-executor", version = "8.0.2", default-features = false }
+pallet-xcm = { version = "15.0.0", default-features = false }
+polkadot-cli = "15.0.0"
+polkadot-parachain-primitives = { version = "13.0.0", default-features = false }
+polkadot-runtime-parachains = { version = "15.0.1", default-features = false }
+polkadot-primitives = { version = "14.0.0", default-features = false }
+polkadot-runtime-common = { version = "15.0.0", default-features = false }
+xcm = { version = "14.0.1", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "15.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "15.0.0", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-asset-test-utils = { version = "8.0.1", default-features = false }
-cumulus-pallet-aura-ext = { version = "0.8.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.8.1", default-features = false, features = ["parameterized-consensus-hook"] }
-cumulus-pallet-session-benchmarking = { version = "10.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.8.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.8.0", default-features = false }
-cumulus-primitives-aura = { version = "0.8.0", default-features = false }
-cumulus-primitives-core = { version = "0.8.0", default-features = false }
-cumulus-primitives-utility = { version = "0.8.1", default-features = false }
-emulated-integration-tests-common = { version = "4.0.0", default-features = false }
-pallet-collator-selection = { version = "10.0.3", default-features = false }
-parachains-common = { version = "8.0.1", default-features = false }
-parachain-info = { package = "staging-parachain-info", version = "0.8.0", default-features = false }
-cumulus-primitives-parachain-inherent = "0.8.0"
-cumulus-relay-chain-interface = "0.8.0"
+asset-test-utils = { version = "15.0.0", default-features = false }
+cumulus-pallet-aura-ext = { version = "0.15.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.15.0", default-features = false }
+cumulus-pallet-session-benchmarking = { version = "17.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.15.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.15.0", default-features = false }
+cumulus-primitives-aura = { version = "0.14.0", default-features = false }
+cumulus-primitives-core = { version = "0.14.0", default-features = false }
+cumulus-primitives-utility = { version = "0.15.0", default-features = false }
+emulated-integration-tests-common = { version = "11.0.0", default-features = false }
+pallet-collator-selection = { version = "17.0.0", default-features = false }
+parachains-common = { version = "15.0.0", default-features = false }
+parachain-info = { version = "0.15.0", package = "staging-parachain-info", default-features = false }
+cumulus-primitives-parachain-inherent = "0.14.0"
+cumulus-relay-chain-interface = "0.15.0"
 color-print = "0.3.4"
-cumulus-client-cli = "0.8.0"
-cumulus-client-collator = "0.8.0"
-cumulus-client-consensus-aura = "0.8.0"
-cumulus-client-consensus-common = "0.8.0"
-cumulus-client-consensus-proposer = "0.8.0"
-cumulus-client-service = "0.8.0"
+cumulus-client-cli = "0.15.0"
+cumulus-client-collator = "0.15.0"
+cumulus-client-consensus-aura = "0.15.0"
+cumulus-client-consensus-common = "0.15.0"
+cumulus-client-consensus-proposer = "0.14.0"
+cumulus-client-service = "0.15.0"
 
 # Paseo
 asset-hub-paseo-runtime = { git = "https://github.com/paseo-network/runtimes/", tag = "v1.2.5-system-chains", default-features = false }

--- a/runtime/devnet/Cargo.toml
+++ b/runtime/devnet/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "pop-runtime-devnet"
-version = "0.1.0"
 authors.workspace = true
 description.workspace = true
-license = "Unlicense"
-homepage.workspace = true
-repository.workspace = true
 edition.workspace = true
+homepage.workspace = true
+license = "Unlicense"
+name = "pop-runtime-devnet"
+repository.workspace = true
+version = "0.1.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -26,39 +26,39 @@ pop-primitives.workspace = true
 pop-runtime-common = { workspace = true, default-features = false }
 
 # Substrate
-frame-benchmarking.workspace = true
+frame-benchmarking = { optional = true, workspace = true }
 frame-executive.workspace = true
-frame-support.workspace = true
-frame-system.workspace = true
-frame-system-benchmarking.workspace = true
+frame-support = { workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
 frame-system-rpc-runtime-api.workspace = true
-frame-try-runtime.workspace = true
+frame-system.workspace = true
+frame-try-runtime = { optional = true, workspace = true }
+pallet-assets.workspace = true
 pallet-aura.workspace = true
 pallet-authorship.workspace = true
-pallet-assets.workspace = true
 pallet-balances.workspace = true
 pallet-contracts.workspace = true
 pallet-message-queue.workspace = true
 pallet-multisig.workspace = true
 pallet-nft-fractionalization.workspace = true
-pallet-nfts.workspace = true
 pallet-nfts-runtime-api.workspace = true
+pallet-nfts.workspace = true
+pallet-preimage.workspace = true
+pallet-proxy.workspace = true
 pallet-scheduler.workspace = true
 pallet-session.workspace = true
 pallet-sudo.workspace = true
-pallet-preimage.workspace = true
-pallet-proxy.workspace = true
 pallet-timestamp.workspace = true
-pallet-transaction-payment.workspace = true
 pallet-transaction-payment-rpc-runtime-api.workspace = true
+pallet-transaction-payment.workspace = true
 pallet-utility.workspace = true
 sp-api.workspace = true
-sp-io.workspace = true
 sp-block-builder.workspace = true
 sp-consensus-aura.workspace = true
 sp-core.workspace = true
 sp-genesis-builder.workspace = true
 sp-inherents.workspace = true
+sp-io.workspace = true
 sp-offchain.workspace = true
 sp-runtime.workspace = true
 sp-session.workspace = true
@@ -70,9 +70,9 @@ sp-version.workspace = true
 pallet-xcm.workspace = true
 polkadot-parachain-primitives.workspace = true
 polkadot-runtime-common.workspace = true
-xcm.workspace = true
 xcm-builder.workspace = true
 xcm-executor.workspace = true
+xcm.workspace = true
 
 # Cumulus
 cumulus-pallet-aura-ext.workspace = true
@@ -84,13 +84,13 @@ cumulus-primitives-aura.workspace = true
 cumulus-primitives-core.workspace = true
 cumulus-primitives-utility.workspace = true
 pallet-collator-selection.workspace = true
-parachains-common.workspace = true
 parachain-info.workspace = true
+parachains-common.workspace = true
 
 [dev-dependencies]
+enumflags2 = "0.7.9"
 env_logger = "0.11.2"
 hex = "0.4.3"
-enumflags2 = "0.7.9"
 
 [features]
 default = ["std"]
@@ -104,30 +104,30 @@ std = [
     "cumulus-primitives-aura/std",
     "cumulus-primitives-core/std",
     "cumulus-primitives-utility/std",
-    "frame-benchmarking/std",
+    "frame-benchmarking?/std",
     "frame-executive/std",
     "frame-support/std",
-    "frame-system-benchmarking/std",
+    "frame-system-benchmarking?/std",
     "frame-system-rpc-runtime-api/std",
     "frame-system/std",
     "frame-try-runtime/std",
     "log/std",
+    "pallet-assets/std",
     "pallet-aura/std",
     "pallet-authorship/std",
-    "pallet-assets/std",
     "pallet-balances/std",
     "pallet-collator-selection/std",
     "pallet-contracts/std",
     "pallet-message-queue/std",
     "pallet-multisig/std",
     "pallet-nft-fractionalization/std",
-    "pallet-nfts/std",
     "pallet-nfts-runtime-api/std",
+    "pallet-nfts/std",
+    "pallet-preimage/std",
+    "pallet-proxy/std",
     "pallet-scheduler/std",
     "pallet-session/std",
     "pallet-sudo/std",
-    "pallet-preimage/std",
-    "pallet-proxy/std",
     "pallet-timestamp/std",
     "pallet-transaction-payment-rpc-runtime-api/std",
     "pallet-transaction-payment/std",
@@ -140,12 +140,12 @@ std = [
     "pop-primitives/std",
     "scale-info/std",
     "sp-api/std",
-    "sp-io/std",
     "sp-block-builder/std",
     "sp-consensus-aura/std",
     "sp-core/std",
     "sp-genesis-builder/std",
     "sp-inherents/std",
+    "sp-io/std",
     "sp-offchain/std",
     "sp-runtime/std",
     "sp-session/std",
@@ -175,10 +175,10 @@ runtime-benchmarks = [
     "pallet-multisig/runtime-benchmarks",
     "pallet-nft-fractionalization/runtime-benchmarks",
     "pallet-nfts/runtime-benchmarks",
-    "pallet-scheduler/runtime-benchmarks",
-    "pallet-sudo/runtime-benchmarks",
     "pallet-preimage/runtime-benchmarks",
     "pallet-proxy/runtime-benchmarks",
+    "pallet-scheduler/runtime-benchmarks",
+    "pallet-sudo/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
     "pallet-utility/runtime-benchmarks",
     "pallet-xcm/runtime-benchmarks",
@@ -199,9 +199,9 @@ try-runtime = [
     "frame-support/try-runtime",
     "frame-system/try-runtime",
     "frame-try-runtime/try-runtime",
+    "pallet-assets/try-runtime",
     "pallet-aura/try-runtime",
     "pallet-authorship/try-runtime",
-    "pallet-assets/try-runtime",
     "pallet-balances/try-runtime",
     "pallet-collator-selection/try-runtime",
     "pallet-contracts/try-runtime",
@@ -209,11 +209,11 @@ try-runtime = [
     "pallet-multisig/try-runtime",
     "pallet-nft-fractionalization/try-runtime",
     "pallet-nfts/try-runtime",
+    "pallet-preimage/try-runtime",
+    "pallet-proxy/try-runtime",
     "pallet-scheduler/try-runtime",
     "pallet-session/try-runtime",
     "pallet-sudo/try-runtime",
-    "pallet-preimage/try-runtime",
-    "pallet-proxy/try-runtime",
     "pallet-timestamp/try-runtime",
     "pallet-transaction-payment/try-runtime",
     "pallet-utility/try-runtime",
@@ -223,4 +223,4 @@ try-runtime = [
     "sp-runtime/try-runtime",
 ]
 
-experimental = ["pallet-aura/experimental"]
+experimental = []

--- a/runtime/devnet/src/config/contracts.rs
+++ b/runtime/devnet/src/config/contracts.rs
@@ -6,7 +6,7 @@ use frame_support::{
 	parameter_types,
 	traits::{ConstBool, ConstU32, Randomness},
 };
-use frame_system::pallet_prelude::BlockNumberFor;
+use frame_system::{pallet_prelude::BlockNumberFor, EnsureSigned};
 
 pub enum AllowBalancesCall {}
 
@@ -87,4 +87,8 @@ impl pallet_contracts::Config for Runtime {
 	type Debug = ();
 	type Migrations = ();
 	type Xcm = pallet_xcm::Pallet<Self>;
+
+	type UploadOrigin = EnsureSigned<Self::AccountId>;
+	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
+	type ApiVersion = ();
 }

--- a/runtime/devnet/src/config/xcm.rs
+++ b/runtime/devnet/src/config/xcm.rs
@@ -152,6 +152,10 @@ impl xcm_executor::Config for XcmConfig {
 	type SafeCallFilter = Everything;
 	type Aliasers = Nothing;
 	type TransactionalProcessor = FrameTransactionalProcessor;
+	type HrmpNewChannelOpenRequestHandler = ();
+	type HrmpChannelAcceptedHandler = ();
+	type HrmpChannelClosingHandler = ();
+	type XcmRecorder = PolkadotXcm;
 }
 
 /// No local origins on this chain are allowed to dispatch XCM sends/executions.

--- a/runtime/devnet/src/extensions.rs
+++ b/runtime/devnet/src/extensions.rs
@@ -6,6 +6,7 @@ use frame_support::{
 use pallet_contracts::chain_extension::{
 	BufInBufOutState, ChainExtension, ChargedAmount, Environment, Ext, InitState, RetVal,
 };
+use pallet_contracts::WeightInfo;
 use pop_primitives::storage_keys::RuntimeStateKeys;
 use sp_core::crypto::UncheckedFrom;
 use sp_runtime::{traits::Dispatchable, DispatchError};
@@ -124,16 +125,14 @@ where
 	T: pallet_contracts::Config,
 	E: Ext<T = T>,
 {
-	let contract_host_weight = ContractSchedule::<T>::get().host_fn_weights;
-
 	// calculate weight for reading bytes of `len`
 	// reference: https://github.com/paritytech/polkadot-sdk/blob/117a9433dac88d5ac00c058c9b39c511d47749d2/substrate/frame/contracts/src/wasm/runtime.rs#L267
-	let base_weight: Weight = contract_host_weight.return_per_byte.saturating_mul(len.into());
+	let base_weight: Weight = T::WeightInfo::seal_return(len.into());
 
 	// debug_message weight is a good approximation of the additional overhead of going
 	// from contract layer to substrate layer.
 	// reference: https://github.com/paritytech/ink-examples/blob/b8d2caa52cf4691e0ddd7c919e4462311deb5ad0/psp22-extension/runtime/psp22-extension-example.rs#L236
-	let overhead = contract_host_weight.debug_message;
+	let overhead = T::WeightInfo::noop_host_fn(1);
 
 	let charged_weight = env.charge_weight(base_weight.saturating_add(overhead))?;
 	log::debug!(target: LOG_TARGET, "{} charged weight: {:?}", log_prefix, charged_weight);
@@ -173,10 +172,8 @@ where
 	let mut env = env.buf_in_buf_out();
 
 	// To be conservative, we charge the weight for reading the input bytes of a fixed-size type.
-	let base_weight: Weight = ContractSchedule::<T>::get()
-		.host_fn_weights
-		.return_per_byte
-		.saturating_mul(env.in_len().into());
+	let base_weight: Weight = T::WeightInfo::seal_return(env.in_len().into());
+
 	let charged_weight = env.charge_weight(base_weight)?;
 
 	log::debug!(target:LOG_TARGET, "{} charged weight: {:?}", LOG_PREFIX, charged_weight);

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "pop-runtime-testnet"
-version = "0.2.0"
 authors.workspace = true
 description.workspace = true
-license = "Unlicense"
-homepage.workspace = true
-repository.workspace = true
 edition.workspace = true
+homepage.workspace = true
+license = "Unlicense"
+name = "pop-runtime-testnet"
+repository.workspace = true
+version = "0.2.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -26,39 +26,39 @@ pop-primitives.workspace = true
 pop-runtime-common = { workspace = true, default-features = false }
 
 # Substrate
-frame-benchmarking.workspace = true
+frame-benchmarking = { optional = true, workspace = true }
 frame-executive.workspace = true
 frame-support.workspace = true
-frame-system.workspace = true
-frame-system-benchmarking.workspace = true
+frame-system-benchmarking = { optional = true, workspace = true }
 frame-system-rpc-runtime-api.workspace = true
+frame-system.workspace = true
 frame-try-runtime.workspace = true
+pallet-assets.workspace = true
 pallet-aura.workspace = true
 pallet-authorship.workspace = true
-pallet-assets.workspace = true
 pallet-balances.workspace = true
 pallet-contracts.workspace = true
 pallet-message-queue.workspace = true
 pallet-multisig.workspace = true
 pallet-nft-fractionalization.workspace = true
-pallet-nfts.workspace = true
 pallet-nfts-runtime-api.workspace = true
+pallet-nfts.workspace = true
+pallet-preimage.workspace = true
+pallet-proxy.workspace = true
 pallet-scheduler.workspace = true
 pallet-session.workspace = true
 pallet-sudo.workspace = true
-pallet-preimage.workspace = true
-pallet-proxy.workspace = true
 pallet-timestamp.workspace = true
-pallet-transaction-payment.workspace = true
 pallet-transaction-payment-rpc-runtime-api.workspace = true
+pallet-transaction-payment.workspace = true
 pallet-utility.workspace = true
 sp-api.workspace = true
-sp-io.workspace = true
 sp-block-builder.workspace = true
 sp-consensus-aura.workspace = true
 sp-core.workspace = true
 sp-genesis-builder.workspace = true
 sp-inherents.workspace = true
+sp-io.workspace = true
 sp-offchain.workspace = true
 sp-runtime.workspace = true
 sp-session.workspace = true
@@ -70,9 +70,9 @@ sp-version.workspace = true
 pallet-xcm.workspace = true
 polkadot-parachain-primitives.workspace = true
 polkadot-runtime-common.workspace = true
-xcm.workspace = true
 xcm-builder.workspace = true
 xcm-executor.workspace = true
+xcm.workspace = true
 
 # Cumulus
 cumulus-pallet-aura-ext.workspace = true
@@ -84,13 +84,13 @@ cumulus-primitives-aura.workspace = true
 cumulus-primitives-core.workspace = true
 cumulus-primitives-utility.workspace = true
 pallet-collator-selection.workspace = true
-parachains-common.workspace = true
 parachain-info.workspace = true
+parachains-common.workspace = true
 
 [dev-dependencies]
+enumflags2 = "0.7.9"
 env_logger = "0.11.2"
 hex = "0.4.3"
-enumflags2 = "0.7.9"
 
 [features]
 default = ["std"]
@@ -104,30 +104,30 @@ std = [
     "cumulus-primitives-aura/std",
     "cumulus-primitives-core/std",
     "cumulus-primitives-utility/std",
-    "frame-benchmarking/std",
+    "frame-benchmarking?/std",
     "frame-executive/std",
     "frame-support/std",
-    "frame-system-benchmarking/std",
+    "frame-system-benchmarking?/std",
     "frame-system-rpc-runtime-api/std",
     "frame-system/std",
     "frame-try-runtime/std",
     "log/std",
+    "pallet-assets/std",
     "pallet-aura/std",
     "pallet-authorship/std",
-    "pallet-assets/std",
     "pallet-balances/std",
     "pallet-collator-selection/std",
     "pallet-contracts/std",
     "pallet-message-queue/std",
     "pallet-multisig/std",
     "pallet-nft-fractionalization/std",
-    "pallet-nfts/std",
     "pallet-nfts-runtime-api/std",
+    "pallet-nfts/std",
+    "pallet-preimage/std",
+    "pallet-proxy/std",
     "pallet-scheduler/std",
     "pallet-session/std",
     "pallet-sudo/std",
-    "pallet-preimage/std",
-    "pallet-proxy/std",
     "pallet-timestamp/std",
     "pallet-transaction-payment-rpc-runtime-api/std",
     "pallet-transaction-payment/std",
@@ -140,12 +140,12 @@ std = [
     "pop-primitives/std",
     "scale-info/std",
     "sp-api/std",
-    "sp-io/std",
     "sp-block-builder/std",
     "sp-consensus-aura/std",
     "sp-core/std",
     "sp-genesis-builder/std",
     "sp-inherents/std",
+    "sp-io/std",
     "sp-offchain/std",
     "sp-runtime/std",
     "sp-session/std",
@@ -175,10 +175,10 @@ runtime-benchmarks = [
     "pallet-multisig/runtime-benchmarks",
     "pallet-nft-fractionalization/runtime-benchmarks",
     "pallet-nfts/runtime-benchmarks",
-    "pallet-scheduler/runtime-benchmarks",
-    "pallet-sudo/runtime-benchmarks",
     "pallet-preimage/runtime-benchmarks",
     "pallet-proxy/runtime-benchmarks",
+    "pallet-scheduler/runtime-benchmarks",
+    "pallet-sudo/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
     "pallet-utility/runtime-benchmarks",
     "pallet-xcm/runtime-benchmarks",
@@ -199,9 +199,9 @@ try-runtime = [
     "frame-support/try-runtime",
     "frame-system/try-runtime",
     "frame-try-runtime/try-runtime",
+    "pallet-assets/try-runtime",
     "pallet-aura/try-runtime",
     "pallet-authorship/try-runtime",
-    "pallet-assets/try-runtime",
     "pallet-balances/try-runtime",
     "pallet-collator-selection/try-runtime",
     "pallet-contracts/try-runtime",
@@ -209,11 +209,11 @@ try-runtime = [
     "pallet-multisig/try-runtime",
     "pallet-nft-fractionalization/try-runtime",
     "pallet-nfts/try-runtime",
+    "pallet-preimage/try-runtime",
+    "pallet-proxy/try-runtime",
     "pallet-scheduler/try-runtime",
     "pallet-session/try-runtime",
     "pallet-sudo/try-runtime",
-    "pallet-preimage/try-runtime",
-    "pallet-proxy/try-runtime",
     "pallet-timestamp/try-runtime",
     "pallet-transaction-payment/try-runtime",
     "pallet-utility/try-runtime",
@@ -223,4 +223,4 @@ try-runtime = [
     "sp-runtime/try-runtime",
 ]
 
-experimental = ["pallet-aura/experimental"]
+experimental = []

--- a/runtime/testnet/src/config/contracts.rs
+++ b/runtime/testnet/src/config/contracts.rs
@@ -6,7 +6,7 @@ use frame_support::{
 	parameter_types,
 	traits::{ConstBool, ConstU32, Randomness},
 };
-use frame_system::pallet_prelude::BlockNumberFor;
+use frame_system::{pallet_prelude::BlockNumberFor, EnsureSigned};
 
 pub enum AllowBalancesCall {}
 
@@ -87,4 +87,8 @@ impl pallet_contracts::Config for Runtime {
 	type Debug = ();
 	type Migrations = ();
 	type Xcm = pallet_xcm::Pallet<Self>;
+
+	type UploadOrigin = EnsureSigned<Self::AccountId>;
+	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
+	type ApiVersion = ();
 }

--- a/runtime/testnet/src/config/xcm.rs
+++ b/runtime/testnet/src/config/xcm.rs
@@ -152,6 +152,10 @@ impl xcm_executor::Config for XcmConfig {
 	type SafeCallFilter = Everything;
 	type Aliasers = Nothing;
 	type TransactionalProcessor = FrameTransactionalProcessor;
+	type HrmpNewChannelOpenRequestHandler = ();
+	type HrmpChannelAcceptedHandler = ();
+	type HrmpChannelClosingHandler = ();
+	type XcmRecorder = PolkadotXcm;
 }
 
 /// No local origins on this chain are allowed to dispatch XCM sends/executions.

--- a/runtime/testnet/src/extensions.rs
+++ b/runtime/testnet/src/extensions.rs
@@ -6,6 +6,7 @@ use frame_support::{
 use pallet_contracts::chain_extension::{
 	BufInBufOutState, ChainExtension, ChargedAmount, Environment, Ext, InitState, RetVal,
 };
+use pallet_contracts::WeightInfo;
 use pop_primitives::storage_keys::RuntimeStateKeys;
 use sp_core::crypto::UncheckedFrom;
 use sp_runtime::{traits::Dispatchable, DispatchError};
@@ -124,16 +125,14 @@ where
 	T: pallet_contracts::Config,
 	E: Ext<T = T>,
 {
-	let contract_host_weight = ContractSchedule::<T>::get().host_fn_weights;
-
 	// calculate weight for reading bytes of `len`
 	// reference: https://github.com/paritytech/polkadot-sdk/blob/117a9433dac88d5ac00c058c9b39c511d47749d2/substrate/frame/contracts/src/wasm/runtime.rs#L267
-	let base_weight: Weight = contract_host_weight.return_per_byte.saturating_mul(len.into());
+	let base_weight: Weight = T::WeightInfo::seal_return(len.into());
 
 	// debug_message weight is a good approximation of the additional overhead of going
 	// from contract layer to substrate layer.
 	// reference: https://github.com/paritytech/ink-examples/blob/b8d2caa52cf4691e0ddd7c919e4462311deb5ad0/psp22-extension/runtime/psp22-extension-example.rs#L236
-	let overhead = contract_host_weight.debug_message;
+	let overhead = T::WeightInfo::noop_host_fn(1);
 
 	let charged_weight = env.charge_weight(base_weight.saturating_add(overhead))?;
 	log::debug!(target: LOG_TARGET, "{} charged weight: {:?}", log_prefix, charged_weight);
@@ -173,10 +172,8 @@ where
 	let mut env = env.buf_in_buf_out();
 
 	// To be conservative, we charge the weight for reading the input bytes of a fixed-size type.
-	let base_weight: Weight = ContractSchedule::<T>::get()
-		.host_fn_weights
-		.return_per_byte
-		.saturating_mul(env.in_len().into());
+	let base_weight: Weight = T::WeightInfo::seal_return(env.in_len().into());
+
 	let charged_weight = env.charge_weight(base_weight)?;
 
 	log::debug!(target:LOG_TARGET, "{} charged weight: {:?}", LOG_PREFIX, charged_weight);

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -32,7 +32,7 @@ use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
 	construct_runtime, derive_impl,
 	dispatch::DispatchClass,
-	genesis_builder_helper::{build_config, create_default_config},
+	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
 	traits::{
 		fungible::HoldConsideration, tokens::nonfungibles_v2::Inspect, ConstBool, ConstU32,
@@ -403,6 +403,7 @@ impl pallet_message_queue::Config for Runtime {
 	type HeapSize = sp_core::ConstU32<{ 64 * 1024 }>;
 	type MaxStale = sp_core::ConstU32<8>;
 	type ServiceWeight = MessageQueueServiceWeight;
+	type IdleMaxServiceWeight = ();
 }
 
 impl cumulus_pallet_aura_ext::Config for Runtime {}
@@ -418,6 +419,8 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type ControllerOriginConverter = XcmOriginToTransactDispatchOrigin;
 	type WeightInfo = ();
 	type PriceForSiblingDelivery = NoPriceForMessageDelivery<ParaId>;
+	type MaxActiveOutboundChannels = ConstU32<128>;
+	type MaxPageSize = ConstU32<{ 1 << 16 }>;
 }
 
 parameter_types! {
@@ -447,7 +450,6 @@ impl pallet_aura::Config for Runtime {
 	// Note: SlotDuration potentially enabled here due to devnet runtime and Rust's feature
 	// unification, requiring the setting of a backwards compatible value.
 	// See https://github.com/paritytech/polkadot-sdk/blob/09df373db9cd5dfed82c5cdb0736d417d54249e6/substrate/frame/aura/src/lib.rs#L262
-	#[cfg(feature = "experimental")]
 	type SlotDuration = pallet_aura::MinimumPeriodTimesTwo<Runtime>;
 }
 
@@ -620,8 +622,7 @@ impl_runtime_apis! {
 		}
 
 		fn authorities() -> Vec<AuraId> {
-			Aura::authorities().into_inner()
-		}
+			pallet_aura::Authorities::<Runtime>::get().into_inner()		}
 	}
 
 	impl sp_api::Core<Block> for Runtime {
@@ -633,7 +634,7 @@ impl_runtime_apis! {
 			Executive::execute_block(block)
 		}
 
-		fn initialize_block(header: &<Block as BlockT>::Header) {
+		fn initialize_block(header: &<Block as BlockT>::Header) -> sp_runtime::ExtrinsicInclusionMode {
 			Executive::initialize_block(header)
 		}
 	}
@@ -947,12 +948,16 @@ impl_runtime_apis! {
 	}
 
 	impl sp_genesis_builder::GenesisBuilder<Block> for Runtime {
-		fn create_default_config() -> Vec<u8> {
-			create_default_config::<RuntimeGenesisConfig>()
+		fn build_state(config: Vec<u8>) -> sp_genesis_builder::Result {
+			build_state::<RuntimeGenesisConfig>(config)
 		}
 
-		fn build_config(config: Vec<u8>) -> sp_genesis_builder::Result {
-			build_config::<RuntimeGenesisConfig>(config)
+		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
+			get_preset::<RuntimeGenesisConfig>(id, |_| None)
+		}
+
+		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
+			Default::default()
 		}
 	}
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.77.0"
 components = ["rust-src", "rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Here is a demonstrative PR showing how uplifting runtimes is relatively easy. This is not a comprehensive PR and should not be treated as 100% accurate.

This does a jump of 7-versions. The changes in the runtime files are very minimal, mostly configuration changes, small changes to the runtime-apis. 

The most difficult change (which needs to be analyzed more closely) was with how pallet-contracts exposes host_fn_weights.

Only the runtimes build:
```
cargo build -p pop-runtime-devnet
cargo build -p pop-runtime-testnet
```

Updating the runtime took only 30 minutes excluding the chain extension change. This is because rust outputs very useful compiler errors for the runtime, which makes it super easy to spot what needs fixing.

The node however spits out a **large** wall of errors that take much more analysis. If this was an OmniNode, we would have to waste very little brain energy.
<img width="1469" alt="Screenshot 2024-08-09 at 2 54 32 PM" src="https://github.com/user-attachments/assets/68218869-5cc7-46da-8470-3f9e39547dd2">
