### PR TITLE
chore: upgrade to 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
  "sp-runtime 32.0.0",
  "sp-session 28.0.0",
  "sp-std",
- "sp-storage",
+ "sp-storage 20.0.0",
  "sp-transaction-pool 27.0.0",
  "sp-version 30.0.0",
  "sp-weights 28.0.0",
@@ -519,33 +519,33 @@ dependencies = [
 
 [[package]]
 name = "asset-test-utils"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c81733430dbb312765566043bcb2c022dbb7492bacbe67018c630dbce753936"
+checksum = "d2e1d4077fc518abe25e26f3963a080686cabecb97f192d9124be3e04cc21cad"
 dependencies = [
- "cumulus-pallet-parachain-system 0.10.0",
- "cumulus-pallet-xcmp-queue 0.10.0",
- "cumulus-primitives-core 0.10.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "pallet-assets 32.0.0",
- "pallet-balances 31.0.0",
- "pallet-collator-selection 12.0.1",
- "pallet-session 31.0.0",
- "pallet-timestamp 30.0.0",
- "pallet-xcm 10.0.1",
- "pallet-xcm-bridge-hub-router 0.8.0",
- "parachains-common 10.0.0",
+ "cumulus-pallet-parachain-system 0.11.0",
+ "cumulus-pallet-xcmp-queue 0.11.0",
+ "cumulus-primitives-core 0.11.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "pallet-assets 33.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-collator-selection 13.0.1",
+ "pallet-session 32.0.0",
+ "pallet-timestamp 31.0.0",
+ "pallet-xcm 11.0.0",
+ "pallet-xcm-bridge-hub-router 0.9.0",
+ "parachains-common 11.0.0",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "staging-parachain-info 0.10.0",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
- "staging-xcm-executor 10.0.0",
- "substrate-wasm-builder 20.0.0",
+ "staging-parachain-info 0.11.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
+ "staging-xcm-executor 11.0.0",
+ "substrate-wasm-builder 21.0.0",
 ]
 
 [[package]]
@@ -1143,19 +1143,19 @@ dependencies = [
 
 [[package]]
 name = "bp-header-chain"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "700fa6f4a3258a0eee471c7f70698c69d5b911d125f49f8139f0c61b7fdb6c9d"
+checksum = "7b4a86e6438700a4217675ef3088fb08694ab69b1bdce4124099b1dcff9a6ff8"
 dependencies = [
- "bp-runtime 0.10.0",
+ "bp-runtime 0.11.0",
  "finality-grandpa",
- "frame-support 31.0.0",
+ "frame-support 32.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-consensus-grandpa 16.0.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -1177,35 +1177,35 @@ dependencies = [
 
 [[package]]
 name = "bp-messages"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfb4d04936f86b63257d32b128b5e757de0273abf22794d3ae827323416e385"
+checksum = "e6a8b4356728ca03a8246104e320a2b1d7ba8c7fbd2917bf62395290f6ef2cc1"
 dependencies = [
- "bp-header-chain 0.10.0",
- "bp-runtime 0.10.0",
- "frame-support 31.0.0",
+ "bp-header-chain 0.11.0",
+ "bp-runtime 0.11.0",
+ "frame-support 32.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "bp-parachains"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0c940507c4db7652a660228daefd82317bf6cd8aacff33df9e6ac9c45371c2"
+checksum = "9d5a4983aec89871fe61f700cd4edaaf30288e7fbd927f7e4f879951f61569d4"
 dependencies = [
- "bp-header-chain 0.10.0",
- "bp-polkadot-core 0.10.0",
- "bp-runtime 0.10.0",
- "frame-support 31.0.0",
+ "bp-header-chain 0.11.0",
+ "bp-polkadot-core 0.11.0",
+ "bp-runtime 0.11.0",
+ "frame-support 32.0.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -1230,35 +1230,35 @@ dependencies = [
 
 [[package]]
 name = "bp-polkadot-core"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14dd5cfb1176aebe8d9dc0c42273f978f63a6137ff10709caf380219847c010"
+checksum = "54ef42ed5eb5ea249ee3f26f38ad114e379accfa1f2a8ee1ff87dc6bbc00b399"
 dependencies = [
- "bp-messages 0.10.0",
- "bp-runtime 0.10.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "bp-messages 0.11.0",
+ "bp-runtime 0.11.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "parity-util-mem",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "bp-relayers"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41101efa1afc121ed8f4b5b93c9ee28bdab3f912237103521eea67c164c86c20"
+checksum = "36f6f38407e79458fefb4c14a6f9f2cd9779b2dfeb3b11112e20902ee9dfea5f"
 dependencies = [
- "bp-messages 0.10.0",
- "bp-runtime 0.10.0",
- "frame-support 31.0.0",
+ "bp-messages 0.11.0",
+ "bp-runtime 0.11.0",
+ "frame-support 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -1288,12 +1288,12 @@ dependencies = [
 
 [[package]]
 name = "bp-runtime"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97193ef70796e6c3bb1e0de930d2174a07c7b8cb07f19eead5b5c3f56d6b7b9"
+checksum = "67f4b1696822790b449046bdb89c273852ef2201a046b64b24293871a953e5e3"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "hash-db",
  "impl-trait-for-tuples",
  "log",
@@ -1301,41 +1301,41 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie 33.0.0",
  "trie-db",
 ]
 
 [[package]]
 name = "bp-test-utils"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eac8331de5fc5e0012e3c5b0c245b9b6b33878edbe64cdfd133c2dce9443898"
+checksum = "c0462cedd4f4dba1dde9d296df6b0e128a61abecde6ff6efa3b122ee8ac2f811"
 dependencies = [
- "bp-header-chain 0.10.0",
+ "bp-header-chain 0.11.0",
  "bp-parachains",
- "bp-polkadot-core 0.10.0",
- "bp-runtime 0.10.0",
+ "bp-polkadot-core 0.11.0",
+ "bp-runtime 0.11.0",
  "ed25519-dalek",
  "finality-grandpa",
  "parity-scale-codec",
- "sp-application-crypto 33.0.0",
- "sp-consensus-grandpa 16.0.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie 33.0.0",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6663e0179d475e30cfcf28cf597cdc8f4bb1c2c39a557b4cbe0057db0657fb67"
+checksum = "192804908f1d3b7bfad12abce448fb3b7ec8dda765cac4a8d811fa75557e528f"
 dependencies = [
  "sp-std",
 ]
@@ -1354,50 +1354,50 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7366e856da4c5f49e1ef94c3ea401854fe52310696561e24b7509d2f963d7210"
+checksum = "063e9ce60db859f26172c1428b251e628751850e7862065104e750310c6afbad"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
 name = "bridge-runtime-common"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857eb39e46b6490b5b36e6485a1364907b767c917c8efe3c84456d6bc0a72b6"
+checksum = "9dde81c8af81ee9bdf0374010288cf03ff3ccd7f57802f24889884f73d0b3bd3"
 dependencies = [
- "bp-header-chain 0.10.0",
- "bp-messages 0.10.0",
+ "bp-header-chain 0.11.0",
+ "bp-messages 0.11.0",
  "bp-parachains",
- "bp-polkadot-core 0.10.0",
+ "bp-polkadot-core 0.11.0",
  "bp-relayers",
- "bp-runtime 0.10.0",
+ "bp-runtime 0.11.0",
  "bp-xcm-bridge-hub",
- "bp-xcm-bridge-hub-router 0.9.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "bp-xcm-bridge-hub-router 0.10.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "hash-db",
  "log",
  "pallet-bridge-grandpa",
  "pallet-bridge-messages",
  "pallet-bridge-parachains",
  "pallet-bridge-relayers",
- "pallet-transaction-payment 31.0.0",
- "pallet-utility 31.0.0",
+ "pallet-transaction-payment 32.0.0",
+ "pallet-utility 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api 29.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-trie 32.0.0",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
+ "sp-trie 33.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
 ]
 
 [[package]]
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b5137986e7a4374bf410e4e11ce02c9807c5d3200d590960056220963ecdbf"
+checksum = "b169c6bebaa58a8f0f2078747919ebd98df45d0d018a0f8caa66ec15e2ad43d4"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2107,55 +2107,55 @@ dependencies = [
  "sc-client-api",
  "sc-service",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "url",
 ]
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7dde39268c86d2975bdd608d114dd52cd8803618196bc7606e684b9090d24d"
+checksum = "9d1ffccac45cddcbb37b8c18283bd57638f648f725091d28c3ac3be515f8dd1d"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-core 0.11.0",
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-client-api",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-consensus",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fbbba68555835c2e2d7f1c17060d3cd6fafafdb16597a2e680e7376f71dec51"
+checksum = "c6d112f874c998d174f034532d238d5e0616c3455f8bf9bb5946c5617e7c7c0f"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-consensus-proposer",
  "cumulus-client-parachain-inherent",
- "cumulus-primitives-aura 0.10.0",
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-aura 0.11.0",
+ "cumulus-primitives-core 0.11.0",
  "cumulus-relay-chain-interface",
  "futures",
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-aura",
@@ -2163,73 +2163,73 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "schnellru",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-block-builder 29.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-block-builder 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura 0.35.0",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
- "sp-timestamp 29.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-timestamp 30.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6ff3972c798e87b918e3065d7b52aabb3fc871136b7dde7c708d20567b509f"
+checksum = "7b6fc5e8237ff0e649c24fb1c31407fddb05cdf4773f83ca2a7b497305ae19b0"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-core 0.11.0",
  "cumulus-relay-chain-interface",
  "dyn-clone",
  "futures",
  "log",
  "parity-scale-codec",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-babe",
  "schnellru",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.35.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-timestamp 29.0.0",
- "sp-trie 32.0.0",
+ "sp-consensus-slots 0.36.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-timestamp 30.0.0",
+ "sp-trie 33.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ff43b5735f8f1a306aa8c44d9efe5bb50c3a3b29afa18728e7a5321a6ba70"
+checksum = "2fb01ccc8275a4ded0caf788e561c7400e630585d34feec8a22700cbbe44f8bb"
 dependencies = [
  "anyhow",
  "async-trait",
- "cumulus-primitives-parachain-inherent 0.10.0",
+ "cumulus-primitives-parachain-inherent 0.11.0",
  "sp-consensus",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10d8141b3de22f002b94fafd9a372f351ee55ad41e1c40ad6534024f176f5bb"
+checksum = "0f70b5f3eb4385498880a74684be6bd17669f2a2b5c7db805eef16337af1d0cd"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2238,50 +2238,50 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-node-primitives",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebeda41b913144e0dbaf57a9537fed6f37ee14c5f31f1bd23808f87e8515ec7"
+checksum = "0a0342e88f2079d7b3287bd52b4e0f7885e563439ff2e8b8d36f99aa596b219e"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.10.0",
- "cumulus-primitives-parachain-inherent 0.10.0",
+ "cumulus-primitives-core 0.11.0",
+ "cumulus-primitives-parachain-inherent 0.11.0",
  "cumulus-relay-chain-interface",
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "sc-client-api",
  "scale-info",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-crypto-hashing",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-storage",
- "sp-trie 32.0.0",
+ "sp-storage 21.0.0",
+ "sp-trie 33.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf51e1e7cfe82e68a93a4f3221181f8258664f0c4113e4d7c846e449b3596f3"
+checksum = "e877fcdae06369ce17fd4d1fd0467d21b08338f7c944e225c5461472f54a166a"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-core 0.11.0",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
@@ -2289,34 +2289,34 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "rand",
  "sc-client-api",
  "sc-consensus",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb334fbaedca019671b900bba71fb7cf70244d9436a832b1c5d67491569359d"
+checksum = "920c64fd704a14c571b79f5d0f19dd2638240f6a9f633f02072a35ab30db3341"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core 0.10.0",
- "cumulus-primitives-proof-size-hostfunction 0.5.0",
+ "cumulus-primitives-core 0.11.0",
+ "cumulus-primitives-proof-size-hostfunction 0.6.0",
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
  "futures",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
@@ -2328,12 +2328,13 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-transaction-pool 29.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-transaction-pool 30.0.0",
 ]
 
 [[package]]
@@ -2357,20 +2358,20 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ec277f09a2c2b693bca6283eb6bc10aede2eaee43a7c395911235d8b632dab"
+checksum = "135b720fe4cd7d2e6282c0c13fbbcf68cd7dcb19d060b5032709c34582d574ad"
 dependencies = [
- "cumulus-pallet-parachain-system 0.10.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "pallet-aura 30.0.0",
- "pallet-timestamp 30.0.0",
+ "cumulus-pallet-parachain-system 0.11.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "pallet-aura 31.0.0",
+ "pallet-timestamp 31.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 33.0.0",
- "sp-consensus-aura 0.35.0",
- "sp-runtime 34.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -2412,37 +2413,37 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19c40a5d04f60562fb38195766104deeb8cec71c11ec77796ee9373cccdb325"
+checksum = "6b426ade835b03cb4eb0b7299a5918e96cb53ed0e38b0d07676be7ed8df772ff"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
- "cumulus-primitives-core 0.10.0",
- "cumulus-primitives-parachain-inherent 0.10.0",
- "cumulus-primitives-proof-size-hostfunction 0.5.0",
+ "cumulus-primitives-core 0.11.0",
+ "cumulus-primitives-parachain-inherent 0.11.0",
+ "cumulus-primitives-proof-size-hostfunction 0.6.0",
  "environmental",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-message-queue 34.0.0",
+ "pallet-message-queue 35.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-runtime-common 10.0.0",
- "polkadot-runtime-parachains 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-runtime-common 11.0.0",
+ "polkadot-runtime-parachains 11.0.0",
  "scale-info",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-trie 32.0.0",
- "sp-version 32.0.0",
- "staging-xcm 10.0.0",
+ "sp-trie 33.0.0",
+ "sp-version 33.0.0",
+ "staging-xcm 11.0.0",
  "trie-db",
 ]
 
@@ -2475,16 +2476,16 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c178666b3a6d0457cb85104475cc0be5f9908a98429710afd29fbd5984cb539"
+checksum = "63b08b5e3bba454f8eaa01a7507c1bacde9343a7a67fc20801e59e0c9c0ec9db"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "pallet-session 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "pallet-session 32.0.0",
  "parity-scale-codec",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -2507,19 +2508,19 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7610ae16cac552adc823ba68deb26e5d3a9de189ef79ae26c79e43ddcfeabef1"
+checksum = "7f14dc8bc002babf1596515a2f1c0158ddeccbf1ef7f5656fe71c8e1fa4bde55"
 dependencies = [
- "cumulus-primitives-core 0.10.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "cumulus-primitives-core 0.11.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "staging-xcm 10.0.0",
+ "staging-xcm 11.0.0",
 ]
 
 [[package]]
@@ -2550,28 +2551,28 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6614dcdbe6c24fcc8677bf158a8c627a3467d262acdc8a0e7d8a3d3d767a757c"
+checksum = "5810a98c95f4219d7dcd6bd89d0c149fc45162e7e0c335579ba5545ec4b9c216"
 dependencies = [
  "bounded-collections 0.2.0",
- "bp-xcm-bridge-hub-router 0.9.0",
- "cumulus-primitives-core 0.10.0",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "bp-xcm-bridge-hub-router 0.10.0",
+ "cumulus-primitives-core 0.11.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-message-queue 34.0.0",
+ "pallet-message-queue 35.0.0",
  "parity-scale-codec",
- "polkadot-runtime-common 10.0.0",
- "polkadot-runtime-parachains 10.0.0",
+ "polkadot-runtime-common 11.0.0",
+ "polkadot-runtime-parachains 11.0.0",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "staging-xcm 10.0.0",
- "staging-xcm-executor 10.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-executor 11.0.0",
 ]
 
 [[package]]
@@ -2591,16 +2592,16 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70d13f3fca1dfaeb868f4fff79c58fef8fa4f8e381a9002d93c50c23683abf"
+checksum = "ca5e91498fef0a7502070d55949b3413361060b1e0556592ed851f220f8aafb4"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 10.0.0",
- "polkadot-primitives 10.0.0",
- "sp-api 29.0.0",
- "sp-consensus-aura 0.35.0",
- "sp-runtime 34.0.0",
+ "polkadot-core-primitives 11.0.0",
+ "polkadot-primitives 11.0.0",
+ "sp-api 30.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -2624,20 +2625,20 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617d02361f5c7df87b6be98b4974241b6836fbaa7d9e786db80eb38bc8636751"
+checksum = "12a1b925068ede5dd9f571f3afcfca877b2f94f988d308d757224464a27bc6ce"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 10.0.0",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
+ "polkadot-core-primitives 11.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "scale-info",
- "sp-api 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-trie 32.0.0",
- "staging-xcm 10.0.0",
+ "sp-trie 33.0.0",
+ "staging-xcm 11.0.0",
 ]
 
 [[package]]
@@ -2658,18 +2659,18 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d64a55b7b9c3a945e543712630708f36407ab49ad8a2fa9f3d1404093a3e8e"
+checksum = "e01642f846368bd7305a2b9c9874a4280b5097c62c33da84b2048e2e3b38bb03"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-core 0.11.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
  "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie 33.0.0",
 ]
 
 [[package]]
@@ -2685,13 +2686,13 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764e27968dce7d5c455dbaf9ba81c037fc5690afc085aa4aa2a4cdfe53716b74"
+checksum = "3a9ce5326ecf86a75ee9a2d53ba8a6950f98d278a1cc88480f1dcbc90077d7dc"
 dependencies = [
- "sp-externalities 0.27.0",
- "sp-runtime-interface 26.0.0",
- "sp-trie 32.0.0",
+ "sp-externalities 0.28.0",
+ "sp-runtime-interface 27.0.0",
+ "sp-trie 33.0.0",
 ]
 
 [[package]]
@@ -2717,33 +2718,33 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beeca40e85d6da3751343a3fc8dd5b335c9a06ba9897a5b36f726d139b7646de"
+checksum = "6b02524805657a76fcca354c2a9466580d7f980a9a9616a4ac1cb91597d1f451"
 dependencies = [
- "cumulus-primitives-core 0.10.0",
- "frame-support 31.0.0",
+ "cumulus-primitives-core 0.11.0",
+ "frame-support 32.0.0",
  "log",
- "pallet-asset-conversion 13.0.0",
+ "pallet-asset-conversion 14.0.0",
  "parity-scale-codec",
- "polkadot-runtime-common 10.0.0",
- "polkadot-runtime-parachains 10.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "polkadot-runtime-common 11.0.0",
+ "polkadot-runtime-parachains 11.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
- "staging-xcm-executor 10.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
+ "staging-xcm-executor 11.0.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec58113249ac91ceb4da1c846f6474cd4b6616100d0b29a86845b177caad52f"
+checksum = "842505bb9820f5d3c7d2561ed9783cd495d3665729e42590b12641e73c69fcf5"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-core 0.11.0",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
@@ -2754,48 +2755,48 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-consensus",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb531263c11cfd73f17090106fff2385ca7b02b39102c367f4c13fb1251e9dd"
+checksum = "a457e637e70eccddfdd06feaf5736e3fa3fd9955ef2dc9ef696cdea640fc6e4c"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-core 0.11.0",
  "futures",
  "jsonrpsee-core",
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
- "sp-state-machine 0.38.0",
+ "sp-state-machine 0.39.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a416b2e6a5c99d78049b91425dbdb844f4351fd9fb61da47b70c2f90cf2ed4"
+checksum = "0f946e5e8f6199bad20b4e65b3e56fb6feeb3c59d50ede9909dcfa9c73697db2"
 dependencies = [
  "array-bytes 6.2.2",
  "async-trait",
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-core 0.11.0",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
  "futures",
  "parking_lot 0.12.1",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives 10.0.0",
+ "polkadot-core-primitives 11.0.0",
  "polkadot-network-bridge",
  "polkadot-node-collation-generation",
  "polkadot-node-core-chain-api",
@@ -2804,7 +2805,7 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "polkadot-service",
  "sc-authority-discovery",
  "sc-client-api",
@@ -2813,11 +2814,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.35.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2825,12 +2826,12 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e011f8da350318316e80356dca70bee537d8f8fb29bb99d1765348b0ab6f6d88"
+checksum = "b173a09d24c4ea2b6f90eb682276f844db7b180651f22a9e918f8bac0642075f"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-core 0.11.0",
  "cumulus-relay-chain-interface",
  "either",
  "futures",
@@ -2848,14 +2849,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api 29.0.0",
- "sp-authority-discovery 29.0.0",
- "sp-consensus-babe 0.35.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
- "sp-storage",
- "sp-version 32.0.0",
+ "sp-api 30.0.0",
+ "sp-authority-discovery 30.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-storage 21.0.0",
+ "sp-version 33.0.0",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2865,17 +2866,17 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e730a7524f50acb03c24476323c4dad35690baf85175ad0f91a2dffed85b39"
+checksum = "48f27d17ab307b0e255431fa21113f2aca1e0b27f54d272198972b29e2eeb88b"
 dependencies = [
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-core 0.11.0",
  "parity-scale-codec",
- "polkadot-primitives 10.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "polkadot-primitives 11.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie 33.0.0",
 ]
 
 [[package]]
@@ -3352,34 +3353,35 @@ dependencies = [
 
 [[package]]
 name = "emulated-integration-tests-common"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f0799ab64756b6751d3ebcb17a30c3ba756193b6c193d14783afb312a16322"
+checksum = "2117a0c89f2afd71f15eebe18f4b48790b675314426773ea282e9f3ff08e5afa"
 dependencies = [
  "asset-test-utils",
- "bp-messages 0.10.0",
+ "bp-messages 0.11.0",
  "bridge-runtime-common",
- "cumulus-pallet-parachain-system 0.10.0",
- "cumulus-pallet-xcmp-queue 0.10.0",
- "cumulus-primitives-core 0.10.0",
- "frame-support 31.0.0",
- "pallet-assets 32.0.0",
- "pallet-balances 31.0.0",
+ "cumulus-pallet-parachain-system 0.11.0",
+ "cumulus-pallet-xcmp-queue 0.11.0",
+ "cumulus-primitives-core 0.11.0",
+ "frame-support 32.0.0",
+ "pallet-assets 33.0.0",
+ "pallet-balances 33.0.0",
  "pallet-bridge-messages",
- "pallet-message-queue 34.0.0",
- "pallet-xcm 10.0.1",
- "parachains-common 10.0.0",
+ "pallet-message-queue 35.0.0",
+ "pallet-xcm 11.0.0",
+ "parachains-common 11.0.0",
  "parity-scale-codec",
  "paste",
- "polkadot-primitives 10.0.0",
- "polkadot-runtime-parachains 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
+ "polkadot-runtime-parachains 11.0.0",
  "sc-consensus-grandpa",
- "sp-authority-discovery 29.0.0",
- "sp-consensus-babe 0.35.0",
- "sp-consensus-beefy 16.0.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "staging-xcm 10.0.0",
+ "sp-authority-discovery 30.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-consensus-beefy 17.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "staging-xcm 11.0.0",
  "xcm-emulator",
 ]
 
@@ -3787,9 +3789,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fork-tree"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93d3f0315c2eccf23453609e0ab92fe7c6ad1ca8129bcaf80b9a08c8d7fc52b"
+checksum = "ad4cc2314d3be8b49c555f6a7e550f5559e73ffd6ef9690ffbd9a706774452e0"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3831,50 +3833,50 @@ dependencies = [
  "sp-runtime 32.0.0",
  "sp-runtime-interface 25.0.0",
  "sp-std",
- "sp-storage",
+ "sp-storage 20.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "frame-benchmarking"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fee087c6a7ddbc6dcfb6a6015d4b2787ecbb2113ed8b8bee8ff15f2bdf93f94"
+checksum = "7f6f8e21cbac73688175cf9b531ed1c3f6578420a0f6106282aa8e5ed6fe3347"
 dependencies = [
- "frame-support 31.0.0",
- "frame-support-procedural 26.0.1",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-support-procedural 27.0.0",
+ "frame-system 32.0.0",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-runtime-interface 26.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-runtime-interface 27.0.0",
  "sp-std",
- "sp-storage",
+ "sp-storage 21.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "35.0.1"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f1660c2e59d206386658ca7fa867c2ccdb44429cc8a5a16a2975a338aa7047"
+checksum = "1be33471ac5fa10ca585d3e06642cc8c754ecd9cb8a76905bf648cff17990e32"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.2",
  "chrono",
  "clap",
  "comfy-table",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "gethostname",
  "handlebars",
  "itertools 0.10.5",
@@ -3893,19 +3895,19 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-database",
- "sp-externalities 0.27.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
- "sp-storage",
- "sp-trie 32.0.0",
- "sp-wasm-interface",
+ "sp-externalities 0.28.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-storage 21.0.0",
+ "sp-trie 33.0.0",
+ "sp-wasm-interface 21.0.0",
  "thiserror",
  "thousands",
 ]
@@ -3942,19 +3944,19 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d651327ec98d12fbdb0d25346de929e3ea2ab8a1ef85570794d9d8d54f204f28"
+checksum = "9c897b912f222280123eedee768b172ed74600292dfbb22843c95c9177e97358"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-npos-elections 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-npos-elections 30.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -3974,27 +3976,27 @@ dependencies = [
  "sp-io 31.0.0",
  "sp-runtime 32.0.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d4502dd4218aaf90240527adb789b9620fcada2af76f4751a8a852583eb0c2"
+checksum = "2cbd97de3a8af65a9e1752b465fc19c7fe19c62ca1842ccec47f3002667c2172"
 dependencies = [
  "aquamarine 0.3.3",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "frame-try-runtime 0.37.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "frame-try-runtime 0.38.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
@@ -4027,9 +4029,9 @@ dependencies = [
 
 [[package]]
 name = "frame-remote-externalities"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c935bea33258c329e9ad4784a720aa4b1faff8c5af474f14e0898db11b7cb8ab"
+checksum = "8f4afeb0769c0ef010c0dcc681a60167692a1cd52f0c0729b327a4415facddc5"
 dependencies = [
  "futures",
  "indicatif",
@@ -4037,11 +4039,11 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "serde",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "spinners",
  "substrate-rpc-client",
  "tokio",
@@ -4079,12 +4081,12 @@ dependencies = [
  "sp-genesis-builder 0.8.0",
  "sp-inherents 27.0.0",
  "sp-io 31.0.0",
- "sp-metadata-ir",
+ "sp-metadata-ir 0.6.0",
  "sp-runtime 32.0.0",
  "sp-staking 27.0.0",
  "sp-state-machine 0.36.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 16.0.0",
  "sp-weights 28.0.0",
  "static_assertions",
  "tt-call",
@@ -4092,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81aecbbc1c62055e8ce472283bc655bf6c0f968a4d22d504bf6aad4ea44ccbc4"
+checksum = "97100a956a2cd152ad4e63a5ec7b5e58503653223a73fff6e916b910b37f12ed"
 dependencies = [
  "aquamarine 0.5.0",
  "array-bytes 6.2.2",
@@ -4102,7 +4104,7 @@ dependencies = [
  "docify",
  "environmental",
  "frame-metadata",
- "frame-support-procedural 26.0.1",
+ "frame-support-procedural 27.0.0",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -4113,21 +4115,21 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api 29.0.0",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
+ "sp-api 30.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder 0.10.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-metadata-ir",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
- "sp-state-machine 0.38.0",
+ "sp-genesis-builder 0.11.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-metadata-ir 0.7.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-tracing",
- "sp-weights 30.0.0",
+ "sp-tracing 17.0.0",
+ "sp-weights 31.0.0",
  "static_assertions",
  "tt-call",
 ]
@@ -4154,13 +4156,13 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "26.0.1"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732fa43a05789f4ffb96955017e40643199d586c3d211754df5824a195f4eab5"
+checksum = "7a74eda80052082e8acd36c7fa232569ce1f968c7ae2adc56d082039ac9d6ba4"
 dependencies = [
  "Inflector",
  "cfg-expr",
- "derive-syn-parse 0.1.5",
+ "derive-syn-parse 0.2.0",
  "expander 2.1.0",
  "frame-support-procedural-tools 11.0.1",
  "itertools 0.10.5",
@@ -4243,23 +4245,23 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7537b5e23f584bf54f26c6297e0260b54fac5298be43a115176a310f256a4ab"
+checksum = "562e02f5139f1beb0edd3cac2db3f974d98b7459342210d101f451d26886ca33"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 31.0.0",
+ "frame-support 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-version 32.0.0",
- "sp-weights 30.0.0",
+ "sp-version 33.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -4280,17 +4282,17 @@ dependencies = [
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6bd0f5700363a845d4c0f83ea3478cdfcfe404d08f35865b78ebc5d37c0a"
+checksum = "4976a4dfad8b4abff9dfc5e1a5bcdfa0452765f5c726805499ea30be0df4eaa4"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -4306,12 +4308,12 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae4e8decf1630ed6731e8912d1ed4ac3986d86c68f59580f2a9f61909150c41"
+checksum = "24451c0fef0c35c50bf577aadd16bb3c7b9eb74f12bb1708114d24c6f750e165"
 dependencies = [
  "parity-scale-codec",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
 ]
 
 [[package]]
@@ -4329,14 +4331,14 @@ dependencies = [
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad42234b76beabf35bbc9a54566f0060b8d3d4fe93726007f02896e8beb91e3"
+checksum = "883f2a531ab7857e8b4bb09997f1333635da1b5e627ac1651c16b5e5152d8fa3"
 dependencies = [
- "frame-support 31.0.0",
+ "frame-support 32.0.0",
  "parity-scale-codec",
- "sp-api 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -5146,29 +5148,29 @@ version = "0.0.0"
 dependencies = [
  "asset-hub-paseo-runtime",
  "asset-test-utils",
- "cumulus-primitives-core 0.10.0",
+ "cumulus-primitives-core 0.11.0",
  "emulated-integration-tests-common",
- "frame-support 31.0.0",
- "pallet-assets 32.0.0",
- "pallet-balances 31.0.0",
- "pallet-message-queue 34.0.0",
- "pallet-xcm 10.0.1",
+ "frame-support 32.0.0",
+ "pallet-assets 33.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-message-queue 35.0.0",
+ "pallet-xcm 11.0.0",
  "parity-scale-codec",
  "paseo-runtime",
  "paseo-runtime-constants",
- "polkadot-primitives 10.0.0",
- "polkadot-runtime-parachains 10.0.0",
+ "polkadot-primitives 11.0.0",
+ "polkadot-runtime-parachains 11.0.0",
  "pop-runtime-common",
  "pop-runtime-devnet",
- "sp-authority-discovery 29.0.0",
- "sp-consensus-aura 0.35.0",
- "sp-consensus-babe 0.35.0",
- "sp-consensus-beefy 16.0.0",
- "sp-consensus-grandpa 16.0.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "staging-xcm 10.0.0",
- "staging-xcm-executor 10.0.0",
+ "sp-authority-discovery 30.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-consensus-beefy 17.0.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-executor 11.0.0",
  "tracing-subscriber 0.3.18",
 ]
 
@@ -6361,38 +6363,38 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5265ecba4e5fc2c242798fc7795f6bf7ce7c9ab909ecea7df3f8242fa74af"
+checksum = "463f3038aebf0766b75c231e293293dec7b85f2358120a2696470159008ddfd2"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-beefy 16.0.0",
- "sp-core 31.0.0",
- "sp-mmr-primitives 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-beefy 17.0.0",
+ "sp-core 32.0.0",
+ "sp-mmr-primitives 30.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
 name = "mmr-rpc"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfab619df48bac956375483e4d57e995fbfaec310c86cfbc420e905506b67002"
+checksum = "d17ec87c5d04009e7d7b149abb2aa8495e2893c5920ce4a83679c76e5d6320f7"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-mmr-primitives 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-mmr-primitives 30.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
@@ -6953,20 +6955,20 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dbd5ff1c6f662d330beb109f6180ee66ed9cd7710cad28f3d15c444556fcce4"
+checksum = "a66fbfb4b9a3a6430f5925a09257c61a048bf0dfbad26f814e0f0e517f43c06a"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api 29.0.0",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-api 30.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7004,17 +7006,17 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-rate"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a492d16d0f7423cb2d7ca6fa6b4d423a4f4e2f67d2dc92d84d5988fcc33cfb"
+checksum = "a63f90c10e0746fce0512e37e1a354fe8c48f32e4e20211e0c1ac9b0e4b3febb"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7039,20 +7041,20 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf34819002b9d6c8d7a28d89207498f63288de6689061fe9c1fb7c55454ff8"
+checksum = "d27f76cc9151160c08fcee2e095b91048a2d1cb041b7c022a88f98ba220827b4"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "pallet-transaction-payment 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "pallet-transaction-payment 32.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7075,18 +7077,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805543c2ea1f10f14bc767f156b8ec80785345b683eaa59dea84d28745a87ee3"
+checksum = "eda0d9362dc1b75cead58f5e9a6004d305f81b2bf38c52e5454d1d868e2cc98f"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7110,19 +7112,19 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f1176f435a94b510b99bc2aaaa84788d60f8c5352c5f34f165b37523e448a1"
+checksum = "8cb27318bf97e8116b1383c726427ab8d6d9dac4da99c8540a247518398c2a55"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-timestamp 30.0.0",
+ "pallet-timestamp 31.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 33.0.0",
- "sp-consensus-aura 0.35.0",
- "sp-runtime 34.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7145,18 +7147,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "31.0.1"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9c124d86227da7ae9073cc2984c0384c7830f7fa61450c0990c56837335da2"
+checksum = "303077e7ec8808fdd9df22a6eaf9d38932a9b7df07c29423935384cf43babb2f"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "pallet-session 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "pallet-session 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 33.0.0",
- "sp-authority-discovery 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-authority-discovery 30.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7177,16 +7179,16 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168348a94c479b7da001b3f0d1100210704eda8ce72c58aac456f1d866d7d67"
+checksum = "f3544ca79d7b1f3b9a0efe6b54038143962e8b05d57a3a4172cd11e7216c43d6"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7217,26 +7219,26 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37353294183655c76cdc56ffc5edf777b1e2275af59ae73c8aa255b6d941b362"
+checksum = "ac02d082761843190fddfea58ce3a8cf042e92d2d78bb21426d2f960880a875c"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-authorship 31.0.0",
- "pallet-session 31.0.0",
- "pallet-timestamp 30.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-session 32.0.0",
+ "pallet-timestamp 31.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 33.0.0",
- "sp-consensus-babe 0.35.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-staking 29.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
@@ -7260,30 +7262,30 @@ dependencies = [
  "sp-io 31.0.0",
  "sp-runtime 32.0.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]
 name = "pallet-bags-list"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3f838e96a2cbd06731beb72b755ccc5bd05bcc696717a1148bdddfe9062e93"
+checksum = "664e6da2fe296a6597f2508f8754bfedaf06b5fc7bc657f7327b7d91896f84f7"
 dependencies = [
  "aquamarine 0.5.0",
  "docify",
- "frame-benchmarking 31.0.0",
- "frame-election-provider-support 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-election-provider-support 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-balances 31.0.0",
+ "pallet-balances 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
@@ -7305,18 +7307,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "31.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3565d525dd88e07da5b2309cd6ffe7447ddc5406eeaa2cb26157d35787a69a7"
+checksum = "b56b559fbf1b04e08f42b08c0cb133cf732b4b0cafd315a3a24ba1ae60669d7e"
 dependencies = [
  "docify",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7343,22 +7345,22 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1371a2f241fd33b794b0e824f28be9de76e7544a2602421e1c4a58cb0eccef6"
+checksum = "b36b750d43f02589284a26ae4bcdaa9cd957abd12ffcedccf5de7f3ede20e14e"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-authorship 31.0.0",
- "pallet-session 31.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-session 32.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-consensus-beefy 16.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-staking 29.0.0",
+ "sp-consensus-beefy 17.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
@@ -7390,27 +7392,27 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32a1e978b043f4bf7cfcdb130a51dda4dbade1de5b85d2d634082edbc08f9cb"
+checksum = "3a0ec062385375cee83f44985bf4d32c86e6ca4018e0a867b448a9a572896388"
 dependencies = [
  "array-bytes 6.2.2",
  "binary-merkle-tree 15.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-beefy 31.0.0",
- "pallet-mmr 30.0.0",
- "pallet-session 31.0.0",
+ "pallet-beefy 32.0.0",
+ "pallet-mmr 31.0.0",
+ "pallet-session 32.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 29.0.0",
- "sp-consensus-beefy 16.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-api 30.0.0",
+ "sp-consensus-beefy 17.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
 ]
 
@@ -7435,104 +7437,104 @@ dependencies = [
 
 [[package]]
 name = "pallet-bounties"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23273ffc30d94c725cb37ac1f45a40e308d8e8bfab251a299d4ed1fa9e8e46f"
+checksum = "fe92916d8bb2f2ce84195ae5e6baec83c5a65bf685613d7cc207f0b8fd26ea43"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-treasury 30.0.0",
+ "pallet-treasury 31.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-bridge-grandpa"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0034e29cd8f1547e0688ba3cb3a621c1dcb076c59f548eb40e0680ba37f14e7"
+checksum = "88e0f44b87681bafd9deec464b7f0d4f3c9b050b53ef1588eb5312d26ebc30a5"
 dependencies = [
- "bp-header-chain 0.10.0",
- "bp-runtime 0.10.0",
+ "bp-header-chain 0.11.0",
+ "bp-runtime 0.11.0",
  "bp-test-utils",
  "finality-grandpa",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-consensus-grandpa 16.0.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie 33.0.0",
 ]
 
 [[package]]
 name = "pallet-bridge-messages"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe205f990c97a766b317378617c3ac8548530e0e29011250ad4c669cf4d86773"
+checksum = "a9da377cff690ae52d872bdc6dd00ef7ebb3b2eb092ddacc2e26e9efb9f13631"
 dependencies = [
- "bp-messages 0.10.0",
- "bp-runtime 0.10.0",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "bp-messages 0.11.0",
+ "bp-runtime 0.11.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "num-traits",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-bridge-parachains"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4315c1346e60031afc119b051fbe9aa32c29143abb1b6b771d82c0e9fe5a4a8"
+checksum = "1c9e9466750027c10df653ac91eaaffe042d1f94dca5f561b6ea9f54f389d496"
 dependencies = [
- "bp-header-chain 0.10.0",
+ "bp-header-chain 0.11.0",
  "bp-parachains",
- "bp-polkadot-core 0.10.0",
- "bp-runtime 0.10.0",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "bp-polkadot-core 0.11.0",
+ "bp-runtime 0.11.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "pallet-bridge-grandpa",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie 33.0.0",
 ]
 
 [[package]]
 name = "pallet-bridge-relayers"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85310662790097b4f391b32822eb55d5088bc09ac91343d68e48e4fc582cb31"
+checksum = "9380cbce05df9451cb9b2149e1284090c0da3f3ab9615b8810b1cb0e2ab3aed5"
 dependencies = [
- "bp-messages 0.10.0",
+ "bp-messages 0.11.0",
  "bp-relayers",
- "bp-runtime 0.10.0",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "bp-runtime 0.11.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "pallet-bridge-messages",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 25.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7557,19 +7559,19 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b05f01c3d279cd661eba2c391844bac03fa5f979b9de821e6eb1cbe6069dfc"
+checksum = "c0d73ed3f977ca5874e32936f7605e83e96f7eb0cb7fca46b9a3f5a8df1933d5"
 dependencies = [
  "bitvec",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7595,21 +7597,21 @@ dependencies = [
 
 [[package]]
 name = "pallet-child-bounties"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f1f5d1f6420b72e7fff2fa9146f1f13f68e3a3d293b421d9b9d34ad0dfa134"
+checksum = "5612487abb09a9e5b6f3a694639fd0826a8b3bae1335047899f032f292f7f410"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-bounties 30.0.0",
- "pallet-treasury 30.0.0",
+ "pallet-bounties 31.0.0",
+ "pallet-treasury 31.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7636,72 +7638,73 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-selection"
-version = "12.0.1"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26edc27ed73c658e6f3d37b4cc8822be3f293e1f0dc58830b42c272781ac8a44"
+checksum = "7e0724831b2b1775542055c80918e78478953ee8d6777962a947404f22001c75"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-authorship 31.0.0",
- "pallet-balances 31.0.0",
- "pallet-session 31.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-session 32.0.0",
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-collective"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241ffbf21673fca6bf8caa2ee35088a18704b95d174e32280cb7569f58af7c61"
+checksum = "0f84d7ad169667bcf184da694db6322bd9a68d9d0bb05b2727005cfadd2b8a17"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-contracts"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a186a60e5b6f7927f8aa77e2fbd7b331b22ad8de870f261dc9d87627d21cbe3"
+checksum = "3ae7354ec341dbdd1df77fd0a55708fa49a164901db89920fdca4132f3991ee1"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 31.0.0",
+ "pallet-balances 33.0.0",
  "pallet-contracts-proc-macro",
  "pallet-contracts-uapi",
  "parity-scale-codec",
+ "paste",
  "rand",
  "rand_pcg",
  "scale-info",
  "serde",
  "smallvec",
- "sp-api 29.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
  "wasm-instrument",
  "wasmi",
 ]
@@ -7719,14 +7722,14 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-uapi"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2b8fce1fa76a3d59b49a532cb43de816f9e5c77dba87d9a7367d764a04e8d7"
+checksum = "2d7a51646d9ff1d91abd0186d2c074f0dfd3b1a2d55f08a229a2f2e4bc6d1e49"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
  "paste",
- "polkavm-derive 0.5.0",
+ "polkavm-derive",
  "scale-info",
 ]
 
@@ -7750,38 +7753,38 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51344679f168ecc258bf52d0a9578f6c3043e2aff4b9147004c7b8429460370"
+checksum = "43080685819927c77fb38dda17e593eab2478406d674dd8c69200129cf613e77"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-democracy"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1603fc7a149fd1f8bc43349035a69370a024acc95d6a10a37d3b9e1f22cc58ab"
+checksum = "83740afbabdabd41a9af23e1085db431b7d0aa10e542f6e1862aa14ff76eeec9"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -7811,26 +7814,26 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da78b2feeba1286b66ac20cbfbcd321fe9d1d2bc15e9e31292023e9a66dbb819"
+checksum = "fd4127300982c54fb31630a3a002daeb060556c0d0ca17031975fe25d613f432"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-election-provider-support 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-election-provider-support 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-election-provider-support-benchmarking 30.0.0",
+ "pallet-election-provider-support-benchmarking 31.0.0",
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-npos-elections 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-npos-elections 30.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "strum 0.24.1",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -7850,36 +7853,36 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b20f98b9a1497a59d2b0eca0051c5ada89851bf29b26fda3a2cfe934a32116"
+checksum = "8d47f77fc73b1caf6317515e884a1451786c8b71fddd910b753a73da7ee4fe84"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-election-provider-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-election-provider-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
- "sp-npos-elections 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-npos-elections 30.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de22659bdd6190e4f94936f0d338e67dde80e537fe22c30eb96ceab9f0d9914f"
+checksum = "08fe6701c248d87e489e998230180b112e639db09c0a50cf6e44cf399bc1028f"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-npos-elections 29.0.0",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-npos-elections 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
@@ -7905,21 +7908,21 @@ dependencies = [
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24717c932bd68705e3a5b6b9311a31e57b354274de1c373feb9ca920f6a3e439"
+checksum = "df2f9df9cbcba5c986e8abb00dc6184cacebcd96064f706bbd47c870255fa4f1"
 dependencies = [
  "docify",
- "frame-benchmarking 31.0.0",
- "frame-election-provider-support 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-election-provider-support 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
@@ -7949,25 +7952,25 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f8a78e4f5e2399596fa918f22e588e034d78c13a46925313abb4b152a9d919"
+checksum = "6beb51686baee78fc838861b825c1b8f1b66a7633dc502dc70da491aed82dcbb"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-authorship 31.0.0",
- "pallet-session 31.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-session 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 33.0.0",
- "sp-consensus-grandpa 16.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-staking 29.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
@@ -7991,19 +7994,19 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33bca13843a11add3909a8c4bffae547ba9fa3a11c07ac2f8afd670acd85cb15"
+checksum = "6c5e41c45a18b5e71b05fd5789b210ce79dbddd454e9bc783dd188790be99d91"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8030,22 +8033,22 @@ dependencies = [
 
 [[package]]
 name = "pallet-im-online"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cb6cbcef9e9ab68a5e79429a1f32ebc8114e4c9c2c2b0356c1db212e3e0bc2"
+checksum = "1c771c379dfa58623a6d88d021c7cebe1f9f4f4537155917f7a9c03b5b36c3ec"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-authorship 31.0.0",
+ "pallet-authorship 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 33.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
@@ -8069,37 +8072,37 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e23345544e9b6635d296195c355a768c82a9e1d82138378ef5b80102828664"
+checksum = "5b75dd0463b1ac775e8d154879e174e06fb8745b0896b8d9a3bd99d57135e914"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-keyring 34.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-keyring 35.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-membership"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bb958b03ec28b6e7e97abfca28acb1c1d8e91ad5194537f6550c348fc60f54"
+checksum = "b6d889d1ab1f8c78dddbe5aa107ae0004f066a79384af010e58539a71c84cbe1"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8126,23 +8129,23 @@ dependencies = [
 
 [[package]]
 name = "pallet-message-queue"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063b2e7912fbbe67985e68e460f2f242b90de48a63a1f03dd2ae022154ba25e9"
+checksum = "1bd58fa73c9e498414c9e6757f5ff1dbb81b9c7439231018c19aca99c35fd35b"
 dependencies = [
  "environmental",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-weights 30.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -8166,20 +8169,20 @@ dependencies = [
 
 [[package]]
 name = "pallet-mmr"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f5356b869f71205d53ed686846075ebb7d67824f334289ebbe6c61766c90c6"
+checksum = "cfe22ce913c1862862a7ce3180b1a52b544a04a629b92c6dff43c3975ee89d39"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-mmr-primitives 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-mmr-primitives 30.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8202,36 +8205,36 @@ dependencies = [
 
 [[package]]
 name = "pallet-multisig"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284ff5c6675ac6438c2f4a20d75627ad4b6d7c78bb5fd911198e34ce48bc7cf2"
+checksum = "57b3d75a9319f7bcb58920ecc087aa246cc4cac0bcf5c9f29bb44260315961db"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nft-fractionalization"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146f26bb84d332034fe4bb1d5938179b23bed20f8aaf3cf37c777014eb35cad6"
+checksum = "677e05e538410a056620e737a4b9c9073a2636fcaab99609a57d0c706af4b186"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-assets 32.0.0",
- "pallet-nfts 25.0.0",
+ "pallet-assets 33.0.0",
+ "pallet-nfts 26.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8256,20 +8259,20 @@ dependencies = [
 
 [[package]]
 name = "pallet-nfts"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fed85cb8969cfbbf7681f16bc2d240cf377af021046c5628d563c8ed041aa26"
+checksum = "190767bc88a1a23f51fccc445a271639fd5a88f1811291d801221e5b9b5b48cc"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8287,30 +8290,30 @@ dependencies = [
 
 [[package]]
 name = "pallet-nfts-runtime-api"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3881d652cf44b1cb8fb6f2b2b25a950338692c3d5f49c5e621a5cf9a1a88c76"
+checksum = "b086ef37b5a2ab6d9c67929bd26480dfc128023039f238f6bc2b25a7348c1232"
 dependencies = [
- "pallet-nfts 25.0.0",
+ "pallet-nfts 26.0.0",
  "parity-scale-codec",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nis"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948a11c933d345bfd7750e92b5650656e4d967f4fbcf7e36200ef7063985b9c6"
+checksum = "5f73f50b2cfeb31dad13e3bd628245bf9f2d8edc98ba3c7591c2f3303304a185"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8331,27 +8334,27 @@ dependencies = [
  "sp-runtime 32.0.0",
  "sp-staking 27.0.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781148c86c07aca84f471d06b449d7098e94d76bc08dd7e69bcb2572264d1b20"
+checksum = "e763dbe561c25187466eabb92d6193ad6098fb656a0dc807ebefbb237f903171"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-balances 31.0.0",
+ "pallet-balances 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
@@ -8377,22 +8380,22 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d267d96d52b7bb17b5bd1333375f86a58595a457218ddc82ddec32c194806713"
+checksum = "a563a0a45f55c747819f1220adc27e492c5c7040e3a4f597d6e0e959f9742aa1"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-election-provider-support 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "pallet-bags-list 30.0.0",
- "pallet-nomination-pools 28.0.0",
- "pallet-staking 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-election-provider-support 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "pallet-bags-list 31.0.0",
+ "pallet-nomination-pools 29.0.0",
+ "pallet-staking 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
- "sp-runtime-interface 26.0.0",
- "sp-staking 29.0.0",
+ "sp-runtime 35.0.0",
+ "sp-runtime-interface 27.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
@@ -8410,13 +8413,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2055f407f235071239494548d86f4f6d5c6ec24968fd8dcac553e00e08588d"
+checksum = "8ce49d48a75a006539583808e526d303a09afd8621d3351ad52f8a4ca62fe8a8"
 dependencies = [
- "pallet-nomination-pools 28.0.0",
+ "pallet-nomination-pools 29.0.0",
  "parity-scale-codec",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-std",
 ]
 
@@ -8440,19 +8443,19 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42b47ac29f107f30213d259cc0f73e1270743b66909fc7c9079d691a891b5a"
+checksum = "621a7fe9a24a3f69cbb14b06c94894b81ad0aa549dbfff178c9236876cf5a892"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-balances 31.0.0",
+ "pallet-balances 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
@@ -8483,26 +8486,26 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0745d6fd98a6ef7b19139470a28f9b9530b425c03dc02fbd773c989fe0a96b"
+checksum = "ca2c55d655bb56fb48c12fa98f1b6ea292ff58a0cf791cc7c180bb77ea73ac83"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-election-provider-support 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-election-provider-support 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-babe 31.0.0",
- "pallet-balances 31.0.0",
- "pallet-grandpa 31.0.0",
- "pallet-im-online 30.0.0",
- "pallet-offences 30.0.0",
- "pallet-session 31.0.0",
- "pallet-staking 31.0.0",
+ "pallet-babe 32.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-grandpa 32.0.0",
+ "pallet-im-online 31.0.0",
+ "pallet-offences 31.0.0",
+ "pallet-session 32.0.0",
+ "pallet-staking 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
@@ -8526,19 +8529,19 @@ dependencies = [
 
 [[package]]
 name = "pallet-preimage"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d01a900fe79c5f0762ccc29a11dda2799830ce233aa5384b2f13d9cc28e2e70"
+checksum = "c28de923b335df5fc38c9e0b565230120184f5e195624a386cd9bec90fda4b55"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8560,53 +8563,53 @@ dependencies = [
 
 [[package]]
 name = "pallet-proxy"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61918227f99ed2b322bf9050337773c8a40908b2f6a800352a20485e5ba0ef1c"
+checksum = "936d02c265142821c0144336d6724ec1fc56ddf333837f5ab502798fab5a447e"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47fbdfc5da0a70c788be3ea594153c825b4e79ae6a83499f38c251cdb5a726c0"
+checksum = "9a6a4587dc3f5438631db3c2ec019f31723c4a7949cf63945f111b6c509d0a97"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-recovery"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf473e4b04cd9ba40ed8963a03499de0a1a84c8eb9343b569b15bab6bb47a79"
+checksum = "dc2320f4d3b35c47180c80a6ea560d25e491d5812486c8691bdd297b5425f11b"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8632,37 +8635,37 @@ dependencies = [
 
 [[package]]
 name = "pallet-referenda"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b515fdbcade5b8a507e1a8ffc8b5a59725b1c8c71cfc6f8f5ae490e4a33f732c"
+checksum = "dbf5abb788c5e8e7960820288caa043f5d037a63248453d493e617a2445790a4"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 25.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-root-testing"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7926eb378bda52162a713aca44a6faab5fc7d6867f82ac14ba375df2b33eaa7f"
+checksum = "cd630721c9f07bdf90e4cade8f825d1842af9f68f470de186087a3d1f0090970"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8687,21 +8690,21 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f81ff1151067225c2c359a132880e084a1c72656457fe443147ed2e6daaac2"
+checksum = "87fac215d9cf301396720219c4d04e4fe7fcf44d14d4be71f9c3ae3df3cead74"
 dependencies = [
  "docify",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-weights 30.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -8729,25 +8732,25 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17951aa288869e5afe5815eedc7038dd50b9741d215b66323ff4a12f5686ac15"
+checksum = "061827f23d4a702a2e159ff84286a0a89488615c31ad05a9af7cc93a57e2b441"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-timestamp 30.0.0",
+ "pallet-timestamp 31.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-staking 29.0.0",
- "sp-state-machine 0.38.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-staking 30.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie 33.0.0",
 ]
 
 [[package]]
@@ -8770,38 +8773,38 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118d0e5a8c09dbb1c7326021335aab36546846c678b3ce79301ace02cec260f7"
+checksum = "817dd673f7d0b965639d27def260f7ff7a1535f2c5016a611445a8e4dedcf5cd"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "pallet-session 31.0.0",
- "pallet-staking 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "pallet-session 32.0.0",
+ "pallet-staking 32.0.0",
  "parity-scale-codec",
  "rand",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-society"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3255dc30ce7ebfd7ee59b1890d1f0091f416f486532d4eaf795dc209e3c28e"
+checksum = "4a89d24f9a15ae30d56fb9de190200d43735f4c055dcbe1c1259d3d4219da42a"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "rand_chacha 0.2.2",
  "scale-info",
- "sp-arithmetic 25.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8831,25 +8834,25 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baeb3d22e737307280e2047cba983cc9aa477a6f4c3001e8c1f07077d148c8f7"
+checksum = "2b8ab61dc6b74c79ad396732c1850dafa89109b749b2b651a1d4f20f45f596a3"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-election-provider-support 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-election-provider-support 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-authorship 31.0.0",
- "pallet-session 31.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-session 32.0.0",
  "parity-scale-codec",
  "rand_chacha 0.2.2",
  "scale-info",
  "serde",
- "sp-application-crypto 33.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
@@ -8877,12 +8880,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-reward-fn"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e341c47481040b68edcf166ad34633c4c5da20d1559413e68387da935a6ae18"
+checksum = "988a7ebeacc84d4bdb0b12409681e956ffe35438447d8f8bc78db547cffb6ebc"
 dependencies = [
  "log",
- "sp-arithmetic 25.0.0",
+ "sp-arithmetic 26.0.0",
 ]
 
 [[package]]
@@ -8898,13 +8901,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b398bbc910ed6e7e2fd76251910a8895e7c3343023e2279124568a1c860cab54"
+checksum = "4b8792b235b42d70e177301cd7e2e2b1afc828f1a6ddfa0639c481cd0c125078"
 dependencies = [
  "parity-scale-codec",
- "sp-api 29.0.0",
- "sp-staking 29.0.0",
+ "sp-api 30.0.0",
+ "sp-staking 30.0.0",
 ]
 
 [[package]]
@@ -8927,19 +8930,19 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de51e792bcf770a00c5adf8db67f35dae450f445d36fa4b650980017063a62aa"
+checksum = "bd3e2b1355eb2e08c2de3b14b175decf8ed49bf50de6cc44f97279257c325694"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8962,18 +8965,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00abb554e916fd31ffbc792bff01e2dd9961a0a4bb781d27ef5f30c908ac2f6"
+checksum = "abdecbca3760e93bb757313495ca7d2437e6141e728a2d266a85884c43d74c0e"
 dependencies = [
  "docify",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -8994,48 +8997,48 @@ dependencies = [
  "sp-io 31.0.0",
  "sp-runtime 32.0.0",
  "sp-std",
- "sp-storage",
+ "sp-storage 20.0.0",
  "sp-timestamp 27.0.0",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb766403f8cabcedb1725326befd7253de3e4c1d3b3d5f7c40adc49ebee5040c"
+checksum = "196720afcbee2f2fd1acfed5a667cffb3914d1311b36adb4d1a3a67d7010e2a5"
 dependencies = [
  "docify",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-storage",
- "sp-timestamp 29.0.0",
+ "sp-storage 21.0.0",
+ "sp-timestamp 30.0.0",
 ]
 
 [[package]]
 name = "pallet-tips"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee0ebf5ee31239f9017785cecd54b46be26edef126b6369af477d67f5088ffb"
+checksum = "5e3c596b6fb68e70f890436d212af74d19154be438ae0255e5ddeea10e5ec91a"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-treasury 30.0.0",
+ "pallet-treasury 31.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -9058,36 +9061,36 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df1de833ad0abff5daa53f80594d6ef66d250cc1ae073c01e406ce37bbf25e"
+checksum = "dedf412abd258989da4a26946f7e480c4335ffc837baef4ef21ba91cd56ba8ee"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b3e7cc2ef454af06e0d73e180d2f22c7f6714dca7c1d4a3cc95786041e42c2"
+checksum = "95122a5483521f5186a008326514e5a579931cc1d36980bbca5bb2b566ca334f"
 dependencies = [
  "jsonrpsee",
- "pallet-transaction-payment-rpc-runtime-api 31.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 32.0.0",
  "parity-scale-codec",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-rpc",
- "sp-runtime 34.0.0",
- "sp-weights 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -9105,15 +9108,15 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e060567db5e59e3f26cc274cb9fc5db5af160ac67062d61e488f7887fef5470"
+checksum = "37d4686402973e542eb83da077b46641643834220fbae74a98bcffa762d99e91"
 dependencies = [
- "pallet-transaction-payment 31.0.0",
+ "pallet-transaction-payment 32.0.0",
  "parity-scale-codec",
- "sp-api 29.0.0",
- "sp-runtime 34.0.0",
- "sp-weights 30.0.0",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -9138,21 +9141,21 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "174da255855136b4bf7174a1499ddf20134efe75d59fac4709244fe813534656"
+checksum = "ac957446c936a57417ff7a4866f3463f7f2f49d9bb2daed81093c2de8f0cceaf"
 dependencies = [
  "docify",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
- "pallet-balances 31.0.0",
+ "pallet-balances 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -9191,18 +9194,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-utility"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c54ec28e67769b35a650d497ddd10bf0dd783d14965a1034cdcb71ae1d1442"
+checksum = "9d770b7c961afe12adc5a727a5d02b44ef09ce38d1dd5923793b3e52e5afde3c"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -9224,17 +9227,17 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5627016e1cb40d02bf589507429558208c05948d1399ab405307bfe3b1d967"
+checksum = "24ce37af22cc31883dfdafa334c4e1f7cea8f2d4fb964f3aa88d77d5eea7ba94"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -9256,17 +9259,17 @@ dependencies = [
 
 [[package]]
 name = "pallet-whitelist"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68e2271ffe7a20565b7539931b9c01f29039ab151ac14fd93032e81f250727f"
+checksum = "28f118e773504b4160eb199d5504d3351d360e9ba64197d72384ee0c5ce1c0e1"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -9296,26 +9299,27 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "10.0.1"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd52ee00a54f8b6ff3a90e97622b2403667ef25105dd08d71d45a7075c0ba478"
+checksum = "649a096b0c178cb81b0e11fac4d2c67eda7cdae949d2a4c7ef693d2b39d677c6"
 dependencies = [
  "bounded-collections 0.2.0",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-balances 31.0.0",
+ "pallet-balances 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
- "staging-xcm-executor 10.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
+ "staging-xcm-executor 11.0.0",
+ "xcm-fee-payment-runtime-api",
 ]
 
 [[package]]
@@ -9340,22 +9344,22 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af346fe874360fdd3e36a63cac72a891283b63a2865b28f8afccaa63472fd40"
+checksum = "14af05792aec4a80c211f029ddc370cc3b0d2153f8adbbb0982d637768837bf0"
 dependencies = [
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
- "staging-xcm-executor 10.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
+ "staging-xcm-executor 11.0.0",
 ]
 
 [[package]]
@@ -9380,22 +9384,22 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d565232e0b191f9ba84ae2b0549122493e283daee73c8f1d46864b2151d17c3"
+checksum = "5e3e699ac017c1ea645c97e6a42d4c193f69282ca37c4197fc2a1cc9e69c2dc6"
 dependencies = [
- "bp-xcm-bridge-hub-router 0.9.0",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "bp-xcm-bridge-hub-router 0.10.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
 ]
 
 [[package]]
@@ -9432,66 +9436,66 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5539fb10c2901cf120d3db87f6ee1568696ccce30cea1a0d0cdee31f64f1da37"
+checksum = "375e035fedfe5e0a6b4de6d29c56f8ed5ca64f421a883e7e5bcdc37a76a7c715"
 dependencies = [
- "cumulus-primitives-core 0.10.0",
- "cumulus-primitives-utility 0.10.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "cumulus-primitives-core 0.11.0",
+ "cumulus-primitives-utility 0.11.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-asset-tx-payment 31.0.0",
- "pallet-assets 32.0.0",
- "pallet-authorship 31.0.0",
- "pallet-balances 31.0.0",
- "pallet-collator-selection 12.0.1",
- "pallet-message-queue 34.0.0",
- "pallet-xcm 10.0.1",
+ "pallet-asset-tx-payment 32.0.0",
+ "pallet-assets 33.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-collator-selection 13.0.1",
+ "pallet-message-queue 35.0.0",
+ "pallet-xcm 11.0.0",
  "parity-scale-codec",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "scale-info",
- "sp-consensus-aura 0.35.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "staging-parachain-info 0.10.0",
- "staging-xcm 10.0.0",
- "staging-xcm-executor 10.0.0",
- "substrate-wasm-builder 20.0.0",
+ "staging-parachain-info 0.11.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-executor 11.0.0",
+ "substrate-wasm-builder 21.0.0",
 ]
 
 [[package]]
 name = "parachains-runtimes-test-utils"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99223f27fe88a1d071e0ddf6e10556aacb6cb507658acc70957783830f6fc37"
+checksum = "562cc3f9874133635992672539509c087126ada17ab738853b93b6fd76033a02"
 dependencies = [
- "cumulus-pallet-parachain-system 0.10.0",
- "cumulus-pallet-xcmp-queue 0.10.0",
- "cumulus-primitives-core 0.10.0",
- "cumulus-primitives-parachain-inherent 0.10.0",
+ "cumulus-pallet-parachain-system 0.11.0",
+ "cumulus-pallet-xcmp-queue 0.11.0",
+ "cumulus-primitives-core 0.11.0",
+ "cumulus-primitives-parachain-inherent 0.11.0",
  "cumulus-test-relay-sproof-builder",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "pallet-balances 31.0.0",
- "pallet-collator-selection 12.0.1",
- "pallet-session 31.0.0",
- "pallet-timestamp 30.0.0",
- "pallet-xcm 10.0.1",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-collator-selection 13.0.1",
+ "pallet-session 32.0.0",
+ "pallet-timestamp 31.0.0",
+ "pallet-xcm 11.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives 9.0.0",
- "sp-consensus-aura 0.35.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-tracing",
- "staging-parachain-info 0.10.0",
- "staging-xcm 10.0.0",
- "staging-xcm-executor 10.0.0",
- "substrate-wasm-builder 20.0.0",
+ "sp-tracing 17.0.0",
+ "staging-parachain-info 0.11.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-executor 11.0.0",
+ "substrate-wasm-builder 21.0.0",
 ]
 
 [[package]]
@@ -9748,7 +9752,7 @@ dependencies = [
  "sp-session 28.0.0",
  "sp-staking 27.0.0",
  "sp-std",
- "sp-storage",
+ "sp-storage 20.0.0",
  "sp-transaction-pool 27.0.0",
  "sp-version 30.0.0",
  "staging-xcm 8.0.1",
@@ -9957,9 +9961,9 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71bcf7eaa793354f996553b9b472833f761d9cd9e9bf6b2123895da4df6a25b"
+checksum = "9022a11f7a24b293242c08357ab90ca725b9a9153489fae32425ff8d43401dee"
 dependencies = [
  "bitvec",
  "futures",
@@ -9971,16 +9975,16 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "rand",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b156f5a0a20ffcd852e266b865ad9149c6180a4cf1af07f334567c3b86f0fec"
+checksum = "630bd08d1b8eeaab90585e50da11114827dbbd0fdf1e6e2a417a57dde01b40d8"
 dependencies = [
  "always-assert",
  "futures",
@@ -9988,16 +9992,16 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "rand",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156b913d3eb7981ac8d540bacef09d5dac3a5d0584fa5a27fc8971870a02040a"
+checksum = "74aab8badb2e230830978ea27a34749ec6d0a096ff5c12fb08935f85e7881283"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10008,20 +10012,20 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "rand",
  "schnellru",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d736bca91fe70f303d09a1e251b7d3cb39164c94948d95a7769256ece066a3ed"
+checksum = "1366718a28780768e5f2bd00c28445b0d37be21829b071a8b763534411978d81"
 dependencies = [
  "async-trait",
  "fatality",
@@ -10032,7 +10036,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "rand",
  "sc-network",
  "schnellru",
@@ -10043,9 +10047,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5509ed80ddcbb63c88b9f346b22f4b663e52dadf475118ec06406a0688817c55"
+checksum = "a6cbe8ee58650efc6a414c940e0bc09462926cfa806ace62207297f6a78c65a7"
 dependencies = [
  "cfg-if",
  "clap",
@@ -10061,11 +10065,11 @@ dependencies = [
  "sc-storage-monitor",
  "sc-sysinfo",
  "sc-tracing",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-keyring 34.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-keyring 35.0.0",
  "sp-maybe-compressed-blob",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "substrate-build-script-utils",
  "thiserror",
  "try-runtime-cli",
@@ -10073,9 +10077,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82682bdd0aea251ab8f31a1b06f4c2c1c494e80fed4fc13ca9bc7622870bc82"
+checksum = "fdade551b33b767772d5bca1e19e4b8ea3dadb0154401dac2e578d9f73889d55"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10085,10 +10089,10 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
+ "polkadot-primitives 11.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
  "thiserror",
  "tokio-util",
  "tracing-gum",
@@ -10109,22 +10113,22 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c2f38f3195108e9da39b9845895bb3dff76f1c7b31409143febeb1560cd276"
+checksum = "9792d6e3323b0bd7372a489bd3dd52afb09436919d073d45302f8e55f48ea4fd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5331cccd51a1593bc26a1619964f49876629589139cdf46151c21a6308c6bad"
+checksum = "62c223fda0baf1414d963922e555001b32f6c13308b8b47081fa75959933cf2c"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10137,58 +10141,58 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-network",
  "schnellru",
- "sp-application-crypto 33.0.0",
- "sp-keystore 0.37.0",
+ "sp-application-crypto 34.0.0",
+ "sp-keystore 0.38.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4842b32ecf4ab29521f1f9dd199c35398cd101883912f74e070658cd465037af"
+checksum = "cf840ff7a6337715e20e1afd76fd20dae11ebb049d89855ee2bf47b36b0e6249"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "reed-solomon-novelpoly",
- "sp-core 31.0.0",
- "sp-trie 32.0.0",
+ "sp-core 32.0.0",
+ "sp-trie 33.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165cced1fd975f43d21e8a0701b19461d07131ace5feae2bfeb8ea005953683"
+checksum = "477f94e8c3eedd6cfcfdfe50a33d610d38dfec4668ff7f3baef8814ffb7da85e"
 dependencies = [
  "futures",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "rand",
  "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto 33.0.0",
- "sp-core 31.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-keystore 0.37.0",
+ "sp-keystore 0.38.0",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f34d1b7dde0d43c37aeacb37c199cbfc1c541a3ff03317fcb6bcc2d69501f6"
+checksum = "bada301d390179f38d18f10435412c81f35fc8f6e357ed84516ca0018f8c6e21"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10201,7 +10205,7 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-network",
  "sp-consensus",
  "thiserror",
@@ -10210,9 +10214,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1060f6954c43f120751ad3f2a54155541893fcf9a966f4a9ce5192ee7888fa1f"
+checksum = "b81555b3a87382c8a7c5660b0b8a09dfd2573615086e7351ef95475a17e76b2d"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10220,8 +10224,8 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
- "sp-core 31.0.0",
+ "polkadot-primitives 11.0.0",
+ "sp-core 32.0.0",
  "sp-maybe-compressed-blob",
  "thiserror",
  "tracing-gum",
@@ -10229,9 +10233,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427edaa41cc878f0d22b3248e900d1f65760a92f6e230e7a54ff6118b8ef9c79"
+checksum = "05e3f49e8102d9a0b20f6f96199040ea253708b34bd30e679481228ebf76ab23"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10246,26 +10250,26 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "rand",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto 33.0.0",
+ "sp-application-crypto 34.0.0",
  "sp-consensus",
- "sp-consensus-slots 0.35.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-slots 0.36.0",
+ "sp-runtime 35.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669f4ba3485a915853e94db99cf0dc5af9bccacd76b4d6f06550c5ecbd33d4aa"
+checksum = "bb6fe8e8eaf3e368e93a24309d812bc1e5f91fe865a80c1c7cd182fe217c50a7"
 dependencies = [
  "bitvec",
  "futures",
@@ -10278,7 +10282,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sp-consensus",
  "thiserror",
  "tracing-gum",
@@ -10286,9 +10290,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307ec8006475fd2f5f878bbfd7c74368f4fde0fd10096925a85b5e027ace4889"
+checksum = "2b5417cf48b5948ed665f847240135f1fa5415cc5d3e9013cc3140a632cbf156"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10297,25 +10301,25 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "polkadot-statement-table",
  "schnellru",
- "sp-keystore 0.37.0",
+ "sp-keystore 0.38.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8133ce90b5bfc6d81c8d124dd26ec86624eb88bb33e57c0fb59d1262c9224ea"
+checksum = "c2365e3ddb8073f54e81b222e51a364cd3e38b7371bcd042017b73db2d523028"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
- "sp-keystore 0.37.0",
+ "polkadot-primitives 11.0.0",
+ "sp-keystore 0.38.0",
  "thiserror",
  "tracing-gum",
  "wasm-timer",
@@ -10323,9 +10327,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a4335b31f5d7dd3c59a7a061ca32061d290244fde416186fd22bee5093cf4bb"
+checksum = "867b7c560556d063b4b93d0cec3a5f6932735311b5d66666105705b87fc36a9c"
 dependencies = [
  "async-trait",
  "futures",
@@ -10337,17 +10341,17 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sp-maybe-compressed-blob",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b25733a45754fa4f049d26289994e379be21b132ca36982378604b53341104"
+checksum = "c2ffcc24bbbc2a2523c599022b106f0b48213bf80ef75f490fe02ec79ab972e4"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10360,9 +10364,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a7c69bd67b0840c0f97c61637b798f6ec49c6a1c4cf153e4d8e8b22e34c45"
+checksum = "a9971f3ef6226f6f12bede58e009aae16fc6fc636159ec1dc7f1add2bad87638"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10371,16 +10375,16 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6fb7b632e37b5eff4d3ceb246a6d7277c82bb573cbc2360c37719a5e00df82"
+checksum = "d3d839dc81ec2f6593fb33bfc4d0e469c56ee0953fd129cc10fe224f7f2ff0bd"
 dependencies = [
  "fatality",
  "futures",
@@ -10389,7 +10393,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-keystore",
  "schnellru",
  "thiserror",
@@ -10398,27 +10402,27 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c904246202cb80fc3e3872e142d74958903515c3b91d3d4d88907cf8bca46e2"
+checksum = "9d3f8faa7a013b08ebdf4e018b8f7daccfc2b13fdac154d361ceb5be9992647b"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sp-blockchain",
- "sp-inherents 29.0.0",
+ "sp-inherents 30.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d343298e502e687bc2f8ae837cad538a9b5d60ce714ace58120cb91aeb41d1c1"
+checksum = "5995f6998c35e9bbb8ab784714fcab7c9ddc6f0125cbd99a7175674a3f99f187"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10427,16 +10431,16 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9be87118cc96f05bd5a35bee2f8c495b894d23fbff1c954b15d7dbe4516564c"
+checksum = "5ccd98d226f1a650827183e6807466d0569691dd4a8434a3974eea041c73a677"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10445,7 +10449,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "schnellru",
  "thiserror",
  "tracing-gum",
@@ -10453,9 +10457,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c07e2dad8712e1e5978c6404aca20d2c7f1b5d6151d60277f49ce949b3ed5d"
+checksum = "6db5f945f8f26982b46c5cb1ed9c37f29d7e851bd06dae97b2b04e6d46dd4b77"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.2",
@@ -10467,18 +10471,18 @@ dependencies = [
  "libc",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives 10.0.0",
+ "polkadot-core-primitives 11.0.0",
  "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "rand",
  "slotmap",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface",
+ "sp-wasm-interface 21.0.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -10487,26 +10491,26 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1536bf89078dca39061f2a4d742e11dc14da38ffa5b6ce84e5c454cf9fd9b151"
+checksum = "275cab7ad2b38fdfb0c097485fe4f51e55e36c96330255edc38ccf121aa2171c"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 10.0.0",
- "sp-keystore 0.37.0",
+ "polkadot-primitives 11.0.0",
+ "sp-keystore 0.38.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2781bf5b07873b37ed5a76b28866367ea2529d4b91497c3db560c0eb59b2a2d9"
+checksum = "2d1cf57c2204d9f80da258cfd1ca8e2ef7f366fa7810333da5f8519a05ba574d"
 dependencies = [
  "cfg-if",
  "cpu-time",
@@ -10515,42 +10519,42 @@ dependencies = [
  "libc",
  "nix 0.27.1",
  "parity-scale-codec",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-executor",
  "sc-executor-common",
  "sc-executor-wasmtime",
  "seccompiler",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-externalities 0.27.0",
- "sp-io 33.0.0",
- "sp-tracing",
+ "sp-externalities 0.28.0",
+ "sp-io 34.0.0",
+ "sp-tracing 17.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7065d7dd209b05ceaf3781ca0a7cdfcb0071c3a61a8357e37dff8587a94928d2"
+checksum = "fd9c685da442b6dde17f0f1e4bd6bb4d6827c6af0dbe96bc603d3d4f8fd05953"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "schnellru",
- "sp-consensus-babe 0.35.0",
+ "sp-consensus-babe 0.36.0",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e65e3d9990d1f8f793a23c05c6aa82a551e551225ab86d2625474afef748f"
+checksum = "cbefc5402f4eadf6dc976d8013c0e050947809a1442a6fc3c44640841c7df712"
 dependencies = [
  "lazy_static",
  "log",
@@ -10558,25 +10562,25 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-node-primitives",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-network",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ca58a67371546b66a011f0e27551094a8499a53223b16c164e769d25d981d0"
+checksum = "ba41f6bbcb2261a92c452ffa2960301079a0922c832491b4e9aa3400887e33ac"
 dependencies = [
  "bs58 0.5.1",
  "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "prioritized-metered-channel",
  "sc-cli",
  "sc-service",
@@ -10587,9 +10591,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c3b078794c9c383ee3ceff65f2713ec81c033c6d8785ead5f7797e914c1fe3"
+checksum = "915df9a38d99dc98216f8dce9a90f3ff2cee0d7fdf9b956c055844421b0d231b"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10601,44 +10605,44 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "rand",
  "sc-authority-discovery",
  "sc-network",
- "strum 0.24.1",
+ "strum 0.26.3",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9521abb7028ce7040f66a0786423bee2cdb7725ca46e5cee1f86191bcb2ed3"
+checksum = "cf8d9fa95f0752c64635b2c8fc8c39b55eedb960f18a068d10720085c8ad06f6"
 dependencies = [
  "bitvec",
  "bounded-vec",
  "futures",
  "parity-scale-codec",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto 33.0.0",
- "sp-consensus-babe 0.35.0",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
+ "sp-application-crypto 34.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
  "sp-maybe-compressed-blob",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "thiserror",
  "zstd 0.12.4",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7865c507f0eab9d816c40b1d4e2acb4e8f77db9efc8c0af23942d6b0f50e6f6"
+checksum = "6d5bbd86b3014ce7cc71e1a90bf641e26c4cea98955522d350268efa97c58de9"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10647,9 +10651,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0e971c1377901212059b794b48acac9a855cac83f2e07dc1b708ca0e77ba64"
+checksum = "ca25de72c086250c6b53ba0a868fcb1c99c305e0abbf5e3faf5568310dd4672b"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10659,26 +10663,26 @@ dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "polkadot-statement-table",
  "sc-client-api",
  "sc-network",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api 29.0.0",
- "sp-authority-discovery 29.0.0",
+ "sp-api 30.0.0",
+ "sp-authority-discovery 30.0.0",
  "sp-blockchain",
- "sp-consensus-babe 0.35.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4937553bd1a5f9ee9343a1a227ae07237b48a29c99ecd53217b090ca84b753c6"
+checksum = "3d61ee42f50de06ae2d0209cb49af9805b780d1042a49f74f9841d2095784827"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10698,23 +10702,23 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "prioritized-metered-channel",
  "rand",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto 33.0.0",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-overseer"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97415bc09e9dd20d44a019eaf0bb803ab3239a7eca20820b181e53901966fdbc"
+checksum = "b6fa9663b506f2c6632468e1207e4a651ca16f2f4aba17d0a3d9e2fb828f02c5"
 dependencies = [
  "async-trait",
  "futures",
@@ -10725,10 +10729,10 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem-types",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-client-api",
- "sp-api 29.0.0",
- "sp-core 31.0.0",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
  "tikv-jemalloc-ctl",
  "tracing-gum",
 ]
@@ -10753,20 +10757,20 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b87dda07862f2b16f2c2b7d315f2b4549c896562d973d466b6d19de36aba30d"
+checksum = "fe77e2febc4b87e7c0a63f857ce5c32a2680cae5f9c2740285cd7378ed1586ca"
 dependencies = [
  "bounded-collections 0.2.0",
  "derive_more",
  "parity-scale-codec",
- "polkadot-core-primitives 10.0.0",
+ "polkadot-core-primitives 11.0.0",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-weights 30.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -10799,42 +10803,42 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e01b525a35852e2861397eecbdb4a03dda69f14f7ca04968f2e06d6cba51dfb"
+checksum = "71eabc294df35faa0877f6427e9a37d3b8323922aa0372cc9208e492d8f1b2f5"
 dependencies = [
  "bitvec",
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-core-primitives 10.0.0",
- "polkadot-parachain-primitives 9.0.0",
+ "polkadot-core-primitives 11.0.0",
+ "polkadot-parachain-primitives 10.0.0",
  "scale-info",
  "serde",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-arithmetic 25.0.0",
- "sp-authority-discovery 29.0.0",
- "sp-consensus-slots 0.35.0",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-authority-discovery 30.0.0",
+ "sp-consensus-slots 0.36.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "polkadot-rpc"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf68469a4e01a0c8a16869fde6de3071fbebdf836058c8afe8396470ef2c462"
+checksum = "fb29231d3184c38d011a7bffea09a2c1724b5d7544d43d6159aaa3870ae74e26"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
  "pallet-transaction-payment-rpc",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus-babe",
@@ -10848,13 +10852,13 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api 29.0.0",
- "sp-block-builder 29.0.0",
+ "sp-api 30.0.0",
+ "sp-block-builder 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.35.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
@@ -10913,53 +10917,53 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1abd7bff20e17e025a4e001aff55dfefcfd7ef8a8ae138de44998a012e227f2"
+checksum = "27c9469b179e1bef848bbf051df1bd529b2b9a2a0428c0f87527586a5bca3848"
 dependencies = [
  "bitvec",
- "frame-benchmarking 31.0.0",
- "frame-election-provider-support 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-election-provider-support 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
- "pallet-asset-rate 10.0.0",
- "pallet-authorship 31.0.0",
- "pallet-babe 31.0.0",
- "pallet-balances 31.0.0",
- "pallet-broker 0.9.0",
- "pallet-election-provider-multi-phase 30.0.0",
- "pallet-fast-unstake 30.0.0",
- "pallet-identity 31.0.0",
- "pallet-session 31.0.0",
- "pallet-staking 31.0.0",
- "pallet-staking-reward-fn 21.0.0",
- "pallet-timestamp 30.0.0",
- "pallet-transaction-payment 31.0.0",
- "pallet-treasury 30.0.0",
- "pallet-vesting 31.0.0",
+ "pallet-asset-rate 11.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-babe 32.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-broker 0.10.0",
+ "pallet-election-provider-multi-phase 31.0.0",
+ "pallet-fast-unstake 31.0.0",
+ "pallet-identity 32.0.0",
+ "pallet-session 32.0.0",
+ "pallet-staking 32.0.0",
+ "pallet-staking-reward-fn 22.0.0",
+ "pallet-timestamp 31.0.0",
+ "pallet-transaction-payment 32.0.0",
+ "pallet-treasury 31.0.0",
+ "pallet-vesting 32.0.0",
  "parity-scale-codec",
- "polkadot-primitives 10.0.0",
- "polkadot-runtime-parachains 10.0.0",
+ "polkadot-primitives 11.0.0",
+ "polkadot-runtime-parachains 11.0.0",
  "rustc-hex",
  "scale-info",
  "serde",
  "serde_derive",
- "slot-range-helper 10.0.0",
- "sp-api 29.0.0",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-npos-elections 29.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-staking 29.0.0",
+ "slot-range-helper 11.0.0",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-npos-elections 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
- "staging-xcm-executor 10.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
+ "staging-xcm-executor 11.0.0",
  "static_assertions",
 ]
 
@@ -10974,21 +10978,21 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-primitives 8.0.1",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fed9088becfd874b6dbf064f9d1dd1bfa2e3c2188459a572aac2e689c028772"
+checksum = "d3c04cc730f9ddcd9a663eddb95915d783704d11ea12eb2882c0abe18968b9de"
 dependencies = [
  "bs58 0.5.1",
- "frame-benchmarking 31.0.0",
+ "frame-benchmarking 32.0.0",
  "parity-scale-codec",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
@@ -11043,66 +11047,66 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce601c5f1005ff1d315c1e5c161a73e63e54bf23527f98c2bfa3ffc5b22f5e6"
+checksum = "32edd5b366f1e45995f613997ed259993cd2746f0407f186136696d54e24d784"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-authority-discovery 31.0.1",
- "pallet-authorship 31.0.0",
- "pallet-babe 31.0.0",
- "pallet-balances 31.0.0",
- "pallet-broker 0.9.0",
- "pallet-message-queue 34.0.0",
- "pallet-session 31.0.0",
- "pallet-staking 31.0.0",
- "pallet-timestamp 30.0.0",
- "pallet-vesting 31.0.0",
+ "pallet-authority-discovery 32.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-babe 32.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-broker 0.10.0",
+ "pallet-message-queue 35.0.0",
+ "pallet-session 32.0.0",
+ "pallet-staking 32.0.0",
+ "pallet-timestamp 31.0.0",
+ "pallet-vesting 32.0.0",
  "parity-scale-codec",
- "polkadot-core-primitives 10.0.0",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
- "polkadot-runtime-metrics 10.0.0",
+ "polkadot-core-primitives 11.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
+ "polkadot-runtime-metrics 11.0.0",
  "rand",
  "rand_chacha 0.3.1",
  "rustc-hex",
  "scale-info",
  "serde",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-staking 29.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
- "staging-xcm 10.0.0",
- "staging-xcm-executor 10.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-executor 11.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "polkadot-service"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322db94a98084bf62ac2c58194856d823455ceb74000c9602f817b8b738a8f78"
+checksum = "f276b38deaab6bff3ddfe061331901196ff992f76398bd0abc78382f4f115cf0"
 dependencies = [
  "async-trait",
- "frame-benchmarking 31.0.0",
+ "frame-benchmarking 32.0.0",
  "frame-benchmarking-cli",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "frame-system-rpc-runtime-api 29.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "frame-system-rpc-runtime-api 30.0.0",
  "futures",
  "hex-literal",
  "is_executable",
@@ -11110,11 +11114,10 @@ dependencies = [
  "kvdb-rocksdb",
  "log",
  "mmr-gadget",
- "pallet-babe 31.0.0",
- "pallet-im-online 30.0.0",
- "pallet-staking 31.0.0",
- "pallet-transaction-payment 31.0.0",
- "pallet-transaction-payment-rpc-runtime-api 31.0.0",
+ "pallet-babe 32.0.0",
+ "pallet-staking 32.0.0",
+ "pallet-transaction-payment 32.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 32.0.0",
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -11123,7 +11126,7 @@ dependencies = [
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives 10.0.0",
+ "polkadot-core-primitives 11.0.0",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
@@ -11148,10 +11151,10 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "polkadot-rpc",
- "polkadot-runtime-parachains 10.0.0",
+ "polkadot-runtime-parachains 11.0.0",
  "polkadot-statement-distribution",
  "rococo-runtime",
  "sc-authority-discovery",
@@ -11180,40 +11183,42 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 29.0.0",
- "sp-authority-discovery 29.0.0",
- "sp-block-builder 29.0.0",
+ "sp-api 30.0.0",
+ "sp-authority-discovery 30.0.0",
+ "sp-block-builder 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.35.0",
- "sp-consensus-beefy 16.0.0",
- "sp-consensus-grandpa 16.0.0",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-keyring 34.0.0",
- "sp-keystore 0.37.0",
- "sp-mmr-primitives 29.0.0",
- "sp-offchain 29.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-state-machine 0.38.0",
- "sp-storage",
- "sp-timestamp 29.0.0",
- "sp-transaction-pool 29.0.0",
- "sp-version 32.0.0",
- "sp-weights 30.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-consensus-beefy 17.0.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-keyring 35.0.0",
+ "sp-keystore 0.38.0",
+ "sp-mmr-primitives 30.0.0",
+ "sp-offchain 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-storage 21.0.0",
+ "sp-timestamp 30.0.0",
+ "sp-transaction-pool 30.0.0",
+ "sp-version 33.0.0",
+ "sp-weights 31.0.0",
+ "staging-xcm 11.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tracing-gum",
  "westend-runtime",
+ "xcm-fee-payment-runtime-api",
 ]
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a4ef148c9bbed26f8630311ac26c9df1c07195a46a84fb5e8e7e7122e90248"
+checksum = "ded486e00b2d5bdc589b4b75c722d7a2b2f4669bd3b492227d3501d60db1b4ec"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -11226,22 +11231,22 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 10.0.0",
- "sp-keystore 0.37.0",
- "sp-staking 29.0.0",
+ "polkadot-primitives 11.0.0",
+ "sp-keystore 0.38.0",
+ "sp-staking 30.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-statement-table"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18144720acd47e1243b60c20bfb03f73dc67cbaf61bf2820991961e1ebb803b"
+checksum = "efc9894c6ae63eb4ba1724cc4859db2224038b770b3ac1bf05f0650cbf01dca7"
 dependencies = [
  "parity-scale-codec",
- "polkadot-primitives 10.0.0",
- "sp-core 31.0.0",
+ "polkadot-primitives 11.0.0",
+ "sp-core 32.0.0",
  "tracing-gum",
 ]
 
@@ -11254,7 +11259,7 @@ dependencies = [
  "libc",
  "log",
  "polkavm-assembler",
- "polkavm-common 0.9.0",
+ "polkavm-common",
  "polkavm-linux-raw",
 ]
 
@@ -11269,18 +11274,6 @@ dependencies = [
 
 [[package]]
 name = "polkavm-common"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b4e215c80fe876147f3d58158d5dfeae7dabdd6047e175af77095b78d0035c"
-
-[[package]]
-name = "polkavm-common"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c99f7eee94e7be43ba37eef65ad0ee8cbaf89b7c00001c3f6d2be985cb1817"
-
-[[package]]
-name = "polkavm-common"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
@@ -11290,54 +11283,11 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6380dbe1fb03ecc74ad55d841cfc75480222d153ba69ddcb00977866cbdabdb8"
-dependencies = [
- "polkavm-derive-impl 0.5.0",
- "syn 2.0.55",
-]
-
-[[package]]
-name = "polkavm-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fa916f7962348bd1bb1a65a83401675e6fc86c51a0fdbcf92a3108e58e6125"
-dependencies = [
- "polkavm-derive-impl-macro 0.8.0",
-]
-
-[[package]]
-name = "polkavm-derive"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
 dependencies = [
- "polkavm-derive-impl-macro 0.9.0",
-]
-
-[[package]]
-name = "polkavm-derive-impl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8211b3365bbafb2fb32057d68b0e1ca55d079f5cf6f9da9b98079b94b3987d"
-dependencies = [
- "polkavm-common 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.55",
-]
-
-[[package]]
-name = "polkavm-derive-impl"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10b2654a8a10a83c260bfb93e97b262cf0017494ab94a65d389e0eda6de6c9c"
-dependencies = [
- "polkavm-common 0.8.0",
- "proc-macro2",
- "quote",
- "syn 2.0.55",
+ "polkavm-derive-impl-macro",
 ]
 
 [[package]]
@@ -11346,19 +11296,9 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
 dependencies = [
- "polkavm-common 0.9.0",
+ "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
-]
-
-[[package]]
-name = "polkavm-derive-impl-macro"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e85319a0d5129dc9f021c62607e0804f5fb777a05cdda44d750ac0732def66"
-dependencies = [
- "polkavm-derive-impl 0.8.0",
  "syn 2.0.55",
 ]
 
@@ -11368,7 +11308,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
- "polkavm-derive-impl 0.9.0",
+ "polkavm-derive-impl",
  "syn 2.0.55",
 ]
 
@@ -11382,7 +11322,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "log",
  "object 0.32.2",
- "polkavm-common 0.9.0",
+ "polkavm-common",
  "regalloc2 0.9.3",
  "rustc-demangle",
 ]
@@ -11459,11 +11399,11 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-consensus-proposer",
  "cumulus-client-service",
- "cumulus-primitives-aura 0.10.0",
- "cumulus-primitives-core 0.10.0",
- "cumulus-primitives-parachain-inherent 0.10.0",
+ "cumulus-primitives-aura 0.11.0",
+ "cumulus-primitives-core 0.11.0",
+ "cumulus-primitives-parachain-inherent 0.11.0",
  "cumulus-relay-chain-interface",
- "frame-benchmarking 31.0.0",
+ "frame-benchmarking 32.0.0",
  "frame-benchmarking-cli",
  "futures",
  "jsonrpsee",
@@ -11471,7 +11411,7 @@ dependencies = [
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
  "polkadot-cli",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "pop-runtime-common",
  "pop-runtime-devnet",
  "pop-runtime-testnet",
@@ -11493,19 +11433,19 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api 29.0.0",
- "sp-block-builder 29.0.0",
+ "sp-api 30.0.0",
+ "sp-block-builder 30.0.0",
  "sp-blockchain",
- "sp-consensus-aura 0.35.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-keystore 0.37.0",
- "sp-offchain 29.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-timestamp 29.0.0",
- "sp-transaction-pool 29.0.0",
- "staging-xcm 10.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-keystore 0.38.0",
+ "sp-offchain 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-timestamp 30.0.0",
+ "sp-transaction-pool 30.0.0",
+ "staging-xcm 11.0.0",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -11524,12 +11464,12 @@ dependencies = [
 name = "pop-runtime-common"
 version = "0.0.0"
 dependencies = [
- "frame-support 31.0.0",
- "parachains-common 10.0.0",
+ "frame-support 32.0.0",
+ "parachains-common 11.0.0",
  "parity-scale-codec",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "scale-info",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -11537,146 +11477,146 @@ dependencies = [
 name = "pop-runtime-devnet"
 version = "0.1.0"
 dependencies = [
- "cumulus-pallet-aura-ext 0.10.0",
- "cumulus-pallet-parachain-system 0.10.0",
- "cumulus-pallet-session-benchmarking 12.0.0",
- "cumulus-pallet-xcm 0.10.0",
- "cumulus-pallet-xcmp-queue 0.10.0",
- "cumulus-primitives-aura 0.10.0",
- "cumulus-primitives-core 0.10.0",
- "cumulus-primitives-utility 0.10.0",
+ "cumulus-pallet-aura-ext 0.11.0",
+ "cumulus-pallet-parachain-system 0.11.0",
+ "cumulus-pallet-session-benchmarking 13.0.0",
+ "cumulus-pallet-xcm 0.11.0",
+ "cumulus-pallet-xcmp-queue 0.11.0",
+ "cumulus-primitives-aura 0.11.0",
+ "cumulus-primitives-core 0.11.0",
+ "cumulus-primitives-utility 0.11.0",
  "enumflags2",
  "env_logger 0.11.3",
- "frame-benchmarking 31.0.0",
- "frame-executive 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "frame-system-benchmarking 31.0.0",
- "frame-system-rpc-runtime-api 29.0.0",
- "frame-try-runtime 0.37.0",
+ "frame-benchmarking 32.0.0",
+ "frame-executive 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "frame-system-benchmarking 32.0.0",
+ "frame-system-rpc-runtime-api 30.0.0",
+ "frame-try-runtime 0.38.0",
  "hex",
  "hex-literal",
  "log",
- "pallet-assets 32.0.0",
- "pallet-aura 30.0.0",
- "pallet-authorship 31.0.0",
- "pallet-balances 31.0.0",
- "pallet-collator-selection 12.0.1",
+ "pallet-assets 33.0.0",
+ "pallet-aura 31.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-collator-selection 13.0.1",
  "pallet-contracts",
- "pallet-message-queue 34.0.0",
- "pallet-multisig 31.0.0",
+ "pallet-message-queue 35.0.0",
+ "pallet-multisig 32.0.0",
  "pallet-nft-fractionalization",
- "pallet-nfts 25.0.0",
- "pallet-nfts-runtime-api 17.0.0",
- "pallet-preimage 31.0.0",
- "pallet-proxy 31.0.0",
- "pallet-scheduler 32.0.0",
- "pallet-session 31.0.0",
- "pallet-sudo 31.0.0",
- "pallet-timestamp 30.0.0",
- "pallet-transaction-payment 31.0.0",
- "pallet-transaction-payment-rpc-runtime-api 31.0.0",
- "pallet-utility 31.0.0",
- "pallet-xcm 10.0.1",
- "parachains-common 10.0.0",
+ "pallet-nfts 26.0.0",
+ "pallet-nfts-runtime-api 18.0.0",
+ "pallet-preimage 32.0.0",
+ "pallet-proxy 32.0.0",
+ "pallet-scheduler 33.0.0",
+ "pallet-session 32.0.0",
+ "pallet-sudo 32.0.0",
+ "pallet-timestamp 31.0.0",
+ "pallet-transaction-payment 32.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 32.0.0",
+ "pallet-utility 32.0.0",
+ "pallet-xcm 11.0.0",
+ "parachains-common 11.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-runtime-common 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-runtime-common 11.0.0",
  "pop-primitives",
  "pop-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api 29.0.0",
- "sp-block-builder 29.0.0",
- "sp-consensus-aura 0.35.0",
- "sp-core 31.0.0",
- "sp-genesis-builder 0.10.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-offchain 29.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
+ "sp-api 30.0.0",
+ "sp-block-builder 30.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-core 32.0.0",
+ "sp-genesis-builder 0.11.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-offchain 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
  "sp-std",
- "sp-transaction-pool 29.0.0",
- "sp-version 32.0.0",
- "staging-parachain-info 0.10.0",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
- "staging-xcm-executor 10.0.0",
- "substrate-wasm-builder 20.0.0",
+ "sp-transaction-pool 30.0.0",
+ "sp-version 33.0.0",
+ "staging-parachain-info 0.11.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
+ "staging-xcm-executor 11.0.0",
+ "substrate-wasm-builder 21.0.0",
 ]
 
 [[package]]
 name = "pop-runtime-testnet"
 version = "0.2.0"
 dependencies = [
- "cumulus-pallet-aura-ext 0.10.0",
- "cumulus-pallet-parachain-system 0.10.0",
- "cumulus-pallet-session-benchmarking 12.0.0",
- "cumulus-pallet-xcm 0.10.0",
- "cumulus-pallet-xcmp-queue 0.10.0",
- "cumulus-primitives-aura 0.10.0",
- "cumulus-primitives-core 0.10.0",
- "cumulus-primitives-utility 0.10.0",
+ "cumulus-pallet-aura-ext 0.11.0",
+ "cumulus-pallet-parachain-system 0.11.0",
+ "cumulus-pallet-session-benchmarking 13.0.0",
+ "cumulus-pallet-xcm 0.11.0",
+ "cumulus-pallet-xcmp-queue 0.11.0",
+ "cumulus-primitives-aura 0.11.0",
+ "cumulus-primitives-core 0.11.0",
+ "cumulus-primitives-utility 0.11.0",
  "enumflags2",
  "env_logger 0.11.3",
- "frame-benchmarking 31.0.0",
- "frame-executive 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "frame-system-benchmarking 31.0.0",
- "frame-system-rpc-runtime-api 29.0.0",
- "frame-try-runtime 0.37.0",
+ "frame-benchmarking 32.0.0",
+ "frame-executive 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "frame-system-benchmarking 32.0.0",
+ "frame-system-rpc-runtime-api 30.0.0",
+ "frame-try-runtime 0.38.0",
  "hex",
  "hex-literal",
  "log",
- "pallet-assets 32.0.0",
- "pallet-aura 30.0.0",
- "pallet-authorship 31.0.0",
- "pallet-balances 31.0.0",
- "pallet-collator-selection 12.0.1",
+ "pallet-assets 33.0.0",
+ "pallet-aura 31.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-collator-selection 13.0.1",
  "pallet-contracts",
- "pallet-message-queue 34.0.0",
- "pallet-multisig 31.0.0",
+ "pallet-message-queue 35.0.0",
+ "pallet-multisig 32.0.0",
  "pallet-nft-fractionalization",
- "pallet-nfts 25.0.0",
- "pallet-nfts-runtime-api 17.0.0",
- "pallet-preimage 31.0.0",
- "pallet-proxy 31.0.0",
- "pallet-scheduler 32.0.0",
- "pallet-session 31.0.0",
- "pallet-sudo 31.0.0",
- "pallet-timestamp 30.0.0",
- "pallet-transaction-payment 31.0.0",
- "pallet-transaction-payment-rpc-runtime-api 31.0.0",
- "pallet-utility 31.0.0",
- "pallet-xcm 10.0.1",
- "parachains-common 10.0.0",
+ "pallet-nfts 26.0.0",
+ "pallet-nfts-runtime-api 18.0.0",
+ "pallet-preimage 32.0.0",
+ "pallet-proxy 32.0.0",
+ "pallet-scheduler 33.0.0",
+ "pallet-session 32.0.0",
+ "pallet-sudo 32.0.0",
+ "pallet-timestamp 31.0.0",
+ "pallet-transaction-payment 32.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 32.0.0",
+ "pallet-utility 32.0.0",
+ "pallet-xcm 11.0.0",
+ "parachains-common 11.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-runtime-common 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-runtime-common 11.0.0",
  "pop-primitives",
  "pop-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api 29.0.0",
- "sp-block-builder 29.0.0",
- "sp-consensus-aura 0.35.0",
- "sp-core 31.0.0",
- "sp-genesis-builder 0.10.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-offchain 29.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
+ "sp-api 30.0.0",
+ "sp-block-builder 30.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-core 32.0.0",
+ "sp-genesis-builder 0.11.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-offchain 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
  "sp-std",
- "sp-transaction-pool 29.0.0",
- "sp-version 32.0.0",
- "staging-parachain-info 0.10.0",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
- "staging-xcm-executor 10.0.0",
- "substrate-wasm-builder 20.0.0",
+ "sp-transaction-pool 30.0.0",
+ "sp-version 33.0.0",
+ "staging-parachain-info 0.11.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
+ "staging-xcm-executor 11.0.0",
+ "substrate-wasm-builder 21.0.0",
 ]
 
 [[package]]
@@ -12387,116 +12327,116 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165988588402ce7dc2d32dfba280cbbd59befc444d8f95579b999ecd8575ef27"
+checksum = "ee1a30be097c0e02d2aacc4b2b73ecba2c795ae9246f2c37711ebae0e69dd95c"
 dependencies = [
  "binary-merkle-tree 15.0.0",
- "frame-benchmarking 31.0.0",
- "frame-executive 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "frame-system-benchmarking 31.0.0",
- "frame-system-rpc-runtime-api 29.0.0",
- "frame-try-runtime 0.37.0",
+ "frame-benchmarking 32.0.0",
+ "frame-executive 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "frame-system-benchmarking 32.0.0",
+ "frame-system-rpc-runtime-api 30.0.0",
+ "frame-try-runtime 0.38.0",
  "hex-literal",
  "log",
- "pallet-asset-rate 10.0.0",
- "pallet-authority-discovery 31.0.1",
- "pallet-authorship 31.0.0",
- "pallet-babe 31.0.0",
- "pallet-balances 31.0.0",
- "pallet-beefy 31.0.0",
- "pallet-beefy-mmr 31.0.0",
- "pallet-bounties 30.0.0",
- "pallet-child-bounties 30.0.0",
+ "pallet-asset-rate 11.0.0",
+ "pallet-authority-discovery 32.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-babe 32.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-beefy 32.0.0",
+ "pallet-beefy-mmr 32.0.0",
+ "pallet-bounties 31.0.0",
+ "pallet-child-bounties 31.0.0",
  "pallet-collective",
- "pallet-conviction-voting 31.0.0",
+ "pallet-conviction-voting 32.0.0",
  "pallet-democracy",
  "pallet-elections-phragmen",
- "pallet-grandpa 31.0.0",
- "pallet-identity 31.0.0",
- "pallet-im-online 30.0.0",
- "pallet-indices 31.0.0",
+ "pallet-grandpa 32.0.0",
+ "pallet-identity 32.0.0",
+ "pallet-indices 32.0.0",
  "pallet-membership",
- "pallet-message-queue 34.0.0",
- "pallet-mmr 30.0.0",
- "pallet-multisig 31.0.0",
+ "pallet-message-queue 35.0.0",
+ "pallet-mmr 31.0.0",
+ "pallet-multisig 32.0.0",
  "pallet-nis",
- "pallet-offences 30.0.0",
- "pallet-preimage 31.0.0",
- "pallet-proxy 31.0.0",
+ "pallet-offences 31.0.0",
+ "pallet-preimage 32.0.0",
+ "pallet-proxy 32.0.0",
  "pallet-ranked-collective",
  "pallet-recovery",
- "pallet-referenda 31.0.0",
+ "pallet-referenda 32.0.0",
  "pallet-root-testing",
- "pallet-scheduler 32.0.0",
- "pallet-session 31.0.0",
+ "pallet-scheduler 33.0.0",
+ "pallet-session 32.0.0",
  "pallet-society",
- "pallet-staking 31.0.0",
- "pallet-state-trie-migration 32.0.0",
- "pallet-sudo 31.0.0",
- "pallet-timestamp 30.0.0",
+ "pallet-staking 32.0.0",
+ "pallet-state-trie-migration 33.0.0",
+ "pallet-sudo 32.0.0",
+ "pallet-timestamp 31.0.0",
  "pallet-tips",
- "pallet-transaction-payment 31.0.0",
- "pallet-transaction-payment-rpc-runtime-api 31.0.0",
- "pallet-treasury 30.0.0",
- "pallet-utility 31.0.0",
- "pallet-vesting 31.0.0",
- "pallet-whitelist 30.0.0",
- "pallet-xcm 10.0.1",
- "pallet-xcm-benchmarks 10.0.0",
+ "pallet-transaction-payment 32.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 32.0.0",
+ "pallet-treasury 31.0.0",
+ "pallet-utility 32.0.0",
+ "pallet-vesting 32.0.0",
+ "pallet-whitelist 31.0.0",
+ "pallet-xcm 11.0.0",
+ "pallet-xcm-benchmarks 11.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
- "polkadot-runtime-common 10.0.0",
- "polkadot-runtime-parachains 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
+ "polkadot-runtime-common 11.0.0",
+ "polkadot-runtime-parachains 11.0.0",
  "rococo-runtime-constants",
  "scale-info",
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api 29.0.0",
- "sp-arithmetic 25.0.0",
- "sp-authority-discovery 29.0.0",
- "sp-block-builder 29.0.0",
- "sp-consensus-babe 0.35.0",
- "sp-consensus-beefy 16.0.0",
- "sp-core 31.0.0",
- "sp-genesis-builder 0.10.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-mmr-primitives 29.0.0",
- "sp-offchain 29.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-staking 29.0.0",
+ "sp-api 30.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-authority-discovery 30.0.0",
+ "sp-block-builder 30.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-consensus-beefy 17.0.0",
+ "sp-core 32.0.0",
+ "sp-genesis-builder 0.11.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-mmr-primitives 30.0.0",
+ "sp-offchain 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
- "sp-storage",
- "sp-transaction-pool 29.0.0",
- "sp-version 32.0.0",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
- "staging-xcm-executor 10.0.0",
+ "sp-storage 21.0.0",
+ "sp-transaction-pool 30.0.0",
+ "sp-version 33.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
+ "staging-xcm-executor 11.0.0",
  "static_assertions",
- "substrate-wasm-builder 20.0.0",
+ "substrate-wasm-builder 21.0.0",
+ "xcm-fee-payment-runtime-api",
 ]
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0033b0335cd7cb691fbcd16346e151ffb21ad4e2a8675eda06b48275b8f52549"
+checksum = "aa26847ef6b32b5fd41d4f86538ef15b8d74f208d211644dc14e4dda74559116"
 dependencies = [
- "frame-support 31.0.0",
- "polkadot-primitives 10.0.0",
- "polkadot-runtime-common 10.0.0",
+ "frame-support 32.0.0",
+ "polkadot-primitives 11.0.0",
+ "polkadot-runtime-common 11.0.0",
  "smallvec",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-weights 30.0.0",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-weights 31.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
 ]
 
 [[package]]
@@ -12781,27 +12721,28 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4715fddb2bd1862aa21f6312528ab339b7d03ef5ec654e3aa200a3119392392f"
+checksum = "97e78771bbc491d4d601afbbf01f5718d6d724d0d971c8581cf5b4c62a9502f7"
 dependencies = [
  "log",
- "sp-core 31.0.0",
- "sp-wasm-interface",
+ "sp-core 32.0.0",
+ "sp-wasm-interface 21.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f987a536468e06b66fe3cac296b27dc532f301199e0278bc42ac32b8eb3a4a9d"
+checksum = "e9cd4cf9f2f6a12f1cc042831474f33103aad8ebf9fa6d49f7119521ed89b1ec"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "ip_network",
  "libp2p",
+ "linked_hash_set",
  "log",
  "multihash 0.18.1",
  "multihash-codetable",
@@ -12811,21 +12752,21 @@ dependencies = [
  "rand",
  "sc-client-api",
  "sc-network",
- "sp-api 29.0.0",
- "sp-authority-discovery 29.0.0",
+ "sp-api 30.0.0",
+ "sp-authority-discovery 30.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295be922b93bd4bc77edadffe66ac85a09436284afe7f12c1efd4d01ec530d07"
+checksum = "a2354138e44624d68245b9490c0d30f73bac7c00f218643ff03fc0dbd1536b98"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12835,36 +12776,36 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-block-builder"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033b5ee0fa6d770c9db8cd59f6d1f88e792c088238278fcb836b5c851936a62d"
+checksum = "7d54ed880c04f6df650dcf4672d7d4a2d08b30e95c51f07b4a3be75eaa535082"
 dependencies = [
  "parity-scale-codec",
- "sp-api 29.0.0",
- "sp-block-builder 29.0.0",
+ "sp-api 30.0.0",
+ "sp-block-builder 30.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
- "sp-trie 32.0.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-trie 33.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "30.0.1"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb28048e5b2d168870e2205d3e41db1f387a781831a8b8b82c9f10536c2742"
+checksum = "e8d25ff00e77262342bd85a71de32170b136773f6a8cdd5641ce8b81fb4e16be"
 dependencies = [
  "array-bytes 6.2.2",
  "docify",
@@ -12879,12 +12820,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-genesis-builder 0.10.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-genesis-builder 0.11.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
 ]
 
 [[package]]
@@ -12901,9 +12842,9 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c2eae4d9396b19403f89f058a6a684066b58e051b1310f246eb9b41a7b54fe"
+checksum = "eade6864cba8ab29c4c7572c6a4a080c0423bc53cb48b00f70eef7d57d22abae"
 dependencies = [
  "array-bytes 6.2.2",
  "chrono",
@@ -12931,21 +12872,21 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-keyring 34.0.0",
- "sp-keystore 0.37.0",
+ "sp-core 32.0.0",
+ "sp-keyring 35.0.0",
+ "sp-keystore 0.38.0",
  "sp-panic-handler",
- "sp-runtime 34.0.0",
- "sp-version 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-version 33.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "sc-client-api"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08db275ca98f1fe44db2e2058893b182b85ef11cee7cf271edffd449a1179fc4"
+checksum = "a6f69c592a2cab8b5cb7860bf57c5084a590d2e0c5df9308f62ddb405ca4d97e"
 dependencies = [
  "fnv",
  "futures",
@@ -12955,25 +12896,25 @@ dependencies = [
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-database",
- "sp-externalities 0.27.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-externalities 0.28.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "sp-statement-store",
- "sp-storage",
- "sp-trie 32.0.0",
+ "sp-storage 21.0.0",
+ "sp-trie 33.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd93f124c30ec885696128a639e190293bee2a6430cc04248d656093b5d4f42"
+checksum = "3f4e8c9db1025f0b17438f5db8937c53022b417593f30d4624b8b2e0d3300b9f"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12987,20 +12928,20 @@ dependencies = [
  "sc-client-api",
  "sc-state-db",
  "schnellru",
- "sp-arithmetic 25.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-database",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
- "sp-trie 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-trie 33.0.0",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da51746e9689ecee65d6c1ac32e89a7b0452ee1ce377485e94c285e9690dcfd"
+checksum = "a051ffa28788f7ec47e46d6236132126d5aa563469e6c852e87cfbe5069e0687"
 dependencies = [
  "async-trait",
  "futures",
@@ -13012,21 +12953,21 @@ dependencies = [
  "sc-client-api",
  "sc-utils",
  "serde",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988701c58dcd9521412cfcbb54457b17546bb4363f021ee8131af409a027b879"
+checksum = "6cd537650a8f23d6775456a5a06e1cf27722fedc5515769983e18ef856a6aad3"
 dependencies = [
  "async-trait",
  "futures",
@@ -13037,26 +12978,26 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-block-builder 29.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-block-builder 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura 0.35.0",
- "sp-consensus-slots 0.35.0",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-consensus-slots 0.36.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65da2a2d198d0c06be3614eabc254b40ebb27516dd17bee56d24cbe08d0c19e"
+checksum = "efe6f127a27ea6ace8e4391ba847ccf21d3512499e1c5e7c300e7e5115642544"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -13073,27 +13014,27 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-block-builder 29.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-block-builder 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.35.0",
- "sp-consensus-slots 0.35.0",
- "sp-core 31.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-consensus-slots 0.36.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-inherents 29.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
+ "sp-inherents 30.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec114d8e12b82b298abdfbca76e7aac3af42865510dfb0f92fd3992e7edbb383"
+checksum = "c93183245d51eab164ab5513f5ad723964c38f293427d99066f8aed02ae715e1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13101,22 +13042,22 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.35.0",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a49993da0847cf1ef84184e24e8d95f71efac2e940556678bf9e45a8fd0a47f"
+checksum = "87f0cdd776453ce7d73fdb548648bdfefdac6c497d198083222aa0d7636445ed"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -13132,17 +13073,17 @@ dependencies = [
  "sc-network-gossip",
  "sc-network-sync",
  "sc-utils",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-arithmetic 25.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-beefy 16.0.0",
- "sp-core 31.0.0",
+ "sp-consensus-beefy 17.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-keystore 0.37.0",
- "sp-mmr-primitives 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-keystore 0.38.0",
+ "sp-mmr-primitives 30.0.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -13151,9 +13092,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179b561aa302c0a5a572c5484a50f85e4ccd55025fc14daddabf5fe16e8150e1"
+checksum = "3f8193f51766e9bf5a94f044333f4807918f7243eab404e9ff91b98ba268f2e9"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13163,31 +13104,31 @@ dependencies = [
  "sc-consensus-beefy",
  "sc-rpc",
  "serde",
- "sp-consensus-beefy 16.0.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-beefy 17.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e892ae8bf5faa9042b6ec46396db1b4d9ded180a5f82afe3236fdebe0195f850"
+checksum = "b2217e53886dbfd4749eaa2e671f8e59807a2fb711ffa0023b3dc5b30f5db458"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19945689693bbea950220bf7af1c79a2f70f5f37b97f7e6d136dcaf2b34f4a5"
+checksum = "5d666c23af4325c6d2ca35bfe2874917f5dfdd94bfca165ad89b92191489e2d8"
 dependencies = [
  "ahash 0.8.11",
  "array-bytes 6.2.2",
@@ -13213,25 +13154,25 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-arithmetic 25.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-grandpa 16.0.0",
- "sp-core 31.0.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cd632a2a33d82e67cfd57dda6d966a6e25df08a4698c8d6ea7010515c5aebc"
+checksum = "24ff3f1dc9c74563e559725736e07f4817e3429cdfd593e4a8c583d2c8da0894"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13243,16 +13184,16 @@ dependencies = [
  "sc-rpc",
  "serde",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b431251c43b5af64b0f2758a387061f53fa045bdbf97d7353fe06aa9ddfb7b"
+checksum = "80382f4da8a76c05c23b84d5c369bb5d617d499749171335e9b47599885fb202"
 dependencies = [
  "async-trait",
  "futures",
@@ -13262,21 +13203,21 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-telemetry",
- "sp-arithmetic 25.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.35.0",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-consensus-slots 0.36.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8f8ddc63df8219768b729f9098ecd4362d2756b40784071cd44c3041f1d51d"
+checksum = "cc6b47b642a92adcabaeadb7d76bd1a02bcf5a93f2b649e81afe8b940107bbda"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -13284,49 +13225,49 @@ dependencies = [
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api 29.0.0",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
- "sp-io 33.0.0",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
+ "sp-io 34.0.0",
  "sp-panic-handler",
- "sp-runtime-interface 26.0.0",
- "sp-trie 32.0.0",
- "sp-version 32.0.0",
- "sp-wasm-interface",
+ "sp-runtime-interface 27.0.0",
+ "sp-trie 33.0.0",
+ "sp-version 33.0.0",
+ "sp-wasm-interface 21.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00308c10173ec6446ccc2b96cd3a3037e64c94a424f94daa8c96f288794f4d34"
+checksum = "88c61ef111d7ccc7697ee4788654f4f998662db057c27ca2de4b94f20e3e6ed1"
 dependencies = [
  "polkavm",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface",
+ "sp-wasm-interface 21.0.0",
  "thiserror",
  "wasm-instrument",
 ]
 
 [[package]]
 name = "sc-executor-polkavm"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b9c814d3a94df7a323d728a6961a3b9ec8c5c5979eb858ec098ddf2838cfc0"
+checksum = "6fb96b22b779ba14f449d114b63efd162f95f1cdf773cdac29f75fe6a250de24"
 dependencies = [
  "log",
  "polkavm",
  "sc-executor-common",
- "sp-wasm-interface",
+ "sp-wasm-interface 21.0.0",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.32.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa37286464bd16146c612e3193a56df728815d23f9bf0faac7df898c0944c87f"
+checksum = "1f45912e90278c06bacf2c37a11937ed6878ee0cd056ae2be2d0b45ec7ac34d1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13336,16 +13277,16 @@ dependencies = [
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 26.0.0",
- "sp-wasm-interface",
+ "sp-runtime-interface 27.0.0",
+ "sp-wasm-interface 21.0.0",
  "wasmtime",
 ]
 
 [[package]]
 name = "sc-informant"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9005c37100c6ea2b06668f72ba5bc927b5a2445ed26b008ddf1875998dea41"
+checksum = "061006dce0dcae3ece90d5d9f656ade507dd922931911d59deea823f28be54dd"
 dependencies = [
  "ansi_term",
  "futures",
@@ -13356,29 +13297,29 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
 name = "sc-keystore"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef7283da5d643ef89ed094e1b23451ec70386a9474d337cdaa0ef81870bb2d4"
+checksum = "6477f27aa17ada189355325c16992d3e612d2fe276ecef9da1b36b6b297b3ac4"
 dependencies = [
  "array-bytes 6.2.2",
  "parking_lot 0.12.1",
  "serde_json",
- "sp-application-crypto 33.0.0",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-mixnet"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248d9be75de68e34f6490065c398b8177ff967902d93e6b88527a0e8c00903ad"
+checksum = "c8e04fecf6e55e4597e473c87e8f3cea5a9963835af30a971203290d62bb2d03"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -13395,20 +13336,20 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-transaction-pool-api",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-consensus",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
  "sp-mixnet",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4067423488686ff78561ed0d32ac7e2617edd31219088b1322e85e945e62de29"
+checksum = "39e68214c9245ee374a6c51fca3c00feddbe20a86451d92c76585a9cc9553425"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -13435,10 +13376,10 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic 25.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -13450,9 +13391,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-bitswap"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dacf210f4e36e53dc3d3ff1cfd72e4378eb973568c261e7c62bc8daaec9f945"
+checksum = "cf7cf01e661f39303737596859139fcdd31bd106a979fae0828f3e5b0decce89"
 dependencies = [
  "async-channel 1.9.0",
  "cid",
@@ -13464,16 +13405,16 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sp-blockchain",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "thiserror",
  "unsigned-varint",
 ]
 
 [[package]]
 name = "sc-network-common"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551dba7ce65d136788c3154044fb425e2cb6e883d20c3cd25c0720a5b5251ed4"
+checksum = "98b1732616f6fd5bcdabd44eac79b466c2075f3f47ebf0cf2f6d52d790890736"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -13483,15 +13424,15 @@ dependencies = [
  "prost-build",
  "sc-consensus",
  "sp-consensus",
- "sp-consensus-grandpa 16.0.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e36f8665cba733bd0690e864ef59cb87627120e57607b768e6e7cf30cecd20"
+checksum = "ebb8b10666371dc53bd9e11dbb99e0763307203ecc70f4d9bb20169cf7ad69db"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -13502,16 +13443,16 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "schnellru",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "sc-network-light"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c4a77832e7d86e2b8f579339a47ebc16eec560bb4d62c42f0daad10700a512"
+checksum = "7be9c7b3d18d5ef3ed493be173e9cb00537585cd9b21bb4ebe24b9b555cf4fa4"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -13524,16 +13465,16 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network-sync"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7dfdaf49edeaa23ae0da1a9bf6ea3e308c11822cb3a853996f1203b06249411"
+checksum = "1df8a240043ecd1c5ca54d1dfdc654878aed6b96fe7292c11dc9e8bc7c4884fb"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -13554,12 +13495,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "smallvec",
- "sp-arithmetic 25.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-grandpa 16.0.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -13568,9 +13509,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b3824e7a1aa29ed3d2294810c8e018a6df3798eec236f3043a62945daf7d9b1"
+checksum = "a1514ca1cc195842970b3a35b80cc14ed002296f3565c19d4659be44ca9255b8"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -13582,15 +13523,15 @@ dependencies = [
  "sc-network-sync",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-offchain"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d03fd90a535f30badaee9763a2124b9c68dae406e29497f406bfd45cbc7eac"
+checksum = "91f289809d0c3fd09474637bfe2dc732f41fb211d1241885194232c5d612a641"
 dependencies = [
  "array-bytes 6.2.2",
  "bytes",
@@ -13611,12 +13552,12 @@ dependencies = [
  "sc-network-common",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 29.0.0",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
- "sp-keystore 0.37.0",
- "sp-offchain 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
+ "sp-keystore 0.38.0",
+ "sp-offchain 30.0.0",
+ "sp-runtime 35.0.0",
  "threadpool",
  "tracing",
 ]
@@ -13633,9 +13574,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d796d75b22785b09c58478f1418b75c9787d598a0d2ab8edbd0072731ec4aaa"
+checksum = "d3d7b43d6ce2c57d90dab64a0eab4673158a7a240119fd3ae934ce95f8ad973f"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13651,24 +13592,24 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
- "sp-offchain 29.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "sp-offchain 30.0.0",
  "sp-rpc",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
  "sp-statement-store",
- "sp-version 32.0.0",
+ "sp-version 33.0.0",
  "tokio",
 ]
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3705feca378ef3f3f84fb337480405a611a15c8637b2449ed514ca63765e421b"
+checksum = "b82060f09f886f59fd19a77cc6668c209e883fc93511e9c441ef84adfea80f36"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13678,18 +13619,18 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-rpc",
- "sp-runtime 34.0.0",
- "sp-version 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-version 33.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-rpc-server"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f705946ae375fc47ee9a2e2df0b7e339a1fb8c8eb5c9eb6f206619d27946a7"
+checksum = "76f6d0924de213aa5c72a47c7bd0d7668531c5845e832d1ac5c33c96d0ff7b9b"
 dependencies = [
  "futures",
  "governor",
@@ -13706,9 +13647,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66dcea3fe5f0bcbaf08d6a42e877ae8f50b9cdbc87f65f7c79fbe5003e3969dc"
+checksum = "ad831d2524de44a89b1801e306fd9718dc5fadb26ea3e88f486faa29c6fdd710"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -13725,12 +13666,12 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-rpc",
- "sp-runtime 34.0.0",
- "sp-version 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-version 33.0.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -13738,9 +13679,9 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42678fb737ea101658a8288cd3fcc0bff59ef40cd1a1c4f4d4042c3fa17bae41"
+checksum = "3ff048cda961d13a0978bf6e75b1978c0fa886d2087133a4d2107a034afd27c8"
 dependencies = [
  "async-trait",
  "directories",
@@ -13778,20 +13719,20 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-state-machine 0.38.0",
- "sp-storage",
- "sp-transaction-pool 29.0.0",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-storage 21.0.0",
+ "sp-transaction-pool 30.0.0",
  "sp-transaction-storage-proof",
- "sp-trie 32.0.0",
- "sp-version 32.0.0",
+ "sp-trie 33.0.0",
+ "sp-version 33.0.0",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -13803,35 +13744,35 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9863fb81595a25b908d7143c1a3e162d237e67890088363df4a121fe37c49d08"
+checksum = "7259ab2e8e2fa1e7a1c38dd8a88353f80e66369ef8b48d5f7098dbc18c67887f"
 dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
 ]
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54aa61816b82fbe136f3c39b40ecb27bc7302c0c9039cc426b2c6f492666ac5"
+checksum = "4536eb51128eed3d3780f442ca74a4464f26401065bc4cf038609c0f9efeab9c"
 dependencies = [
  "clap",
  "fs4",
  "log",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa4c5d5add3ee03e2b0aa02c827b8e3bc307be7c403eb534f95d5c81d372f78"
+checksum = "75577af6d7128f3c0cd1dfa83f9ec056dbe4cdce297f1d257f2a1253134c6e9a"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13843,15 +13784,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-sysinfo"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f098da1a83dc5b4e69ef66f7dfc5c0a82bc63defe8dcb0aaa1819e9b2bd6d744"
+checksum = "d6a838bf3ba61e83c0f3be4a41ba7ed8c71d19c2adee6396046f78317006637b"
 dependencies = [
  "derive_more",
  "futures",
@@ -13863,17 +13804,17 @@ dependencies = [
  "sc-telemetry",
  "serde",
  "serde_json",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-io 33.0.0",
+ "sp-io 34.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6807ebd9f43ab628931842d3aaa9404ddfd07013e9c7027ca603f496939577"
+checksum = "72a5a306d8c75e61e8c59e18b92886f85db6b4102c4669240eca101954fec79e"
 dependencies = [
  "chrono",
  "futures",
@@ -13891,9 +13832,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e8f5e8eb36f887dba06e1392717e27e4edf12d23d5220dba8ee851de8b174e"
+checksum = "584e4f81defe03776909ce283429c9cd3d80fea6b2f3a303dc2bdf913e11d9e8"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -13908,12 +13849,12 @@ dependencies = [
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-rpc",
- "sp-runtime 34.0.0",
- "sp-tracing",
+ "sp-runtime 35.0.0",
+ "sp-tracing 17.0.0",
  "thiserror",
  "tracing",
  "tracing-log 0.1.4",
@@ -13934,9 +13875,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56300f466670067cca98a931b0b6cbc8b018c0d296eb915c1473bac45b7cd73"
+checksum = "54754bf43dede417a8e64a0d6a46bf2bbed47ff050c1f81c8a575f9b94416886"
 dependencies = [
  "async-trait",
  "futures",
@@ -13949,22 +13890,22 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-runtime 34.0.0",
- "sp-tracing",
- "sp-transaction-pool 29.0.0",
+ "sp-runtime 35.0.0",
+ "sp-tracing 17.0.0",
+ "sp-transaction-pool 30.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3609025d39a1b75f1ee4f490dc52e000de144948a73cacd788f5995df5ebe8bf"
+checksum = "41b563c7257ab650b2639d623da13d1a50a5a6c4ec582bc92e118c73d072bcd4"
 dependencies = [
  "async-trait",
  "futures",
@@ -13972,16 +13913,16 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-utils"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1863d482be044f4768ef5de6119dc70b5e31e6e9f71ad225c177474d6540e424"
+checksum = "acf1bad736c230f16beb1cf48af9e69564df23b13aca9e5751a61266340b4bb5"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -13990,7 +13931,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "prometheus",
- "sp-arithmetic 25.0.0",
+ "sp-arithmetic 26.0.0",
 ]
 
 [[package]]
@@ -14409,14 +14350,14 @@ dependencies = [
 
 [[package]]
 name = "slot-range-helper"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada4c82b85daa6134837918889b341716e4918c608b3cc5345ae67ea85a187c6"
+checksum = "8a0e4ae8d02b43620ca7f567ca94fff494d85aecc73ffebda6c8fa19545b1673"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -14736,7 +14677,7 @@ dependencies = [
  "sp-api-proc-macro 15.0.1",
  "sp-core 29.0.0",
  "sp-externalities 0.26.0",
- "sp-metadata-ir",
+ "sp-metadata-ir 0.6.0",
  "sp-runtime 32.0.0",
  "sp-state-machine 0.36.0",
  "sp-std",
@@ -14747,24 +14688,24 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3fb2cdf7ee9b8d6ec7c2d8740b1a506e393dc18c7c2776764b47136d72dce7"
+checksum = "c8abd1d0732054ad896db8f092abe822106f1acf8bbc462c70f57d0f24c0dcdf"
 dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro 17.0.1",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
- "sp-metadata-ir",
- "sp-runtime 34.0.0",
- "sp-runtime-interface 26.0.0",
- "sp-state-machine 0.38.0",
+ "sp-api-proc-macro 18.0.0",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
+ "sp-metadata-ir 0.7.0",
+ "sp-runtime 35.0.0",
+ "sp-runtime-interface 27.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-trie 32.0.0",
- "sp-version 32.0.0",
+ "sp-trie 33.0.0",
+ "sp-version 33.0.0",
  "thiserror",
 ]
 
@@ -14785,9 +14726,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "17.0.1"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a5680d94c55e1c7dc54e9e09b4827314fab44f9300f0be170898dc402318de"
+checksum = "681e80c1b259ee71880cd3b4ad2a2d41454596252bd267c3edf4e14552ab40e1"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14814,15 +14755,15 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ca6121c22c8bd3d1dce1f05c479101fd0d7b159bef2a3e8c834138d839c75c"
+checksum = "1505fad69251900048ddddc6387265e1545d1a366e3b4dcd57b76a03f0a65ae7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
  "sp-std",
 ]
 
@@ -14843,10 +14784,11 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910c07fa263b20bf7271fdd4adcb5d3217dfdac14270592e0780223542e7e114"
+checksum = "46d0d0a4c591c421d3231ddd5e27d828618c24456d51445d21a1f79fcee97c23"
 dependencies = [
+ "docify",
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
@@ -14872,16 +14814,15 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab47c385784b3f9646a21d5dcb236399083d77420a1269e70c04772336c519f"
+checksum = "4f5700c6f51afc80af2dd2b39973183d7527e8b5be390fa125d777f948db0e88"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-runtime 34.0.0",
- "sp-std",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
@@ -14898,48 +14839,47 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e155e388d7e41c39a27f40f50c2517facdbf20dde4a73f40ec8f1f30ce190e"
+checksum = "466eaa1fe1745e9456a5e5afc033b67a52211463a137ea3551bff36b4d72ce03"
 dependencies = [
- "sp-api 29.0.0",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
- "sp-std",
+ "sp-api 30.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00084ddd62a3bad1fc4c04cdb1cdbcbb55d813dbd4e42d52e42e8b6599fb210"
+checksum = "eed0dc760fde2b2cd07ca9428e3d6b7ecc02bbd00a5dc32b7f829c80889b152b"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "schnellru",
- "sp-api 29.0.0",
+ "sp-api 30.0.0",
  "sp-consensus",
  "sp-database",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-consensus"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6f1ae58a74d619bd2c1d7939b4aa805f4226c7454ec3591c8a59fb0cc6477f"
+checksum = "19910bc7cd10336a1b13611df1212bce5cabbcfcd92a9394e23476498aa360c7"
 dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "thiserror",
 ]
 
@@ -14963,20 +14903,19 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334d0088b7de70a94d58e7e93acd8d5101b35fadca7e19fa26788203b22e309b"
+checksum = "67647dc44d2f47f8b96a56f30a896926485e55a8209cfe916cf8d08a6d488f03"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-consensus-slots 0.35.0",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
- "sp-std",
- "sp-timestamp 29.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-consensus-slots 0.36.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-timestamp 30.0.0",
 ]
 
 [[package]]
@@ -15001,22 +14940,21 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb593ec8ec674a583d6fc5386b7f8964a9db78dcaabc0595559145a4053c9f6c"
+checksum = "a3500dd1ceb99ca5e6f399d37c4e42f22fcbb6505e07378791ebe57eec6a1960"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-consensus-slots 0.35.0",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
- "sp-std",
- "sp-timestamp 29.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-consensus-slots 0.36.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-timestamp 30.0.0",
 ]
 
 [[package]]
@@ -15042,24 +14980,23 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2b03bc552702dd20fd3dad01631b13ca3e62e814ad278fe3012f5e3bb3e100"
+checksum = "160ad989b247b55fdc2acd8baa7d5a0b9daca5ad0d4fac6e94ee119ed0fdf164"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-core 31.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-io 33.0.0",
- "sp-keystore 0.37.0",
- "sp-mmr-primitives 29.0.0",
- "sp-runtime 34.0.0",
- "sp-std",
- "strum 0.24.1",
+ "sp-io 34.0.0",
+ "sp-keystore 0.38.0",
+ "sp-mmr-primitives 30.0.0",
+ "sp-runtime 35.0.0",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -15083,21 +15020,20 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71df706a104a752101b52f12cca7f5b7ffe1ca6ce9b4b1eb8c5d04356f248fa5"
+checksum = "0ffc3f88b33c2a8c14f4d05a3c69c5fc7b02cdd3300993a22d6d2175d35447f6"
 dependencies = [
  "finality-grandpa",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
- "sp-std",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
@@ -15115,15 +15051,14 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a5c47c52ad58aa349f7c13cb356ab45c32964ee28354c27fd6e4b417cb2644"
+checksum = "52dcae1dac6908d80bceaff4f311bc694c3b9c0d3ac6e74128ed4e3a29e9e31f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-std",
- "sp-timestamp 29.0.0",
+ "sp-timestamp 30.0.0",
 ]
 
 [[package]]
@@ -15163,7 +15098,7 @@ dependencies = [
  "sp-externalities 0.26.0",
  "sp-runtime-interface 25.0.0",
  "sp-std",
- "sp-storage",
+ "sp-storage 20.0.0",
  "ss58-registry",
  "substrate-bip39 0.4.6",
  "thiserror",
@@ -15174,9 +15109,9 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d7a0fd8f16dcc3761198fc83be12872f823b37b749bc72a3a6a1f702509366"
+checksum = "bb2dac7e47c7ddbb61efe196d5cce99f6ea88926c961fa39909bfeae46fc5a7b"
 dependencies = [
  "array-bytes 6.2.2",
  "bitflags 1.3.2",
@@ -15207,12 +15142,12 @@ dependencies = [
  "serde",
  "sp-crypto-hashing",
  "sp-debug-derive",
- "sp-externalities 0.27.0",
- "sp-runtime-interface 26.0.0",
+ "sp-externalities 0.28.0",
+ "sp-runtime-interface 27.0.0",
  "sp-std",
- "sp-storage",
+ "sp-storage 21.0.0",
  "ss58-registry",
- "substrate-bip39 0.5.0",
+ "substrate-bip39 0.6.0",
  "thiserror",
  "tracing",
  "w3f-bls",
@@ -15274,19 +15209,18 @@ dependencies = [
  "environmental",
  "parity-scale-codec",
  "sp-std",
- "sp-storage",
+ "sp-storage 20.0.0",
 ]
 
 [[package]]
 name = "sp-externalities"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d6a4572eadd4a63cff92509a210bf425501a0c5e76574b30a366ac77653787"
+checksum = "33abaec4be69b1613796bbf430decbbcaaf978756379e2016e683a4d6379cd02"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std",
- "sp-storage",
+ "sp-storage 21.0.0",
 ]
 
 [[package]]
@@ -15303,14 +15237,13 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1192b502d38c6d17b1005a7b3e7a6ab835df996803968ae3be9e8f7399ee4"
+checksum = "ee8a812b56fb4ed6a598ad7b43be127702aba1f7351ad4916f5bab995054cdc5"
 dependencies = [
  "serde_json",
- "sp-api 29.0.0",
- "sp-runtime 34.0.0",
- "sp-std",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
@@ -15330,16 +15263,15 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5e46ccc5848542648dcf05f882e41de2e341d0eeca97ff2b7dfad0f38e8500"
+checksum = "0fcba3b816fdfadf30d8c7c484e1873f1af89ed2560c77d2b2137d152cc5a585"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
- "sp-std",
+ "sp-runtime 35.0.0",
  "thiserror",
 ]
 
@@ -15363,7 +15295,7 @@ dependencies = [
  "sp-runtime-interface 25.0.0",
  "sp-state-machine 0.36.0",
  "sp-std",
- "sp-tracing",
+ "sp-tracing 16.0.0",
  "sp-trie 30.0.0",
  "tracing",
  "tracing-core",
@@ -15371,27 +15303,27 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e09bba780b55bd9e67979cd8f654a31e4a6cf45426ff371394a65953d2177f2"
+checksum = "c44ed47247b6eee76ff703f9fa9f04f99c4104ac1faf629e6d1128e09066b57b"
 dependencies = [
  "bytes",
  "ed25519-dalek",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "polkavm-derive 0.9.1",
+ "polkavm-derive",
  "rustversion",
  "secp256k1",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-externalities 0.27.0",
- "sp-keystore 0.37.0",
- "sp-runtime-interface 26.0.0",
- "sp-state-machine 0.38.0",
+ "sp-externalities 0.28.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime-interface 27.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-tracing",
- "sp-trie 32.0.0",
+ "sp-tracing 17.0.0",
+ "sp-trie 33.0.0",
  "tracing",
  "tracing-core",
 ]
@@ -15409,13 +15341,13 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07a31da596d705b3a3458d784a897af7fd2f8090de436dc386a112e8ea7f34f"
+checksum = "089da5d08c4a6b4a36de664de287f4a391ac338e351a923b79aedfc46162f201"
 dependencies = [
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "strum 0.24.1",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -15433,14 +15365,14 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbab8b61bd61d5f8625a0c75753b5d5a23be55d3445419acd42caf59cf6236b"
+checksum = "4e6c7a7abd860a5211a356cf9d5fcabf0eb37d997985e5d722b6b33dcc815528"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
 ]
 
 [[package]]
@@ -15466,16 +15398,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-mixnet"
+name = "sp-metadata-ir"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d9da31673ad5771faf8cd0e62ab0c183ea71a630d187b926bc52af379cb1de"
+checksum = "a616fa51350b35326682a472ee8e6ba742fdacb18babac38ecd46b3e05ead869"
+dependencies = [
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "sp-mixnet"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ba1e6ceede3aa5e36ee161dc02f1b294a659823887cefc4f0f2fce589e3c11"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-std",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
 ]
 
 [[package]]
@@ -15499,20 +15441,19 @@ dependencies = [
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518fcd8710618d104e04c9e63e697d3406180afbe55cc5400168019647fc5880"
+checksum = "e8abf5586785c20bb4bdbc81243877d5bb2bdf6dff6a03c101b6a3a875bc9278"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 29.0.0",
- "sp-core 31.0.0",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
  "sp-debug-derive",
- "sp-runtime 34.0.0",
- "sp-std",
+ "sp-runtime 35.0.0",
  "thiserror",
 ]
 
@@ -15533,17 +15474,16 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03ec553bc1a0f4d3aa902d3c5b3cdbe76f8218c642cbca0305722b3f8bbc826"
+checksum = "3ae4f90a3a36f052f4f9aa6f6ab1d59cf6f895f3a939f40dbe1f3e14907a2e31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-std",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
@@ -15559,13 +15499,13 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c041d932d7debf1d2e073ecece1425aadae7482689cd4bf148d5886b28bd10d7"
+checksum = "50efea44dfc8e40c59e9f9099c6a4f64dc750ad224fd8dbf9aec12fc857fa145"
 dependencies = [
- "sp-api 29.0.0",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
@@ -15581,13 +15521,13 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26650747f5c204afd8c637df5e882ea912a890cf974fe67c36b430318fc451c"
+checksum = "51104c3cab9d6c9e8361adbd487dd409a8343e740744fb0b3f983bc775fd1847"
 dependencies = [
  "rustc-hash",
  "serde",
- "sp-core 31.0.0",
+ "sp-core 32.0.0",
 ]
 
 [[package]]
@@ -15617,9 +15557,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3cb126971e7db2f0fcf8053dce740684c438c7180cfca1959598230f342c58"
+checksum = "42ce931b7fbfdeeca1340801dbd4a1cae54ad4c97a1e3dcfcc79709bc800dd46"
 dependencies = [
  "docify",
  "either",
@@ -15632,12 +15572,12 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 33.0.0",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
  "sp-std",
- "sp-weights 30.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
@@ -15653,29 +15593,29 @@ dependencies = [
  "sp-externalities 0.26.0",
  "sp-runtime-interface-proc-macro 17.0.0",
  "sp-std",
- "sp-storage",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-storage 20.0.0",
+ "sp-tracing 16.0.0",
+ "sp-wasm-interface 20.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a675ea4858333d4d755899ed5ed780174aa34fec15953428d516af5452295"
+checksum = "647db5e1dc481686628b41554e832df6ab400c4b43a6a54e54d3b0a71ca404aa"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.8.0",
+ "polkavm-derive",
  "primitive-types",
- "sp-externalities 0.27.0",
+ "sp-externalities 0.28.0",
  "sp-runtime-interface-proc-macro 18.0.0",
  "sp-std",
- "sp-storage",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-storage 21.0.0",
+ "sp-tracing 17.0.0",
+ "sp-wasm-interface 21.0.0",
  "static_assertions",
 ]
 
@@ -15725,18 +15665,17 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a61ea4ca90f644da2c25edee711b53b1c0b8d50628ceef372224ea24d252b57"
+checksum = "3d66f0f2f00e4c520deae07eeab7acf04c1a41dd875c7a4689e4e4302fb89925"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 29.0.0",
- "sp-core 31.0.0",
- "sp-keystore 0.37.0",
- "sp-runtime 34.0.0",
- "sp-staking 29.0.0",
- "sp-std",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
 ]
 
 [[package]]
@@ -15756,17 +15695,16 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114cde17987eaa2f17b8850a8c856b90364666cdbc920d511e7a1cde0574d24"
+checksum = "09a43ec7f6c9759ba3011a16bb022afe056bc26f88b3c424598737cba71d3ef0"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-std",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
@@ -15793,9 +15731,9 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eae0eac8034ba14437e772366336f579398a46d101de13dbb781ab1e35e67c5"
+checksum = "21d9078306c3066f1824e41153e1ceec34231d39d9a7e7956b101eadf7b9fd3a"
 dependencies = [
  "hash-db",
  "log",
@@ -15803,11 +15741,10 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand",
  "smallvec",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
  "sp-panic-handler",
- "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie 33.0.0",
  "thiserror",
  "tracing",
  "trie-db",
@@ -15815,9 +15752,9 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90e8440d72e0ae5d273374af3ebe16768d05b40dff1f487835dd2f826ee9568"
+checksum = "0e22e2d355461e02aa8325a819d24403fb7232a828bf1e21ad8982fde3f0dc0e"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
@@ -15827,14 +15764,13 @@ dependencies = [
  "rand",
  "scale-info",
  "sha2 0.10.8",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-core 31.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-externalities 0.27.0",
- "sp-runtime 34.0.0",
- "sp-runtime-interface 26.0.0",
- "sp-std",
+ "sp-externalities 0.28.0",
+ "sp-runtime 35.0.0",
+ "sp-runtime-interface 27.0.0",
  "thiserror",
  "x25519-dalek 2.0.1",
 ]
@@ -15860,6 +15796,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-storage"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c82989b3a4979a7e1ad848aad9f5d0b4388f1f454cc131766526601ab9e8f8"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "ref-cast",
+ "serde",
+ "sp-debug-derive",
+]
+
+[[package]]
 name = "sp-timestamp"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15875,15 +15824,14 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d51fcd008fd5a79d61dba98c7ae89c2460a49dff07001bf1e9b12535d49536"
+checksum = "d6d3965ef60cc066fcc01dbcb7837404f40de8ac58f1115e3a3a1d6550575ff6"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
- "sp-std",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
  "thiserror",
 ]
 
@@ -15901,6 +15849,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-tracing"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b3decf116db9f1dfaf1f1597096b043d0e12c952d3bcdc018c6d6b77deec7e"
+dependencies = [
+ "parity-scale-codec",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
 name = "sp-transaction-pool"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15912,28 +15872,27 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0484eaf40c2abda75bda9688298cc8f6e02161176e3aab501207c8ccf4d4b3e1"
+checksum = "7bddae32e6935eedda993b7371b79e69af901a277e11be2bbd6d9bc7643b49cb"
 dependencies = [
- "sp-api 29.0.0",
- "sp-runtime 34.0.0",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0c99e0852ddd18159c2dc6100c2b5852e49211d8afe373cbce33d1da0050dd"
+checksum = "726f90279766e231ad86f884e5f07d9331852a59d739f27c5f5e28bee0fc6da5"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-core 31.0.0",
- "sp-inherents 29.0.0",
- "sp-runtime 34.0.0",
- "sp-std",
- "sp-trie 32.0.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-trie 33.0.0",
 ]
 
 [[package]]
@@ -15963,9 +15922,9 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1aa91ad26c62b93d73e65f9ce7ebd04459c4bad086599348846a81988d6faa4"
+checksum = "d1f5b3620a1c87c265a83d85d7519c6b60c47acf7f77593966afe313d086f00e"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
@@ -15977,9 +15936,8 @@ dependencies = [
  "rand",
  "scale-info",
  "schnellru",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
- "sp-std",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
  "thiserror",
  "tracing",
  "trie-db",
@@ -16000,15 +15958,15 @@ dependencies = [
  "sp-crypto-hashing-proc-macro",
  "sp-runtime 32.0.0",
  "sp-std",
- "sp-version-proc-macro",
+ "sp-version-proc-macro 13.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-version"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0219b1aeb89e36d13bd43a718920a9087dbb66c567e672c4639cefb2fefc05"
+checksum = "3ba2f18b89ac5f356fb247f70163098bc976117221c373d5590079a5797a3b43"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -16016,9 +15974,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-version-proc-macro",
+ "sp-version-proc-macro 14.0.0",
  "thiserror",
 ]
 
@@ -16027,6 +15985,18 @@ name = "sp-version-proc-macro"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9bc3fed32d6dacbbbfb28dd1fe0224affbb737cb6cbfca1d9149351c2b69a7d"
+dependencies = [
+ "parity-scale-codec",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "sp-version-proc-macro"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aee8f6730641a65fcf0c8f9b1e448af4b3bb083d08058b47528188bccc7b7a7"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -16049,6 +16019,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-wasm-interface"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b04b919e150b4736d85089d49327eab65507deb1485eec929af69daa2278eb3"
+dependencies = [
+ "anyhow",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "wasmtime",
+]
+
+[[package]]
 name = "sp-weights"
 version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16066,18 +16049,17 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af6c661fe3066b29f9e1d258000f402ff5cc2529a9191972d214e5871d0ba87"
+checksum = "93cdaf72a1dad537bbb130ba4d47307ebe5170405280ed1aa31fa712718a400e"
 dependencies = [
  "bounded-collections 0.2.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic 25.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-debug-derive",
- "sp-std",
 ]
 
 [[package]]
@@ -16183,16 +16165,16 @@ dependencies = [
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df1c48ca2892cb0694c7e10fbcfc8d15fe0fd0b763d61fbc587a870fbb97147"
+checksum = "1383aa763f2cea1a816761948bfc1245040740d418c6b77d36fd4f259b944d84"
 dependencies = [
- "cumulus-primitives-core 0.10.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "cumulus-primitives-core 0.11.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -16217,9 +16199,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ee775f7fc9dfae15d9d5a806efa7d3215f7b7b1cfd225809285a0281addeab"
+checksum = "aded0292274ad473250c22ed3deaf2d9ed47d15786d700e9e83ab7c1cad2ad44"
 dependencies = [
  "array-bytes 6.2.2",
  "bounded-collections 0.2.0",
@@ -16230,7 +16212,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-weights 30.0.0",
+ "sp-weights 31.0.0",
  "xcm-procedural",
 ]
 
@@ -16259,25 +16241,25 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c905c7e545eb80efdbf62470575a37935260503494453ffa3c1ac6207d06c9"
+checksum = "0681b0a478c2f5e1f1ae9b7e8e4970d79ec8ef94f4efebc011ea335822bc264e"
 dependencies = [
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-transaction-payment 31.0.0",
+ "pallet-transaction-payment 32.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives 9.0.0",
+ "polkadot-parachain-primitives 10.0.0",
  "scale-info",
- "sp-arithmetic 25.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-weights 30.0.0",
- "staging-xcm 10.0.0",
- "staging-xcm-executor 10.0.0",
+ "sp-weights 31.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-executor 11.0.0",
 ]
 
 [[package]]
@@ -16304,24 +16286,24 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30434a78d4392b698bc7854c00f52d83c1c544da4be1912f898958c3e32f062"
+checksum = "cb518e82e9982c90c32b66263642385fc186c76f329766884d3360b65e84dd46"
 dependencies = [
  "environmental",
- "frame-benchmarking 31.0.0",
- "frame-support 31.0.0",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-weights 30.0.0",
- "staging-xcm 10.0.0",
+ "sp-weights 31.0.0",
+ "staging-xcm 11.0.0",
 ]
 
 [[package]]
@@ -16393,6 +16375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16419,6 +16410,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "substrate-bip39"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16433,9 +16437,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b564c293e6194e8b222e52436bcb99f60de72043c7f845cf6c4406db4df121"
+checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -16452,22 +16456,22 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0da351445855b0d5bff2721c64508dc790d5cc0804d1d395074c8dafeb2170"
+checksum = "949d14f7bb2a53b77985bd17a8eb2e9edf8d5bbf4409e9acb036fa3bf7310d8f"
 dependencies = [
- "frame-system-rpc-runtime-api 29.0.0",
+ "frame-system-rpc-runtime-api 30.0.0",
  "futures",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api 29.0.0",
- "sp-block-builder 29.0.0",
+ "sp-api 30.0.0",
+ "sp-block-builder 30.0.0",
  "sp-blockchain",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
@@ -16485,33 +16489,33 @@ dependencies = [
 
 [[package]]
 name = "substrate-rpc-client"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71c3305c6159e3f4cfc158f88ceefb94dd86b2c92c6120ad51a9d9c31c0dce6"
+checksum = "812076602836d6d90242c431729814c790c49685d142f47ec41f3b897a5fb6ad"
 dependencies = [
  "async-trait",
  "jsonrpsee",
  "log",
  "sc-rpc-api",
  "serde",
- "sp-runtime 34.0.0",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff3afa7be8eca9226448012fa58eeaaab9c42be60214471d304658ac4856052b"
+checksum = "0da2e823fb02fbd5c77d6949cde60ff3e320c100278818000b39e9f0a8c8c428"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
  "serde",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
- "sp-trie 32.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-trie 33.0.0",
  "trie-db",
 ]
 
@@ -16536,9 +16540,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55ed4ff2945faa132b9658cb581a3a5cf14dd90b5e217b3e16724eb202ed6c6"
+checksum = "82a7c3e61041eaa76a89ded469f84d243fb34557ba4ee1e60335e65c8b5540c9"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -16547,7 +16551,7 @@ dependencies = [
  "parity-wasm",
  "polkavm-linker",
  "sp-maybe-compressed-blob",
- "strum 0.24.1",
+ "strum 0.26.3",
  "tempfile",
  "toml 0.8.12",
  "walkdir",
@@ -17088,12 +17092,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461fe686e103f3afc4c93a56474193ffc46d4b2770f8df5d56e025e8bb54960c"
+checksum = "48057e9b12f413d8d104aeb84d6efad65e8bd325acbfa91f7f97724bcf1dd2ed"
 dependencies = [
  "coarsetime",
- "polkadot-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
  "tracing",
  "tracing-gum-proc-macro",
 ]
@@ -17258,14 +17262,14 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "try-runtime-cli"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80765dc36d90e9f2112dccc6e5d70df50ab1239dba8e004bcc70cc77b3a9712d"
+checksum = "a45904e10377e9973238ae9e52bd0fbbb0bba5d7be9198458ba9d3fe0a4173ed"
 dependencies = [
  "async-trait",
  "clap",
  "frame-remote-externalities",
- "frame-try-runtime 0.37.0",
+ "frame-try-runtime 0.38.0",
  "hex",
  "log",
  "parity-scale-codec",
@@ -17273,22 +17277,22 @@ dependencies = [
  "sc-executor",
  "serde",
  "serde_json",
- "sp-api 29.0.0",
- "sp-consensus-aura 0.35.0",
- "sp-consensus-babe 0.35.0",
- "sp-core 31.0.0",
+ "sp-api 30.0.0",
+ "sp-consensus-aura 0.36.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-core 32.0.0",
  "sp-debug-derive",
- "sp-externalities 0.27.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-keystore 0.37.0",
+ "sp-externalities 0.28.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-keystore 0.38.0",
  "sp-rpc",
- "sp-runtime 34.0.0",
- "sp-state-machine 0.38.0",
- "sp-timestamp 29.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-timestamp 30.0.0",
  "sp-transaction-storage-proof",
- "sp-version 32.0.0",
- "sp-weights 30.0.0",
+ "sp-version 33.0.0",
+ "sp-weights 31.0.0",
  "substrate-rpc-client",
  "zstd 0.12.4",
 ]
@@ -17919,126 +17923,126 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef1f629f711d7d110a1d13a12d3b4ab8fdc4ec3f97abbe9d1f0d248014a9e72"
+checksum = "c6d7d64eabcbf938ac7978ebc0e3385caedacb2967ee6e2a9b9e1b69a2590498"
 dependencies = [
  "binary-merkle-tree 15.0.0",
  "bitvec",
- "frame-benchmarking 31.0.0",
- "frame-election-provider-support 31.0.0",
- "frame-executive 31.0.0",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
- "frame-system-benchmarking 31.0.0",
- "frame-system-rpc-runtime-api 29.0.0",
- "frame-try-runtime 0.37.0",
+ "frame-benchmarking 32.0.0",
+ "frame-election-provider-support 32.0.0",
+ "frame-executive 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
+ "frame-system-benchmarking 32.0.0",
+ "frame-system-rpc-runtime-api 30.0.0",
+ "frame-try-runtime 0.38.0",
  "hex-literal",
  "log",
- "pallet-asset-rate 10.0.0",
- "pallet-authority-discovery 31.0.1",
- "pallet-authorship 31.0.0",
- "pallet-babe 31.0.0",
- "pallet-bags-list 30.0.0",
- "pallet-balances 31.0.0",
- "pallet-beefy 31.0.0",
- "pallet-beefy-mmr 31.0.0",
+ "pallet-asset-rate 11.0.0",
+ "pallet-authority-discovery 32.0.0",
+ "pallet-authorship 32.0.0",
+ "pallet-babe 32.0.0",
+ "pallet-bags-list 31.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-beefy 32.0.0",
+ "pallet-beefy-mmr 32.0.0",
  "pallet-collective",
- "pallet-conviction-voting 31.0.0",
+ "pallet-conviction-voting 32.0.0",
  "pallet-democracy",
- "pallet-election-provider-multi-phase 30.0.0",
- "pallet-election-provider-support-benchmarking 30.0.0",
+ "pallet-election-provider-multi-phase 31.0.0",
+ "pallet-election-provider-support-benchmarking 31.0.0",
  "pallet-elections-phragmen",
- "pallet-fast-unstake 30.0.0",
- "pallet-grandpa 31.0.0",
- "pallet-identity 31.0.0",
- "pallet-im-online 30.0.0",
- "pallet-indices 31.0.0",
+ "pallet-fast-unstake 31.0.0",
+ "pallet-grandpa 32.0.0",
+ "pallet-identity 32.0.0",
+ "pallet-indices 32.0.0",
  "pallet-membership",
- "pallet-message-queue 34.0.0",
- "pallet-mmr 30.0.0",
- "pallet-multisig 31.0.0",
- "pallet-nomination-pools 28.0.0",
- "pallet-nomination-pools-benchmarking 29.0.0",
- "pallet-nomination-pools-runtime-api 26.0.0",
- "pallet-offences 30.0.0",
- "pallet-offences-benchmarking 31.0.0",
- "pallet-preimage 31.0.0",
- "pallet-proxy 31.0.0",
+ "pallet-message-queue 35.0.0",
+ "pallet-mmr 31.0.0",
+ "pallet-multisig 32.0.0",
+ "pallet-nomination-pools 29.0.0",
+ "pallet-nomination-pools-benchmarking 30.0.0",
+ "pallet-nomination-pools-runtime-api 27.0.0",
+ "pallet-offences 31.0.0",
+ "pallet-offences-benchmarking 32.0.0",
+ "pallet-preimage 32.0.0",
+ "pallet-proxy 32.0.0",
  "pallet-recovery",
- "pallet-referenda 31.0.0",
+ "pallet-referenda 32.0.0",
  "pallet-root-testing",
- "pallet-scheduler 32.0.0",
- "pallet-session 31.0.0",
- "pallet-session-benchmarking 31.0.0",
+ "pallet-scheduler 33.0.0",
+ "pallet-session 32.0.0",
+ "pallet-session-benchmarking 32.0.0",
  "pallet-society",
- "pallet-staking 31.0.0",
+ "pallet-staking 32.0.0",
  "pallet-staking-reward-curve",
- "pallet-staking-runtime-api 17.0.0",
- "pallet-state-trie-migration 32.0.0",
- "pallet-sudo 31.0.0",
- "pallet-timestamp 30.0.0",
- "pallet-transaction-payment 31.0.0",
- "pallet-transaction-payment-rpc-runtime-api 31.0.0",
- "pallet-treasury 30.0.0",
- "pallet-utility 31.0.0",
- "pallet-vesting 31.0.0",
- "pallet-whitelist 30.0.0",
- "pallet-xcm 10.0.1",
- "pallet-xcm-benchmarks 10.0.0",
+ "pallet-staking-runtime-api 18.0.0",
+ "pallet-state-trie-migration 33.0.0",
+ "pallet-sudo 32.0.0",
+ "pallet-timestamp 31.0.0",
+ "pallet-transaction-payment 32.0.0",
+ "pallet-transaction-payment-rpc-runtime-api 32.0.0",
+ "pallet-treasury 31.0.0",
+ "pallet-utility 32.0.0",
+ "pallet-vesting 32.0.0",
+ "pallet-whitelist 31.0.0",
+ "pallet-xcm 11.0.0",
+ "pallet-xcm-benchmarks 11.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
- "polkadot-runtime-common 10.0.0",
- "polkadot-runtime-parachains 10.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
+ "polkadot-runtime-common 11.0.0",
+ "polkadot-runtime-parachains 11.0.0",
  "rustc-hex",
  "scale-info",
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api 29.0.0",
- "sp-application-crypto 33.0.0",
- "sp-arithmetic 25.0.0",
- "sp-authority-discovery 29.0.0",
- "sp-block-builder 29.0.0",
- "sp-consensus-babe 0.35.0",
- "sp-consensus-beefy 16.0.0",
- "sp-core 31.0.0",
- "sp-genesis-builder 0.10.0",
- "sp-inherents 29.0.0",
- "sp-io 33.0.0",
- "sp-mmr-primitives 29.0.0",
- "sp-npos-elections 29.0.0",
- "sp-offchain 29.0.0",
- "sp-runtime 34.0.0",
- "sp-session 30.0.0",
- "sp-staking 29.0.0",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-authority-discovery 30.0.0",
+ "sp-block-builder 30.0.0",
+ "sp-consensus-babe 0.36.0",
+ "sp-consensus-beefy 17.0.0",
+ "sp-core 32.0.0",
+ "sp-genesis-builder 0.11.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-mmr-primitives 30.0.0",
+ "sp-npos-elections 30.0.0",
+ "sp-offchain 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-staking 30.0.0",
  "sp-std",
- "sp-storage",
- "sp-transaction-pool 29.0.0",
- "sp-version 32.0.0",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
- "staging-xcm-executor 10.0.0",
- "substrate-wasm-builder 20.0.0",
+ "sp-storage 21.0.0",
+ "sp-transaction-pool 30.0.0",
+ "sp-version 33.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
+ "staging-xcm-executor 11.0.0",
+ "substrate-wasm-builder 21.0.0",
  "westend-runtime-constants",
+ "xcm-fee-payment-runtime-api",
 ]
 
 [[package]]
 name = "westend-runtime-constants"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ee9606d7d954aef2b22107e80fc128a467cd8d6f1d347f64e417f88b2833c8"
+checksum = "56e49413f666c93595698e3e3283fb05d7d5e0a522ecb6d4c6220d959691d479"
 dependencies = [
- "frame-support 31.0.0",
- "polkadot-primitives 10.0.0",
- "polkadot-runtime-common 10.0.0",
+ "frame-support 32.0.0",
+ "polkadot-primitives 11.0.0",
+ "polkadot-runtime-common 11.0.0",
  "smallvec",
- "sp-core 31.0.0",
- "sp-runtime 34.0.0",
- "sp-weights 30.0.0",
- "staging-xcm 10.0.0",
- "staging-xcm-builder 10.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-weights 31.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
 ]
 
 [[package]]
@@ -18397,37 +18401,53 @@ dependencies = [
 
 [[package]]
 name = "xcm-emulator"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6acd5a2d4c654cb659666c7bc3730b6b29b6caf4d98c6799911069d81b1ed2"
+checksum = "37e42f8cc343d8c52d9412350da0fa8597ddd91c9b4d5664c06f63bb813c69de"
 dependencies = [
- "cumulus-pallet-parachain-system 0.10.0",
- "cumulus-pallet-xcmp-queue 0.10.0",
- "cumulus-primitives-core 0.10.0",
- "cumulus-primitives-parachain-inherent 0.10.0",
+ "cumulus-pallet-parachain-system 0.11.0",
+ "cumulus-pallet-xcmp-queue 0.11.0",
+ "cumulus-primitives-core 0.11.0",
+ "cumulus-primitives-parachain-inherent 0.11.0",
  "cumulus-test-relay-sproof-builder",
- "frame-support 31.0.0",
- "frame-system 31.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "lazy_static",
  "log",
- "pallet-balances 31.0.0",
- "pallet-message-queue 34.0.0",
- "parachains-common 10.0.0",
+ "pallet-balances 33.0.0",
+ "pallet-message-queue 35.0.0",
+ "parachains-common 11.0.0",
  "parity-scale-codec",
  "paste",
- "polkadot-parachain-primitives 9.0.0",
- "polkadot-primitives 10.0.0",
- "polkadot-runtime-parachains 10.0.0",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
+ "polkadot-parachain-primitives 10.0.0",
+ "polkadot-primitives 11.0.0",
+ "polkadot-runtime-parachains 11.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-io 33.0.0",
- "sp-runtime 34.0.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-tracing",
- "staging-xcm 10.0.0",
- "staging-xcm-executor 10.0.0",
+ "sp-tracing 17.0.0",
+ "staging-xcm 11.0.0",
+ "staging-xcm-executor 11.0.0",
+]
+
+[[package]]
+name = "xcm-fee-payment-runtime-api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd9c9513e249ed6d355d0243748c70cb0d7ca81d0604707f334fd481d54e8264"
+dependencies = [
+ "frame-support 32.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-std",
+ "sp-weights 31.0.0",
+ "staging-xcm 11.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ subxt-signer = "0.34.0"
 tokio = { version = "1.36", features = ["macros", "time", "rt-multi-thread"] }
 
 # Build
-substrate-wasm-builder = "20.0.0"
+substrate-wasm-builder = "21.0.0"
 substrate-build-script-utils = "11.0.0"
 
 # Local
@@ -61,112 +61,112 @@ pop-runtime-common = { path = "runtime/common", default-features = false }
 pop-primitives = { path = "./primitives", default-features = false }
 
 # Substrate
-sc-basic-authorship = "0.37.0"
-sc-chain-spec = "30.0.1"
-sc-cli = "0.39.0"
-sc-client-api = "31.0.0"
-sc-offchain = "32.0.0"
-sc-consensus = "0.36.0"
-sc-executor = "0.35.0"
-sc-network = "0.37.0"
-sc-network-sync = "0.36.0"
-sc-rpc = "32.0.0"
-sc-service = "0.38.0"
-sc-sysinfo = "30.0.0"
-sc-telemetry = "17.0.0"
-sc-tracing = "31.0.0"
-sc-transaction-pool = "31.0.0"
-sc-transaction-pool-api = "31.0.0"
-frame-benchmarking = { version = "31.0.0", default-features = false }
-frame-benchmarking-cli = "35.0.1"
-frame-executive = { version = "31.0.0", default-features = false }
-frame-support = { version = "31.0.0", default-features = false }
-frame-system = { version = "31.0.0", default-features = false }
-frame-system-benchmarking = { version = "31.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "29.0.0", default-features = false }
-frame-try-runtime = { version = "0.37.0", default-features = false }
-pallet-aura = { version = "30.0.0", default-features = false }
-pallet-authorship = { version = "31.0.0", default-features = false }
-pallet-assets = { version = "32.0.0", default-features = false }
-pallet-balances = { version = "31.0.0", default-features = false }
-pallet-contracts = { version = "30.0.0", default-features = false }
-pallet-message-queue = { version = "34.0.0", default-features = false }
-pallet-multisig = { version = "31.0.0", default-features = false }
-pallet-nft-fractionalization = { version = "13.0.0", default-features = false }
-pallet-nfts = { version = "25.0.0", default-features = false }
-pallet-nfts-runtime-api = { version = "17.0.0", default-features = false }
-pallet-preimage = { version = "31.0.0", default-features = false }
-pallet-proxy = { version = "31.0.0", default-features = false }
-pallet-scheduler = { version = "32.0.0", default-features = false }
-pallet-session = { version = "31.0.0", default-features = false }
-pallet-sudo = { version = "31.0.0", default-features = false }
-pallet-timestamp = { version = "30.0.0", default-features = false }
-pallet-transaction-payment = { version = "31.0.0", default-features = false }
-pallet-transaction-payment-rpc = "33.0.0"
-pallet-transaction-payment-rpc-runtime-api = { version = "31.0.0", default-features = false }
-pallet-utility = { version = "31.0.0", default-features = false }
-sp-api = { version = "29.0.0", default-features = false }
-sp-authority-discovery = { version = "29.0.0", default-features = false }
-sp-block-builder = { version = "29.0.0", default-features = false }
-sp-blockchain = "31.0.0"
-sp-consensus-aura = { version = "0.35.0", default-features = false }
-sp-consensus-babe = { version = "0.35.0", default-features = false }
-sp-consensus-beefy = { version = "16.0.0", default-features = false }
-sp-consensus-grandpa = { version = "16.0.0", default-features = false }
-sp-core = { version = "31.0.0", default-features = false }
-sp-keystore = "0.37.0"
-sp-io = { version = "33.0.0", default-features = false }
-sp-genesis-builder = { version = "0.10.0", default-features = false }
-sp-inherents = { version = "29.0.0", default-features = false }
-sp-offchain = { version = "29.0.0", default-features = false }
-sp-runtime = { version = "34.0.0", default-features = false }
-sp-timestamp = "29.0.0"
-substrate-frame-rpc-system = "31.0.0"
+sc-basic-authorship = "0.38.0"
+sc-chain-spec = "31.0.0"
+sc-cli = "0.40.0"
+sc-client-api = "32.0.0"
+sc-offchain = "33.0.0"
+sc-consensus = "0.37.0"
+sc-executor = "0.36.0"
+sc-network = "0.38.0"
+sc-network-sync = "0.37.0"
+sc-rpc = "33.0.0"
+sc-service = "0.39.0"
+sc-sysinfo = "31.0.0"
+sc-telemetry = "18.0.0"
+sc-tracing = "32.0.0"
+sc-transaction-pool = "32.0.0"
+sc-transaction-pool-api = "32.0.0"
+frame-benchmarking = { version = "32.0.0", default-features = false }
+frame-benchmarking-cli = "36.0.0"
+frame-executive = { version = "32.0.0", default-features = false }
+frame-support = { version = "32.0.0", default-features = false }
+frame-system = { version = "32.0.0", default-features = false }
+frame-system-benchmarking = { version = "32.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "30.0.0", default-features = false }
+frame-try-runtime = { version = "0.38.0", default-features = false }
+pallet-aura = { version = "31.0.0", default-features = false }
+pallet-authorship = { version = "32.0.0", default-features = false }
+pallet-assets = { version = "33.0.0", default-features = false }
+pallet-balances = { version = "33.0.0", default-features = false }
+pallet-contracts = { version = "31.0.0", default-features = false }
+pallet-message-queue = { version = "35.0.0", default-features = false }
+pallet-multisig = { version = "32.0.0", default-features = false }
+pallet-nft-fractionalization = { version = "14.0.0", default-features = false }
+pallet-nfts = { version = "26.0.0", default-features = false }
+pallet-nfts-runtime-api = { version = "18.0.0", default-features = false }
+pallet-preimage = { version = "32.0.0", default-features = false }
+pallet-proxy = { version = "32.0.0", default-features = false }
+pallet-scheduler = { version = "33.0.0", default-features = false }
+pallet-session = { version = "32.0.0", default-features = false }
+pallet-sudo = { version = "32.0.0", default-features = false }
+pallet-timestamp = { version = "31.0.0", default-features = false }
+pallet-transaction-payment = { version = "32.0.0", default-features = false }
+pallet-transaction-payment-rpc = "34.0.0"
+pallet-transaction-payment-rpc-runtime-api = { version = "32.0.0", default-features = false }
+pallet-utility = { version = "32.0.0", default-features = false }
+sp-api = { version = "30.0.0", default-features = false }
+sp-authority-discovery = { version = "30.0.0", default-features = false }
+sp-block-builder = { version = "30.0.0", default-features = false }
+sp-blockchain = "32.0.0"
+sp-consensus-aura = { version = "0.36.0", default-features = false }
+sp-consensus-babe = { version = "0.36.0", default-features = false }
+sp-consensus-beefy = { version = "17.0.0", default-features = false }
+sp-consensus-grandpa = { version = "17.0.0", default-features = false }
+sp-core = { version = "32.0.0", default-features = false }
+sp-keystore = "0.38.0"
+sp-io = { version = "34.0.0", default-features = false }
+sp-genesis-builder = { version = "0.11.0", default-features = false }
+sp-inherents = { version = "30.0.0", default-features = false }
+sp-offchain = { version = "30.0.0", default-features = false }
+sp-runtime = { version = "35.0.0", default-features = false }
+sp-timestamp = "30.0.0"
+substrate-frame-rpc-system = "32.0.0"
 substrate-prometheus-endpoint = "0.17.0"
-sp-session = { version = "30.0.0", default-features = false }
+sp-session = { version = "31.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
-sp-transaction-pool = { version = "29.0.0", default-features = false }
-sp-version = { version = "32.0.0", default-features = false }
+sp-transaction-pool = { version = "30.0.0", default-features = false }
+sp-version = { version = "33.0.0", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "10.0.1", default-features = false }
-polkadot-cli = "10.0.0"
-polkadot-parachain-primitives = { version = "9.0.0", default-features = false }
-polkadot-runtime-parachains = { version = "10.0.0", default-features = false }
-polkadot-primitives = { version = "10.0.0", default-features = false }
-polkadot-runtime-common = { version = "10.0.0", default-features = false }
-rococo-runtime-constants = { version = "10.0.0", default-features = false }
-rococo-runtime = { version = "10.0.0", default-features = false }
-xcm = { version = "10.0.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "10.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "10.0.0", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { version = "11.0.0", default-features = false }
+polkadot-cli = "11.0.0"
+polkadot-parachain-primitives = { version = "10.0.0", default-features = false }
+polkadot-runtime-parachains = { version = "11.0.0", default-features = false }
+polkadot-primitives = { version = "11.0.0", default-features = false }
+polkadot-runtime-common = { version = "11.0.0", default-features = false }
+rococo-runtime-constants = { version = "11.0.0", default-features = false }
+rococo-runtime = { version = "11.0.0", default-features = false }
+xcm = { version = "11.0.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "11.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "11.0.0", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-asset-hub-rococo-runtime = { version = "0.14.0", default-features = false }
-asset-test-utils = { version = "10.0.0", default-features = false }
-cumulus-pallet-aura-ext = { version = "0.10.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.10.0", default-features = false, features = [
+asset-hub-rococo-runtime = { version = "0.15.0", default-features = false }
+asset-test-utils = { version = "11.0.0", default-features = false }
+cumulus-pallet-aura-ext = { version = "0.11.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.11.0", default-features = false, features = [
     "parameterized-consensus-hook",
 ] }
-cumulus-pallet-session-benchmarking = { version = "12.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.10.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.10.0", default-features = false }
-cumulus-primitives-aura = { version = "0.10.0", default-features = false }
-cumulus-primitives-core = { version = "0.10.0", default-features = false }
-cumulus-primitives-utility = { version = "0.10.0", default-features = false }
-emulated-integration-tests-common = { version = "6.0.0", default-features = false }
-pallet-collator-selection = { version = "12.0.1", default-features = false }
-parachains-common = { version = "10.0.0", default-features = false }
-parachain-info = { version = "0.10.0", package = "staging-parachain-info", default-features = false }
-cumulus-primitives-parachain-inherent = "0.10.0"
-cumulus-relay-chain-interface = "0.10.0"
+cumulus-pallet-session-benchmarking = { version = "13.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.11.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.11.0", default-features = false }
+cumulus-primitives-aura = { version = "0.11.0", default-features = false }
+cumulus-primitives-core = { version = "0.11.0", default-features = false }
+cumulus-primitives-utility = { version = "0.11.0", default-features = false }
+emulated-integration-tests-common = { version = "7.0.0", default-features = false }
+pallet-collator-selection = { version = "13.0.1", default-features = false }
+parachains-common = { version = "11.0.0", default-features = false }
+parachain-info = { version = "0.11.0", package = "staging-parachain-info", default-features = false }
+cumulus-primitives-parachain-inherent = "0.11.0"
+cumulus-relay-chain-interface = "0.11.0"
 color-print = "0.3.4"
-cumulus-client-cli = "0.10.0"
-cumulus-client-collator = "0.10.0"
-cumulus-client-consensus-aura = "0.10.0"
-cumulus-client-consensus-common = "0.10.0"
-cumulus-client-consensus-proposer = "0.10.0"
-cumulus-client-service = "0.10.0"
+cumulus-client-cli = "0.11.0"
+cumulus-client-collator = "0.11.0"
+cumulus-client-consensus-aura = "0.11.0"
+cumulus-client-consensus-common = "0.11.0"
+cumulus-client-consensus-proposer = "0.11.0"
+cumulus-client-service = "0.11.0"
 
 # Paseo
 asset-hub-paseo-runtime = { git = "https://github.com/paseo-network/runtimes/", tag = "v1.2.5-system-chains", default-features = false }

--- a/runtime/devnet/Cargo.toml
+++ b/runtime/devnet/Cargo.toml
@@ -223,4 +223,4 @@ try-runtime = [
     "sp-runtime/try-runtime",
 ]
 
-experimental = ["pallet-aura/experimental"]
+experimental = []

--- a/runtime/devnet/src/config/xcm.rs
+++ b/runtime/devnet/src/config/xcm.rs
@@ -152,6 +152,9 @@ impl xcm_executor::Config for XcmConfig {
 	type SafeCallFilter = Everything;
 	type Aliasers = Nothing;
 	type TransactionalProcessor = FrameTransactionalProcessor;
+	type HrmpNewChannelOpenRequestHandler = ();
+	type HrmpChannelAcceptedHandler = ();
+	type HrmpChannelClosingHandler = ();
 }
 
 /// No local origins on this chain are allowed to dispatch XCM sends/executions.

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -414,6 +414,7 @@ impl pallet_message_queue::Config for Runtime {
 	type HeapSize = sp_core::ConstU32<{ 64 * 1024 }>;
 	type MaxStale = sp_core::ConstU32<8>;
 	type ServiceWeight = MessageQueueServiceWeight;
+	type IdleMaxServiceWeight = ();
 }
 
 impl cumulus_pallet_aura_ext::Config for Runtime {}
@@ -455,7 +456,6 @@ impl pallet_aura::Config for Runtime {
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<100_000>;
 	type AllowMultipleBlocksPerSlot = ConstBool<true>;
-	#[cfg(feature = "experimental")]
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
@@ -628,7 +628,7 @@ impl_runtime_apis! {
 		}
 
 		fn authorities() -> Vec<AuraId> {
-			Aura::authorities().into_inner()
+			pallet_aura::Authorities::<Runtime>::get().into_inner()
 		}
 	}
 

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -223,4 +223,4 @@ try-runtime = [
     "sp-runtime/try-runtime",
 ]
 
-experimental = ["pallet-aura/experimental"]
+experimental = []

--- a/runtime/testnet/src/config/xcm.rs
+++ b/runtime/testnet/src/config/xcm.rs
@@ -152,6 +152,9 @@ impl xcm_executor::Config for XcmConfig {
 	type SafeCallFilter = Everything;
 	type Aliasers = Nothing;
 	type TransactionalProcessor = FrameTransactionalProcessor;
+	type HrmpNewChannelOpenRequestHandler = ();
+	type HrmpChannelAcceptedHandler = ();
+	type HrmpChannelClosingHandler = ();
 }
 
 /// No local origins on this chain are allowed to dispatch XCM sends/executions.

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -403,6 +403,7 @@ impl pallet_message_queue::Config for Runtime {
 	type HeapSize = sp_core::ConstU32<{ 64 * 1024 }>;
 	type MaxStale = sp_core::ConstU32<8>;
 	type ServiceWeight = MessageQueueServiceWeight;
+	type IdleMaxServiceWeight = ();
 }
 
 impl cumulus_pallet_aura_ext::Config for Runtime {}
@@ -447,7 +448,6 @@ impl pallet_aura::Config for Runtime {
 	// Note: SlotDuration potentially enabled here due to devnet runtime and Rust's feature
 	// unification, requiring the setting of a backwards compatible value.
 	// See https://github.com/paritytech/polkadot-sdk/blob/09df373db9cd5dfed82c5cdb0736d417d54249e6/substrate/frame/aura/src/lib.rs#L262
-	#[cfg(feature = "experimental")]
 	type SlotDuration = pallet_aura::MinimumPeriodTimesTwo<Runtime>;
 }
 
@@ -620,7 +620,7 @@ impl_runtime_apis! {
 		}
 
 		fn authorities() -> Vec<AuraId> {
-			Aura::authorities().into_inner()
+			pallet_aura::Authorities::<Runtime>::get().into_inner()
 		}
 	}
 


### PR DESCRIPTION
- ISSUE: https://github.com/r0gue-io/pop-node/issues/141
- Release: https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.10.0
- Prerequisite: https://github.com/r0gue-io/pop-node/pull/179

### References
- Compare `pallet-contracts`: [`v1.9.0`](https://github.com/paritytech/polkadot-sdk/commits/polkadot-v1.8.0/substrate/frame/contracts) and [`v1.10.0`](https://github.com/paritytech/polkadot-sdk/commits/polkadot-v1.9.0/substrate/frame/contracts)
- Compare `pallet-xcm`: [`v1.9.0`](https://github.com/paritytech/polkadot-sdk/commits/polkadot-v1.8.0/substrate/frame/xcm) and [`v1.10.0`](https://github.com/paritytech/polkadot-sdk/commits/polkadot-v1.9.0/substrate/frame/xcm)
### Direct changes
- [[#3696](https://github.com/paritytech/polkadot-sdk/pull/3696)]: Add HRMP notification handlers to the xcm-executor
- [[#3844](https://github.com/paritytech/polkadot-sdk/pull/3844)]: Add the ability for MessageQueue to process enqueued messages on idle
- [[#3350](https://github.com/paritytech/polkadot-sdk/pull/3350)]: removed `pallet::getter` from Pallet AURA
- [[#3654](https://github.com/paritytech/polkadot-sdk/pull/3654)]: Remove `experimental` feature from `pallet-aura`

### Other updates that might be related
- [[#3471](https://github.com/paritytech/polkadot-sdk/pull/3471)]: removed `pallet::getter` from cumulus pallets
- [[#3749](https://github.com/paritytech/polkadot-sdk/pull/3749)]: pallet-xcm: deprecate execute and send in favor of execute_blob and send_blob

`pallet-contracts` takes the XCM encoded now as well. It follows the same API as `execute_blob` and `send_blob`.

- [[#3607](https://github.com/paritytech/polkadot-sdk/pull/3607)]: XCM fee payment API