### PR TITLE
[WIP] refactor: generic api

### DIFF
--- a/runtime/devnet/src/config/api.rs
+++ b/runtime/devnet/src/config/api.rs
@@ -24,7 +24,7 @@ pub enum RuntimeRead {
 #[derive(Default)]
 pub struct Extension;
 
-impl ExtensionTrait<Runtime> for Extension {
+impl ExtensionTrait for Extension {
 	type StateReader = StateReader;
 	type DispatchHandler = DispatchHandler;
 	type EnvExtractor = EnvExtractor;

--- a/runtime/devnet/src/config/api.rs
+++ b/runtime/devnet/src/config/api.rs
@@ -2,7 +2,13 @@ use crate::{
 	config::assets::TrustBackedAssetsInstance, fungibles, Runtime, RuntimeCall, RuntimeEvent,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
-use pop_chain_extension::{CallFilter, ReadState};
+use frame_support::ensure;
+use pallet_contracts::chain_extension::{BufInBufOutState, Environment, Ext, State};
+use pop_chain_extension::{
+	ExtensionTrait, ExtractEnv, HandleDispatch, ReadState, DECODING_FAILED_ERROR,
+	UNKNOWN_CALL_ERROR,
+};
+use sp_runtime::DispatchError;
 use sp_std::vec::Vec;
 
 /// A query of runtime state.
@@ -17,7 +23,17 @@ pub enum RuntimeRead {
 /// A struct that implement requirements for the Pop API chain extension.
 #[derive(Default)]
 pub struct Extension;
-impl ReadState for Extension {
+
+impl ExtensionTrait<Runtime> for Extension {
+	type StateReader = StateReader;
+	type DispatchHandler = DispatchHandler;
+	type EnvExtractor = EnvExtractor;
+}
+
+#[derive(Default)]
+pub struct StateReader;
+
+impl ReadState for StateReader {
 	type StateQuery = RuntimeRead;
 
 	fn contains(c: &Self::StateQuery) -> bool {
@@ -38,9 +54,49 @@ impl ReadState for Extension {
 			RuntimeRead::Fungibles(key) => fungibles::Pallet::read_state(key),
 		}
 	}
+
+	fn versioned_read_state_handler(
+		mut params: Vec<u8>,
+		version: u8,
+		pallet_index: u8,
+		call_index: u8,
+	) -> Result<Self::StateQuery, DispatchError> {
+		match version.try_into()? {
+			VersionedStateRead::V0 => {
+				// Prefix params with pallet, index to simplify decoding.
+				params.insert(0, pallet_index);
+				params.insert(1, call_index);
+				decode_checked::<Self::StateQuery>(&mut &params[..])
+			},
+		}
+	}
 }
 
-impl CallFilter for Extension {
+// Wrapper to enable versioning of runtime state reads.
+enum VersionedStateRead {
+	// Version zero of state reads.
+	V0,
+}
+
+impl TryFrom<u8> for VersionedStateRead {
+	type Error = DispatchError;
+
+	// Attempts to convert a `u8` value to its corresponding `VersionedStateRead` variant.
+	//
+	// If the `u8` value does not match any known function identifier, it returns a
+	// `DispatchError::Other` indicating an unknown versioned state read.
+	fn try_from(index: u8) -> Result<Self, Self::Error> {
+		match index {
+			0 => Ok(VersionedStateRead::V0),
+			_ => Err(UNKNOWN_CALL_ERROR),
+		}
+	}
+}
+
+#[derive(Default)]
+pub struct DispatchHandler;
+
+impl HandleDispatch for DispatchHandler {
 	type Call = RuntimeCall;
 
 	fn contains(c: &Self::Call) -> bool {
@@ -58,6 +114,69 @@ impl CallFilter for Extension {
 					| mint { .. } | burn { .. }
 			)
 		)
+	}
+
+	fn versioned_dispatch_handler(
+		mut params: Vec<u8>,
+		version: u8,
+		pallet_index: u8,
+		call_index: u8,
+	) -> Result<RuntimeCall, DispatchError> {
+		match version.try_into()? {
+			VersionedDispatch::V0 => {
+				// Prefix params with version, pallet, index to simplify decoding.
+				params.insert(1, pallet_index);
+				params.insert(2, call_index);
+				decode_checked::<RuntimeCall>(&mut &params[..])
+			},
+		}
+	}
+}
+
+// Wrapper to enable versioning of runtime calls.
+enum VersionedDispatch {
+	// Version zero of dispatch calls.
+	V0,
+}
+
+impl TryFrom<u8> for VersionedDispatch {
+	type Error = DispatchError;
+
+	// Attempts to convert a `u8` value to its corresponding `VersionedStateRead` variant.
+	//
+	// If the `u8` value does not match any known function identifier, it returns a
+	// `DispatchError::Other` indicating an unknown versioned state read.
+	fn try_from(index: u8) -> Result<Self, Self::Error> {
+		match index {
+			0 => Ok(VersionedDispatch::V0),
+			_ => Err(UNKNOWN_CALL_ERROR),
+		}
+	}
+}
+
+// Helper method to decode the byte data to a provided type and throws error if failed.
+fn decode_checked<T: Decode>(params: &mut &[u8]) -> Result<T, DispatchError> {
+	T::decode(params).map_err(|_| DECODING_FAILED_ERROR)
+}
+
+#[derive(Default)]
+pub struct EnvExtractor;
+
+impl ExtractEnv for EnvExtractor {
+	// Extract (version, function_id, pallet_index, call_index) from the payload bytes.
+	fn extract_env<T, E: Ext<T = T>>(env: &Environment<E, BufInBufOutState>) -> (u8, u8, u8, u8) {
+		// Extract version and function_id from first two bytes.
+		let (version, function_id) = {
+			let bytes = env.func_id().to_le_bytes();
+			(bytes[0], bytes[1])
+		};
+		// Extract pallet index and call / key index from last two bytes.
+		let (pallet_index, call_index) = {
+			let bytes = env.ext_id().to_le_bytes();
+			(bytes[0], bytes[1])
+		};
+
+		(version, function_id, pallet_index, call_index)
 	}
 }
 

--- a/runtime/devnet/src/config/contracts.rs
+++ b/runtime/devnet/src/config/contracts.rs
@@ -64,7 +64,7 @@ impl pallet_contracts::Config for Runtime {
 	type CallStack = [pallet_contracts::Frame<Self>; 23];
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
 	type WeightInfo = pallet_contracts::weights::SubstrateWeight<Self>;
-	type ChainExtension = pop_chain_extension::ApiExtension<Extension>;
+	type ChainExtension = pop_chain_extension::ApiExtension<Runtime, Extension>;
 	type Schedule = Schedule;
 	type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
 	// This node is geared towards development and testing of contracts.


### PR DESCRIPTION
Just a draft of how it might look like. Facing a problem that the `ChainExtension` type in pallet contracts is bounded by the `Default` trait. Because `Runtime` doesn't implement the `Default` trait I'm not sure how we can make the `ExtensionTrait` generic over Runtimes. 

Not sure whether it is an easy fix, still feel that it can be simplified though. Don't mind the naming at the moment. Just wanted to get something working and get feedback.

I put `dispatch` and `dispatch_call` in one function for simplicity for the refactoring.