### PR TITLE
refactor: remove config and add generic extension type

### DIFF
--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -10,7 +10,7 @@ use constants::*;
 use frame_support::{
 	dispatch::{GetDispatchInfo, PostDispatchInfo},
 	pallet_prelude::*,
-	traits::{Contains, OriginTrait},
+	traits::OriginTrait,
 };
 use frame_system::RawOrigin;
 use pallet_contracts::chain_extension::{
@@ -23,13 +23,11 @@ use sp_std::vec::Vec;
 type ContractSchedule<T> = <T as pallet_contracts::Config>::Schedule;
 
 /// Handles the query from the chain extension environment for state reads.
-pub trait ReadState<T>
-where
-	T: frame_system::Config<
-		RuntimeCall: GetDispatchInfo + Dispatchable<PostInfo = PostDispatchInfo>,
-	>,
-{
+pub trait ReadState {
 	type StateQuery: Decode;
+
+	/// Allowed state queries from the API.
+	fn contains(c: &Self::StateQuery) -> bool;
 
 	/// Reads state using the provided query, returning the result as a byte vector.
 	fn read(read: Self::StateQuery) -> Vec<u8>;
@@ -40,18 +38,26 @@ where
 	}
 }
 
-#[derive(Default)]
-pub struct ApiExtension<S, A>(core::marker::PhantomData<(S, A)>);
+/// Handles the query from the chain extension environment for dispatch calls.
+pub trait CallFilter {
+	type Call: Decode;
 
-impl<T, S, A> ChainExtension<T> for ApiExtension<S, A>
+	/// Allowed runtime calls from the API.
+	fn contains(t: &Self::Call) -> bool;
+}
+
+#[derive(Default)]
+pub struct ApiExtension<I>(PhantomData<I>);
+
+impl<T, I> ChainExtension<T> for ApiExtension<I>
 where
 	T: pallet_contracts::Config
 		+ frame_system::Config<
 			RuntimeCall: GetDispatchInfo + Dispatchable<PostInfo = PostDispatchInfo>,
 		>,
 	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-	S: ReadState<T>,
-	A: Contains<<T as frame_system::Config>::RuntimeCall> + Contains<S::StateQuery> + 'static,
+	// Bound the type by the two traits which need to be implemented by the runtime.
+	I: ReadState + CallFilter<Call = <T as frame_system::Config>::RuntimeCall> + 'static,
 {
 	fn call<E: Ext<T = T>>(
 		&mut self,
@@ -78,15 +84,11 @@ where
 				log::debug!(target: LOG_TARGET, "Read input successfully");
 				match function_id {
 					FuncId::Dispatch => {
-						dispatch::<T, E, A>(&mut env, version, pallet_index, call_index, params)
+						dispatch::<T, E, I>(&mut env, version, pallet_index, call_index, params)
 					},
-					FuncId::ReadState => read_state::<T, E, S, A>(
-						&mut env,
-						version,
-						pallet_index,
-						call_index,
-						params,
-					),
+					FuncId::ReadState => {
+						read_state::<T, E, I>(&mut env, version, pallet_index, call_index, params)
+					},
 				}
 			},
 			Err(e) => Err(e),
@@ -115,21 +117,13 @@ fn extract_env<T, E: Ext<T = T>>(env: &Environment<E, BufInBufOutState>) -> (u8,
 	(version, function_id, pallet_index, call_index)
 }
 
-fn read_state<T, E, S, A>(
+fn read_state<T: frame_system::Config, E: Ext<T = T>, StateReader: ReadState>(
 	env: &mut Environment<E, BufInBufOutState>,
 	version: u8,
 	pallet_index: u8,
 	call_index: u8,
 	mut params: Vec<u8>,
-) -> Result<(), DispatchError>
-where
-	T: frame_system::Config<
-		RuntimeCall: GetDispatchInfo + Dispatchable<PostInfo = PostDispatchInfo>,
-	>,
-	E: Ext<T = T>,
-	S: ReadState<T>,
-	A: Contains<S::StateQuery>,
-{
+) -> Result<(), DispatchError> {
 	const LOG_PREFIX: &str = " read_state |";
 
 	// Prefix params with version, pallet, index to simplify decoding.
@@ -143,9 +137,9 @@ where
 	env.charge_weight(T::DbWeight::get().reads(1_u64))?;
 	let result = match version {
 		VersionedStateRead::V0 => {
-			let read = S::decode(&mut encoded_read)?;
-			ensure!(A::contains(&read), UNKNOWN_CALL_ERROR);
-			S::read(read)
+			let read = StateReader::decode(&mut encoded_read)?;
+			ensure!(StateReader::contains(&read), UNKNOWN_CALL_ERROR);
+			StateReader::read(read)
 		},
 	};
 	log::trace!(
@@ -155,7 +149,7 @@ where
 	env.write(&result, false, None)
 }
 
-fn dispatch<T, E, A>(
+fn dispatch<T, E, Filter>(
 	env: &mut Environment<E, BufInBufOutState>,
 	version: u8,
 	pallet_index: u8,
@@ -167,7 +161,7 @@ where
 		RuntimeCall: GetDispatchInfo + Dispatchable<PostInfo = PostDispatchInfo>,
 	>,
 	E: Ext<T = T>,
-	A: Contains<T::RuntimeCall> + 'static,
+	Filter: CallFilter<Call = <T as frame_system::Config>::RuntimeCall> + 'static,
 {
 	const LOG_PREFIX: &str = " dispatch |";
 
@@ -179,7 +173,7 @@ where
 	// Contract is the origin by default.
 	let origin: T::RuntimeOrigin = RawOrigin::Signed(env.ext().address().clone()).into();
 	match call {
-		VersionedDispatch::V0(call) => dispatch_call::<T, E, A>(env, call, origin, LOG_PREFIX),
+		VersionedDispatch::V0(call) => dispatch_call::<T, E, Filter>(env, call, origin, LOG_PREFIX),
 	}
 }
 
@@ -188,7 +182,7 @@ fn decode_checked<T: Decode>(params: &mut &[u8]) -> Result<T, DispatchError> {
 	T::decode(params).map_err(|_| DECODING_FAILED_ERROR)
 }
 
-fn dispatch_call<T, E, A>(
+fn dispatch_call<T, E, Filter>(
 	env: &mut Environment<E, BufInBufOutState>,
 	call: T::RuntimeCall,
 	mut origin: T::RuntimeOrigin,
@@ -199,11 +193,11 @@ where
 		RuntimeCall: GetDispatchInfo + Dispatchable<PostInfo = PostDispatchInfo>,
 	>,
 	E: Ext<T = T>,
-	A: Contains<T::RuntimeCall> + 'static,
+	Filter: CallFilter<Call = <T as frame_system::Config>::RuntimeCall> + 'static,
 {
 	let charged_dispatch_weight = env.charge_weight(call.get_dispatch_info().weight)?;
 	log::debug!(target:LOG_TARGET, "{} Inputted RuntimeCall: {:?}", log_prefix, call);
-	origin.add_filter(A::contains);
+	origin.add_filter(Filter::contains);
 	match call.dispatch(origin) {
 		Ok(info) => {
 			log::debug!(target:LOG_TARGET, "{} success, actual weight: {:?}", log_prefix, info.actual_weight);

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -169,7 +169,7 @@ where
 	params.insert(0, version);
 	params.insert(1, pallet_index);
 	params.insert(2, call_index);
-	let call = decode_checked::<VersionedDispatch<T>>(&mut &params[..])?;
+	let call = decode_checked::<VersionedDispatch<T::RuntimeCall>>(&mut &params[..])?;
 	// Contract is the origin by default.
 	let origin: T::RuntimeOrigin = RawOrigin::Signed(env.ext().address().clone()).into();
 	match call {
@@ -224,12 +224,10 @@ enum VersionedStateRead {
 
 /// Wrapper to enable versioning of runtime calls.
 #[derive(Decode, Debug)]
-enum VersionedDispatch<
-	T: frame_system::Config<RuntimeCall: GetDispatchInfo + Dispatchable<PostInfo = PostDispatchInfo>>,
-> {
+enum VersionedDispatch<RuntimeCall: Decode> {
 	/// Version zero of dispatch calls.
 	#[codec(index = 0)]
-	V0(T::RuntimeCall),
+	V0(RuntimeCall),
 }
 
 /// Function identifiers used in the Pop API.

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -22,7 +22,7 @@ use sp_std::vec::Vec;
 
 type ContractSchedule<T> = <T as pallet_contracts::Config>::Schedule;
 
-/// Trait for handling parameters from the chain extension environment during state read operations.
+/// Handles the query from the chain extension environment for state reads.
 pub trait ReadState<T>
 where
 	T: frame_system::Config<
@@ -31,9 +31,11 @@ where
 {
 	type StateQuery: Decode;
 
+	/// Reads state using the provided query, returning the result as a byte vector.
 	fn read(read: Self::StateQuery) -> Vec<u8>;
 
-	fn unpack(params: &mut &[u8]) -> Result<Self::StateQuery, DispatchError> {
+	/// Decodes parameters into state query.
+	fn decode(params: &mut &[u8]) -> Result<Self::StateQuery, DispatchError> {
 		decode_checked(params)
 	}
 }
@@ -141,7 +143,7 @@ where
 	env.charge_weight(T::DbWeight::get().reads(1_u64))?;
 	let result = match version {
 		VersionedStateRead::V0 => {
-			let read = S::unpack(&mut encoded_read)?;
+			let read = S::decode(&mut encoded_read)?;
 			ensure!(A::contains(&read), UNKNOWN_CALL_ERROR);
 			S::read(read)
 		},

--- a/runtime/devnet/src/config/api.rs
+++ b/runtime/devnet/src/config/api.rs
@@ -1,7 +1,6 @@
 use crate::{config::assets::TrustBackedAssetsInstance, fungibles, Runtime, RuntimeCall};
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::traits::Contains;
-use pop_chain_extension::ReadState;
+use pop_chain_extension::{CallFilter, ReadState};
 use sp_std::vec::Vec;
 
 /// A query of runtime state.
@@ -13,11 +12,24 @@ pub enum RuntimeRead {
 	Fungibles(fungibles::Read<Runtime>),
 }
 
-/// A struct that provides a state reading implementation for the Runtime.
+/// A struct that implement requirements for the Pop API chain extension.
 #[derive(Default)]
-pub struct StateReader;
-impl ReadState<Runtime> for StateReader {
+pub struct Extension;
+impl ReadState for Extension {
 	type StateQuery = RuntimeRead;
+
+	fn contains(c: &Self::StateQuery) -> bool {
+		use fungibles::Read::*;
+		matches!(
+			c,
+			RuntimeRead::Fungibles(
+				TotalSupply(..)
+					| BalanceOf { .. } | Allowance { .. }
+					| TokenName(..) | TokenSymbol(..)
+					| TokenDecimals(..) | AssetExists(..)
+			)
+		)
+	}
 
 	fn read(read: RuntimeRead) -> Vec<u8> {
 		match read {
@@ -26,13 +38,10 @@ impl ReadState<Runtime> for StateReader {
 	}
 }
 
-/// A type to identify allowed calls to the Runtime from the API.
-#[derive(Default)]
-pub struct AllowedApiCalls;
+impl CallFilter for Extension {
+	type Call = RuntimeCall;
 
-impl Contains<RuntimeCall> for AllowedApiCalls {
-	/// Allowed runtime calls from the API.
-	fn contains(c: &RuntimeCall) -> bool {
+	fn contains(c: &Self::Call) -> bool {
 		use fungibles::Call::*;
 		matches!(
 			c,
@@ -45,22 +54,6 @@ impl Contains<RuntimeCall> for AllowedApiCalls {
 					| start_destroy { .. }
 					| clear_metadata { .. }
 					| mint { .. } | burn { .. }
-			)
-		)
-	}
-}
-
-impl Contains<RuntimeRead> for AllowedApiCalls {
-	/// Allowed state queries from the API.
-	fn contains(c: &RuntimeRead) -> bool {
-		use fungibles::Read::*;
-		matches!(
-			c,
-			RuntimeRead::Fungibles(
-				TotalSupply(..)
-					| BalanceOf { .. } | Allowance { .. }
-					| TokenName(..) | TokenSymbol(..)
-					| TokenDecimals(..) | AssetExists(..)
 			)
 		)
 	}

--- a/runtime/devnet/src/config/api.rs
+++ b/runtime/devnet/src/config/api.rs
@@ -14,8 +14,11 @@ pub enum RuntimeRead {
 }
 
 /// A struct that provides a state reading implementation for the Runtime.
+#[derive(Default)]
 pub struct StateReader;
 impl ReadState<Runtime> for StateReader {
+	type StateQuery = RuntimeRead;
+
 	fn read(read: RuntimeRead) -> Vec<u8> {
 		match read {
 			RuntimeRead::Fungibles(key) => fungibles::Pallet::read_state(key),
@@ -24,6 +27,7 @@ impl ReadState<Runtime> for StateReader {
 }
 
 /// A type to identify allowed calls to the Runtime from the API.
+#[derive(Default)]
 pub struct AllowedApiCalls;
 
 impl Contains<RuntimeCall> for AllowedApiCalls {

--- a/runtime/devnet/src/config/contracts.rs
+++ b/runtime/devnet/src/config/contracts.rs
@@ -1,4 +1,4 @@
-use super::api::{AllowedApiCalls, RuntimeRead, StateReader};
+use super::api::Extension;
 use crate::{
 	deposit, Balance, Balances, BalancesCall, Perbill, Runtime, RuntimeCall, RuntimeEvent,
 	RuntimeHoldReason, Timestamp,
@@ -64,7 +64,7 @@ impl pallet_contracts::Config for Runtime {
 	type CallStack = [pallet_contracts::Frame<Self>; 23];
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
 	type WeightInfo = pallet_contracts::weights::SubstrateWeight<Self>;
-	type ChainExtension = pop_chain_extension::ApiExtension<StateReader, AllowedApiCalls>;
+	type ChainExtension = pop_chain_extension::ApiExtension<Extension>;
 	type Schedule = Schedule;
 	type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
 	// This node is geared towards development and testing of contracts.

--- a/runtime/devnet/src/config/contracts.rs
+++ b/runtime/devnet/src/config/contracts.rs
@@ -45,12 +45,6 @@ parameter_types! {
 	pub const CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);
 }
 
-impl pop_chain_extension::Config for Runtime {
-	type RuntimeRead = RuntimeRead;
-	type StateReader = StateReader;
-	type AllowedApiCalls = AllowedApiCalls;
-}
-
 impl pallet_contracts::Config for Runtime {
 	type Time = Timestamp;
 	type Randomness = DummyRandomness<Self>;
@@ -70,7 +64,7 @@ impl pallet_contracts::Config for Runtime {
 	type CallStack = [pallet_contracts::Frame<Self>; 23];
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
 	type WeightInfo = pallet_contracts::weights::SubstrateWeight<Self>;
-	type ChainExtension = pop_chain_extension::ApiExtension;
+	type ChainExtension = pop_chain_extension::ApiExtension<StateReader, AllowedApiCalls>;
 	type Schedule = Schedule;
 	type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
 	// This node is geared towards development and testing of contracts.


### PR DESCRIPTION
Alternative design of the PR: https://github.com/r0gue-io/pop-node/pull/163
- Removing the `Config` trait so there is no relationship between the `Runtime` and the extension. 
- Types need to be passed to the generic extension type `ApiExtension`. 
This alternative approach removes all the connections with the `Runtime`, every configuration will be on the level of the `ApiExtension`