### PR TITLE
test: improve test cases

### DIFF
--- a/extension/src/v0.rs
+++ b/extension/src/v0.rs
@@ -1,28 +1,6 @@
-#[cfg(test)]
-use crate::convert_to_status_code;
+//! TODO
 
-pub(crate) fn handle_unknown_error(encoded_error: &mut [u8; 4]) {
-	let unknown = match encoded_error[0] {
-		code if UNIT_ERRORS.contains(&code) => nested_errors(&encoded_error[1..], None),
-		// Single nested errors with a limit in their nesting.
-		//
-		// `TokenError`: has ten variants - translated to a limit of nine.
-		7 => nested_errors(&encoded_error[1..], Some(9)),
-		// `ArithmeticError`: has 3 variants - translated to a limit of two.
-		8 => nested_errors(&encoded_error[1..], Some(2)),
-		// `TransactionalError`: has 2 variants - translated to a limit of one.
-		9 => nested_errors(&encoded_error[1..], Some(1)),
-		code if DOUBLE_NESTED_ERRORS.contains(&code) => nested_errors(&encoded_error[3..], None),
-		_ => true,
-	};
-	if unknown {
-		encoded_error[..].rotate_right(1);
-		encoded_error[0] = 0u8;
-	}
-}
-
-// Unit `Error` variants.
-// (variant: index):
+// Unit errors.
 // - CannotLookup: 1,
 // - BadOrigin: 2,
 // - ConsumerRemaining: 4,
@@ -32,27 +10,63 @@ pub(crate) fn handle_unknown_error(encoded_error: &mut [u8; 4]) {
 // - Corruption: 11,
 // - Unavailable: 12,
 // - RootNotAllowed: 13,
-// - UnknownFunctionId: 254,
+// - UnknownCall: 254,
 // - DecodingFailed: 255,
 const UNIT_ERRORS: [u8; 11] = [1, 2, 4, 5, 6, 10, 11, 12, 13, 254, 255];
 
-#[cfg(test)]
-const SINGLE_NESTED_ERRORS: [u8; 3] = [7, 8, 9];
+// Single nested errors.
+const TOKEN_ERROR: u8 = 7;
+const ARITHMETIC_ERROR: u8 = 8;
+const TRANSACTIONAL_ERROR: u8 = 9;
+// Starting indices at which specific single nested error variants are considered invalid. These
+// constants define the boundary for valid error variant indices within certain `DispatchError` enums.
+const INVALID_TOKEN_INDEX: u8 = 10;
+const INVALID_ARITHMETIC_INDEX: u8 = 3;
+const INVALID_TRANSACTIONAL_INDEX: u8 = 2;
 
-// Double nested `Error` variants
-// (variant: index):
-// - Module: 3,
-const DOUBLE_NESTED_ERRORS: [u8; 1] = [3];
+// Double nested error.
+const MODULE_ERROR: u8 = 3;
 
-// Checks for unknown nested errors within the `DispatchError`.
-// - For single nested errors with a limit, it verifies if the nested value exceeds the limit.
-// - For other nested errors, it checks if any subsequent bytes are non-zero.
+// If an unknown error of the `DispatchError` is detected, the error needs to be converted
+// into the encoded value of `pop_api::Error::Other`. This conversion is performed by shifting the bytes one
+// position forward (discarding the last byte as it is not used) and setting the first byte to the
+// encoded value of `Other` (0u8). This ensures the error is correctly categorized as an `Other`
+// variant which provides all the necessary information to debug which error occurred in the runtime.
 //
-// `nested_error` - The slice of bytes representing the nested error.
-// `limit` - An optional limit for single nested errors.
-fn nested_errors(nested_error: &[u8], limit: Option<u8>) -> bool {
-	match limit {
-		Some(l) => nested_error[0] > l || nested_error[1..].iter().any(|&x| x != 0u8),
+// Byte layout explanation (prior to conversion by `handle_unknown_error`):
+// - Byte 0: index of the error within `pop_api::Error`
+// - Byte 1:
+//   - Must be zero for `UNIT_ERRORS`.
+//   - Represents the nested error in `SINGLE_NESTED_ERRORS`.
+//   - Represents the first level of nesting in `DOUBLE_NESTED_ERRORS`.
+// - Byte 2:
+//   - Represents the second level of nesting in `DOUBLE_NESTED_ERRORS`.
+// - Byte 3:
+//   - Unused or represents further nested information.
+pub(crate) fn handle_unknown_error(encoded_error: &mut [u8; 4]) {
+	let is_unknown_error = match encoded_error[0] {
+		code if UNIT_ERRORS.contains(&code) => nested_errors(&encoded_error[1..], None),
+		TOKEN_ERROR => nested_errors(&encoded_error[1..], Some(INVALID_TOKEN_INDEX)),
+		ARITHMETIC_ERROR => nested_errors(&encoded_error[1..], Some(INVALID_ARITHMETIC_INDEX)),
+		TRANSACTIONAL_ERROR => {
+			nested_errors(&encoded_error[1..], Some(INVALID_TRANSACTIONAL_INDEX))
+		},
+		MODULE_ERROR => nested_errors(&encoded_error[3..], None),
+		_ => true,
+	};
+	if is_unknown_error {
+		encoded_error[..].rotate_right(1);
+		encoded_error[0] = 0u8;
+	}
+}
+
+// Checks for unknown or invalid nested errors within the `DispatchError`.
+fn nested_errors(nested_error: &[u8], invalid_index_start: Option<u8>) -> bool {
+	match invalid_index_start {
+		// Checks if the first byte is equal or exceeds `invalid_index_start` or if any subsequent
+		// byte is non-zero.
+		Some(i) => nested_error[0] >= i || nested_error[1..].iter().any(|&x| x != 0u8),
+		// If no limit is provided, check if any byte is non-zero.
 		None => nested_error.iter().any(|&x| x != 0u8),
 	}
 }
@@ -60,239 +74,165 @@ fn nested_errors(nested_error: &[u8], limit: Option<u8>) -> bool {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use pop_primitives::error::{
-		ArithmeticError::*,
-		Error::{self, *},
-		TokenError::*,
-		TransactionalError::*,
-	};
-	use sp_runtime::DispatchError;
+	use crate::tests::assert_encoding_matches;
+	use sp_runtime::{ArithmeticError::*, DispatchError::*, TokenError::*, TransactionalError::*};
 
-	// Compare all the different `DispatchError` variants with the expected `Error`.
-	#[test]
-	fn dispatch_error_to_error() {
-		let test_cases = vec![
-			(
-				DispatchError::Other(""),
-				(Other { dispatch_error_index: 0, error_index: 0, error: 0 }),
-			),
-			(DispatchError::Other("UnknownCall"), UnknownCall),
-			(DispatchError::Other("DecodingFailed"), DecodingFailed),
-			(DispatchError::CannotLookup, CannotLookup),
-			(DispatchError::BadOrigin, BadOrigin),
-			(
-				DispatchError::Module(sp_runtime::ModuleError {
-					index: 1,
-					error: [2, 0, 0, 0],
-					message: Some("hallo"),
-				}),
-				Module { index: 1, error: 2 },
-			),
-			(DispatchError::ConsumerRemaining, ConsumerRemaining),
-			(DispatchError::NoProviders, NoProviders),
-			(DispatchError::TooManyConsumers, TooManyConsumers),
-			(DispatchError::Token(sp_runtime::TokenError::BelowMinimum), Token(BelowMinimum)),
-			(
-				DispatchError::Arithmetic(sp_runtime::ArithmeticError::Overflow),
-				Arithmetic(Overflow),
-			),
-			(
-				DispatchError::Transactional(sp_runtime::TransactionalError::LimitReached),
-				Transactional(LimitReached),
-			),
-			(DispatchError::Exhausted, Exhausted),
-			(DispatchError::Corruption, Corruption),
-			(DispatchError::Unavailable, Unavailable),
-			(DispatchError::RootNotAllowed, RootNotAllowed),
-		];
-		for (dispatch_error, expected) in test_cases {
-			let status_code = crate::convert_to_status_code(dispatch_error, 0);
-			let error: Error = status_code.into();
+	// Assert encoding after `handle_unknown_error` with expected encoding.
+	fn assert_error_cases(test_cases: Vec<([u8; 4], [u8; 4])>) {
+		for (mut error, expected) in test_cases {
+			handle_unknown_error(&mut error);
 			assert_eq!(error, expected);
 		}
 	}
 
-	// Compare all the different `DispatchError::Other` possibilities with the expected `Error`.
-	#[test]
-	fn other_error() {
-		let test_cases = vec![
-			(
-				DispatchError::Other("Random"),
-				(Other { dispatch_error_index: 0, error_index: 0, error: 0 }),
-			),
-			(DispatchError::Other("UnknownCall"), UnknownCall),
-			(DispatchError::Other("DecodingFailed"), DecodingFailed),
-		];
-		for (dispatch_error, expected) in test_cases {
-			let status_code = convert_to_status_code(dispatch_error, 0);
-			let error: Error = status_code.into();
-			assert_eq!(error, expected);
-		}
-	}
+	// Tests for `handle_unknown_error`:
+	// 1. Unit errors.
+	// 2. Single nested errors.
+	// 3. Double nested errors.
 
-	// Compare all the different `DispatchError::Module` nesting possibilities, which can not be
-	// handled, with the expected `Error`. See `double_nested_error_variants` fourth byte nesting.
-	#[test]
-	fn test_module_error() {
-		let test_cases = vec![
-			DispatchError::Module(sp_runtime::ModuleError {
-				index: 1,
-				error: [2, 2, 0, 0],
-				message: Some("Random"),
-			}),
-			DispatchError::Module(sp_runtime::ModuleError {
-				index: 1,
-				error: [2, 2, 2, 0],
-				message: Some("Random"),
-			}),
-			DispatchError::Module(sp_runtime::ModuleError {
-				index: 1,
-				error: [2, 2, 2, 2],
-				message: Some("Random"),
-			}),
-		];
-		for dispatch_error in test_cases {
-			let status_code = convert_to_status_code(dispatch_error, 0);
-			let error: Error = status_code.into();
-			assert_eq!(error, Other { dispatch_error_index: 3, error_index: 1, error: 2 });
-		}
-	}
-
-	// Converts 4 bytes into `Error` and handles unknown errors (used in `convert_to_status_code`).
-	fn into_error(mut error_bytes: [u8; 4]) -> Error {
-		handle_unknown_error(&mut error_bytes);
-		u32::from_le_bytes(error_bytes).into()
-	}
-
-	// Tests the `handle_unknown_error` for `Error`, version 0.
+	// 1. Unit errors.
 	//
-	// Unit variants:
-	// If the encoded value indicates a nested `Error` which is known by V0 as a
-	// unit variant, the encoded value is converted into `Error::Other`.
+	// If the encoded value indicates a nested enum, which is known by V0 as a
+	// unit error, the encoded value is converted.
 	//
 	// Example: the error `BadOrigin` (encoded: `[2, 0, 0, 0]`) with a non-zero value for one
-	// of the bytes [1..4]: `[2, 0, 1, 0]` is converted into `[0, 2, 0, 1]` (shifting the bits
+	// of the bytes [1..4] - `[2, 0, 1, 0]` - is converted into `[0, 2, 0, 1]` (shifting the bits
 	// one forward). This is decoded to `Error::Other { dispatch_error: 2, index: 0, error: 1 }`.
-	#[test]
-	fn unit_error_variants() {
-		let errors = vec![
-			CannotLookup,
-			BadOrigin,
-			ConsumerRemaining,
-			NoProviders,
-			TooManyConsumers,
-			Exhausted,
-			Corruption,
-			Unavailable,
-			RootNotAllowed,
-			UnknownCall,
-			DecodingFailed,
-		];
-		// Compare an `Error`, which is converted from an encoded value, with the expected `Error`.
-		for (i, &error_code) in UNIT_ERRORS.iter().enumerate() {
-			// No nesting and unit variant correctly returned.
-			assert_eq!(into_error([error_code, 0, 0, 0]), errors[i]);
-			// Unexpected second byte nested.
-			assert_eq!(
-				into_error([error_code, 1, 0, 0]),
-				(Other { dispatch_error_index: error_code, error_index: 1, error: 0 }),
-			);
-			// Unexpected third byte nested.
-			assert_eq!(
-				into_error([error_code, 1, 1, 0]),
-				(Other { dispatch_error_index: error_code, error_index: 1, error: 1 }),
-			);
-			// Unexpected fourth byte nested.
-			assert_eq!(
-				into_error([error_code, 1, 1, 1]),
-				(Other { dispatch_error_index: error_code, error_index: 1, error: 1 }),
-			);
-		}
+
+	macro_rules! unit_error_test {
+		($name:ident, $error_variant:expr, $encoded_value:expr) => {
+			#[test]
+			fn $name() {
+				assert_encoding_matches($error_variant, $encoded_value);
+				let index = $encoded_value[0];
+				let test_cases = vec![
+					($encoded_value, $encoded_value),
+					([index, 1, 0, 0], [0, index, 1, 0]),
+					([index, 1, 1, 0], [0, index, 1, 1]),
+					([index, 1, 1, 1], [0, index, 1, 1]),
+					([index, 1, 0, 1], [0, index, 1, 0]),
+					([index, 0, 1, 1], [0, index, 0, 1]),
+					([index, 0, 0, 1], [0, index, 0, 0]),
+				];
+				assert_error_cases(test_cases);
+			}
+		};
 	}
 
-	// Single nested variants:
-	// If the encoded value indicates a double nested `Error` which is known by V0
-	// as a single nested variant, the encoded value is converted into `Error::Other`.
+	unit_error_test!(cannot_lookup_works, CannotLookup, [1u8, 0, 0, 0]);
+	unit_error_test!(bad_origin_works, BadOrigin, [2u8, 0, 0, 0]);
+	unit_error_test!(consumer_remaining_works, ConsumerRemaining, [4u8, 0, 0, 0]);
+	unit_error_test!(no_providers_works, NoProviders, [5u8, 0, 0, 0]);
+	unit_error_test!(too_many_consumers_works, TooManyConsumers, [6u8, 0, 0, 0]);
+	unit_error_test!(exhausted_works, Exhausted, [10u8, 0, 0, 0]);
+	unit_error_test!(corruption_works, Corruption, [11u8, 0, 0, 0]);
+	unit_error_test!(unavailable_works, Unavailable, [12u8, 0, 0, 0]);
+	unit_error_test!(root_not_allowed_works, RootNotAllowed, [13u8, 0, 0, 0]);
+
+	// 2. Single nested errors.
+	//
+	// If the encoded value indicates a double nested error which is known by V0
+	// as a single nested error, the encoded value is converted.
 	//
 	// Example: the error `Arithmetic(Overflow)` (encoded: `[8, 1, 0, 0]`) with a non-zero
 	// value for one of the bytes [2..4]: `[8, 1, 1, 0]` is converted into `[0, 8, 1, 1]`. This is
 	// decoded to `Error::Other { dispatch_error: 8, index: 1,  error: 1 }`.
+
+	macro_rules! single_nested_error_test {
+		($name:ident, $error_enum:path, $base_error_code:expr, $invalid_index:expr, $errors:expr) => {
+			#[test]
+			fn $name() {
+				for (error, index) in $errors {
+					let valid_variant_expected_encoding = [$base_error_code, index, 0, 0];
+					assert_encoding_matches($error_enum(error), valid_variant_expected_encoding);
+					// Test cases with valid single nested values.
+					let test_cases = vec![
+						([$base_error_code, index, 0, 0], valid_variant_expected_encoding),
+						([$base_error_code, index, 1, 0], [0, $base_error_code, index, 1]),
+						([$base_error_code, index, 0, 1], [0, $base_error_code, index, 0]),
+						([$base_error_code, index, 1, 1], [0, $base_error_code, index, 1]),
+					];
+					assert_error_cases(test_cases);
+				}
+
+				// Test cases with invalid single nested values.
+				for x in [$invalid_index, 100, u8::MAX] {
+					let test_cases = vec![
+						([$base_error_code, x, 0, 0], [0, $base_error_code, x, 0]),
+						([$base_error_code, x, 1, 0], [0, $base_error_code, x, 1]),
+						([$base_error_code, x, 0, 1], [0, $base_error_code, x, 0]),
+						([$base_error_code, x, 1, 1], [0, $base_error_code, x, 1]),
+					];
+					assert_error_cases(test_cases);
+				}
+			}
+		};
+	}
+
+	single_nested_error_test!(
+		token_error_works,
+		Token,
+		TOKEN_ERROR,
+		INVALID_TOKEN_INDEX,
+		vec![
+			(FundsUnavailable, 0),
+			(OnlyProvider, 1),
+			(BelowMinimum, 2),
+			(CannotCreate, 3),
+			(UnknownAsset, 4),
+			(Frozen, 5),
+			(Unsupported, 6),
+			(CannotCreateHold, 7),
+			(NotExpendable, 8),
+			(Blocked, 9),
+		]
+	);
+
+	single_nested_error_test!(
+		arithmetic_error_works,
+		Arithmetic,
+		ARITHMETIC_ERROR,
+		INVALID_ARITHMETIC_INDEX,
+		vec![(Underflow, 0), (Overflow, 1), (DivisionByZero, 2)]
+	);
+
+	single_nested_error_test!(
+		transactional_error_works,
+		Transactional,
+		TRANSACTIONAL_ERROR,
+		INVALID_TRANSACTIONAL_INDEX,
+		vec![(LimitReached, 0), (NoLayer, 1)]
+	);
+
+	// 3. Double nested error.
+	//
+	// If the encoded value indicates a triple nested error which is known by V0
+	// as a double nested error, the encoded value is converted.
+	//
+	// Example: the error `Module { index: 10, error 5 }` (encoded: `[3, 10, 5, 0]`) with a non-zero
+	// value for the last byte: `[3, 10, 5, 3]` is converted into `[0, 3, 10, 5]`. This is
+	// decoded to `Error::Other { dispatch_error: 3, index: 10, error: 5 }`.
+
 	#[test]
-	fn single_nested_error_variants() {
-		let errors = vec![
-			[Token(FundsUnavailable), Token(OnlyProvider)],
-			[Arithmetic(Underflow), Arithmetic(Overflow)],
-			[Transactional(LimitReached), Transactional(NoLayer)],
-		];
-		// Compare an `Error`, which is converted from an encoded value, with the expected `Error`.
-		for (i, &error_code) in SINGLE_NESTED_ERRORS.iter().enumerate() {
-			// No nested and single nested variant correctly returned.
-			assert_eq!(into_error([error_code, 0, 0, 0]), errors[i][0]);
-			assert_eq!(into_error([error_code, 1, 0, 0]), errors[i][1]);
-			// Unexpected third byte nested.
-			assert_eq!(
-				into_error([error_code, 1, 1, 0]),
-				(Other { dispatch_error_index: error_code, error_index: 1, error: 1 }),
-			);
-			// Unexpected fourth byte nested.
-			assert_eq!(
-				into_error([error_code, 1, 1, 1]),
-				Other { dispatch_error_index: error_code, error_index: 1, error: 1 },
-			);
+	fn double_nested_error_variants() {
+		for x in [1, 100, u8::MAX] {
+			let test_cases = vec![
+				([MODULE_ERROR, x, 0, 0], [MODULE_ERROR, x, 0, 0]),
+				([MODULE_ERROR, x, x, 0], [MODULE_ERROR, x, x, 0]),
+				([MODULE_ERROR, x, x, x], [0, MODULE_ERROR, x, x]),
+				([MODULE_ERROR, 0, x, x], [0, MODULE_ERROR, 0, x]),
+				([MODULE_ERROR, 0, 0, x], [0, MODULE_ERROR, 0, 0]),
+			];
+			assert_error_cases(test_cases);
 		}
 	}
 
 	#[test]
-	fn single_nested_unknown_variants() {
-		// Unknown `TokenError` variant.
-		assert_eq!(
-			into_error([7, 10, 0, 0]),
-			Other { dispatch_error_index: 7, error_index: 10, error: 0 }
-		);
-		// Unknown `Arithmetic` variant.
-		assert_eq!(
-			into_error([8, 3, 0, 0]),
-			Other { dispatch_error_index: 8, error_index: 3, error: 0 }
-		);
-		// Unknown `Transactional` variant.
-		assert_eq!(
-			into_error([9, 2, 0, 0]),
-			Other { dispatch_error_index: 9, error_index: 2, error: 0 }
-		);
-	}
-
-	// Double nested variants:
-	// If the encoded value indicates a triple nested `Error` which is known by V0
-	// as a double nested variant, the encoded value is converted into `Error::Other`.
-	//
-	// Example: the error `Module { index: 10, error 5 }` (encoded: `[3, 10, 5, 0]`) with a non-zero
-	// value for the last byte: `[3, 10, 5, 3]` is converted into `[0, 3, 10, 5]`. This is
-	// decoded to `Error::Other { dispatch_error: 3, index: 10,  error: 5 }`.
-	#[test]
-	fn double_nested_error_variants() {
-		// Compare an `Error`, which is converted from an encoded value, with the expected `Error`.
-		// No nesting and unit variant correctly returned.
-		assert_eq!(into_error([3, 0, 0, 0]), Module { index: 0, error: 0 });
-		// Allowed single nesting and variant correctly returned.
-		assert_eq!(into_error([3, 1, 0, 0]), Module { index: 1, error: 0 });
-		// Allowed double nesting and variant correctly returned.
-		assert_eq!(into_error([3, 1, 1, 0]), Module { index: 1, error: 1 });
-		// Unexpected fourth byte nested.
-		assert_eq!(
-			into_error([3, 1, 1, 1]),
-			Other { dispatch_error_index: 3, error_index: 1, error: 1 },
-		);
-	}
-
-	#[test]
 	fn test_random_encoded_values() {
-		assert_eq!(
-			into_error([100, 100, 100, 100]),
-			Other { dispatch_error_index: 100, error_index: 100, error: 100 }
-		);
-		assert_eq!(
-			into_error([200, 200, 200, 200]),
-			Other { dispatch_error_index: 200, error_index: 200, error: 200 }
-		);
+		let test_cases = vec![
+			([100, 100, 100, 100], [0, 100, 100, 100]),
+			([u8::MAX, u8::MAX, u8::MAX, u8::MAX], [0, u8::MAX, u8::MAX, u8::MAX]),
+		];
+		assert_error_cases(test_cases);
 	}
 }

--- a/extension/src/v0.rs
+++ b/extension/src/v0.rs
@@ -1,4 +1,9 @@
-//! TODO
+//! This module is responsible for handling and converting unknown errors returned to contracts that use the first version of the Pop API.
+//!
+//! The errors are categorized into unit errors, single nested errors, and double nested errors,
+//! each of which is encoded into a 4-byte array. The module provides functionality to convert
+//! unknown errors into the general "pop_api::Error::Other" error type, ensuring consistent error categorization
+//! across the runtime for contracts using the API.
 
 // Unit errors.
 // - CannotLookup: 1,
@@ -43,7 +48,7 @@ const MODULE_ERROR: u8 = 3;
 //   - Represents the second level of nesting in `DOUBLE_NESTED_ERRORS`.
 // - Byte 3:
 //   - Unused or represents further nested information.
-pub(crate) fn handle_unknown_error(encoded_error: &mut [u8; 4]) {
+pub(super) fn handle_unknown_error(encoded_error: &mut [u8; 4]) {
 	let is_unknown_error = match encoded_error[0] {
 		code if UNIT_ERRORS.contains(&code) => nested_errors(&encoded_error[1..], None),
 		TOKEN_ERROR => nested_errors(&encoded_error[1..], Some(INVALID_TOKEN_INDEX)),
@@ -96,7 +101,7 @@ mod tests {
 	// unit error, the encoded value is converted.
 	//
 	// Example: the error `BadOrigin` (encoded: `[2, 0, 0, 0]`) with a non-zero value for one
-	// of the bytes [1..4] - `[2, 0, 1, 0]` - is converted into `[0, 2, 0, 1]` (shifting the bits
+	// of the bytes [1..4]: `[2, 0, 1, 0]` is converted into `[0, 2, 0, 1]` (shifting the bits
 	// one forward). This is decoded to `Error::Other { dispatch_error: 2, index: 0, error: 1 }`.
 
 	macro_rules! unit_error_test {

--- a/pallets/api/Cargo.toml
+++ b/pallets/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pallet-api"
 authors.workspace = true
-description = "Api pallet, enabling smart(er) contracts with the power of Polkadot"
+description = "API pallet, enabling smart(er) contracts with the power of Polkadot"
 edition.workspace = true
 license.workspace = true
 version = "0.1.0"

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -16,16 +16,16 @@ type Event = crate::fungibles::Event<Test>;
 fn transfer_works() {
 	new_test_ext().execute_with(|| {
 		let value: Balance = 100 * UNIT;
-		let id = ASSET;
+		let asset = ASSET;
 		let from = Some(ALICE);
 		let to = Some(BOB);
 
-		create_asset_and_mint_to(ALICE, id, ALICE, value * 2);
-		let balance_before_transfer = Assets::balance(id, &BOB);
-		assert_ok!(Fungibles::transfer(signed(ALICE), id, BOB, value));
-		let balance_after_transfer = Assets::balance(id, &BOB);
+		create_asset_and_mint_to(ALICE, asset, ALICE, value * 2);
+		let balance_before_transfer = Assets::balance(asset, &BOB);
+		assert_ok!(Fungibles::transfer(signed(ALICE), asset, BOB, value));
+		let balance_after_transfer = Assets::balance(asset, &BOB);
 		assert_eq!(balance_after_transfer, balance_before_transfer + value);
-		System::assert_last_event(Event::Transfer { id, from, to, value }.into());
+		System::assert_last_event(Event::Transfer { asset, from, to, value }.into());
 	});
 }
 
@@ -33,22 +33,22 @@ fn transfer_works() {
 fn transfer_from_works() {
 	new_test_ext().execute_with(|| {
 		let value: Balance = 100 * UNIT;
-		let id = ASSET;
+		let asset = ASSET;
 		let from = Some(ALICE);
 		let to = Some(BOB);
 
 		// Approve CHARLIE to transfer up to `value` to BOB.
-		create_asset_mint_and_approve(ALICE, id, ALICE, value * 2, CHARLIE, value);
+		create_asset_mint_and_approve(ALICE, asset, ALICE, value * 2, CHARLIE, value);
 		// Successfully call transfer from.
-		let alice_balance_before_transfer = Assets::balance(id, &ALICE);
-		let bob_balance_before_transfer = Assets::balance(id, &BOB);
-		assert_ok!(Fungibles::transfer_from(signed(CHARLIE), id, ALICE, BOB, value));
-		let alice_balance_after_transfer = Assets::balance(id, &ALICE);
-		let bob_balance_after_transfer = Assets::balance(id, &BOB);
+		let alice_balance_before_transfer = Assets::balance(asset, &ALICE);
+		let bob_balance_before_transfer = Assets::balance(asset, &BOB);
+		assert_ok!(Fungibles::transfer_from(signed(CHARLIE), asset, ALICE, BOB, value));
+		let alice_balance_after_transfer = Assets::balance(asset, &ALICE);
+		let bob_balance_after_transfer = Assets::balance(asset, &BOB);
 		// Check that BOB receives the `value` and ALICE `amount` is spent successfully by CHARLIE.
 		assert_eq!(bob_balance_after_transfer, bob_balance_before_transfer + value);
 		assert_eq!(alice_balance_after_transfer, alice_balance_before_transfer - value);
-		System::assert_last_event(Event::Transfer { id, from, to, value }.into());
+		System::assert_last_event(Event::Transfer { asset, from, to, value }.into());
 	});
 }
 
@@ -57,31 +57,37 @@ fn transfer_from_works() {
 fn approve_works() {
 	new_test_ext().execute_with(|| {
 		let value: Balance = 100 * UNIT;
-		let id = ASSET;
+		let asset = ASSET;
 		let owner = ALICE;
 		let spender = BOB;
 
-		create_asset_and_mint_to(ALICE, id, ALICE, value);
-		assert_eq!(0, Assets::allowance(id, &ALICE, &BOB));
-		assert_ok!(Fungibles::approve(signed(ALICE), id, BOB, value));
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), value);
-		System::assert_last_event(Event::Approval { id, owner, spender, value }.into());
+		create_asset_and_mint_to(ALICE, asset, ALICE, value);
+		assert_eq!(0, Assets::allowance(asset, &ALICE, &BOB));
+		assert_ok!(Fungibles::approve(signed(ALICE), asset, BOB, value));
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), value);
+		System::assert_last_event(Event::Approval { asset, owner, spender, value }.into());
 		// Approves an value to spend that is lower than the current allowance.
-		assert_ok!(Fungibles::approve(signed(ALICE), id, BOB, value / 2));
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), value / 2);
-		System::assert_last_event(Event::Approval { id, owner, spender, value: value / 2 }.into());
+		assert_ok!(Fungibles::approve(signed(ALICE), asset, BOB, value / 2));
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), value / 2);
+		System::assert_last_event(
+			Event::Approval { asset, owner, spender, value: value / 2 }.into(),
+		);
 		// Approves an value to spend that is higher than the current allowance.
-		assert_ok!(Fungibles::approve(signed(ALICE), id, BOB, value * 2));
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), value * 2);
-		System::assert_last_event(Event::Approval { id, owner, spender, value: value * 2 }.into());
+		assert_ok!(Fungibles::approve(signed(ALICE), asset, BOB, value * 2));
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), value * 2);
+		System::assert_last_event(
+			Event::Approval { asset, owner, spender, value: value * 2 }.into(),
+		);
 		// Approves an value to spend that is equal to the current allowance.
-		assert_ok!(Fungibles::approve(signed(ALICE), id, BOB, value * 2));
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), value * 2);
-		System::assert_last_event(Event::Approval { id, owner, spender, value: value * 2 }.into());
+		assert_ok!(Fungibles::approve(signed(ALICE), asset, BOB, value * 2));
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), value * 2);
+		System::assert_last_event(
+			Event::Approval { asset, owner, spender, value: value * 2 }.into(),
+		);
 		// Sets allowance to zero.
-		assert_ok!(Fungibles::approve(signed(ALICE), id, BOB, 0));
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), 0);
-		System::assert_last_event(Event::Approval { id, owner, spender, value: 0 }.into());
+		assert_ok!(Fungibles::approve(signed(ALICE), asset, BOB, 0));
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), 0);
+		System::assert_last_event(Event::Approval { asset, owner, spender, value: 0 }.into());
 	});
 }
 
@@ -89,19 +95,21 @@ fn approve_works() {
 fn increase_allowance_works() {
 	new_test_ext().execute_with(|| {
 		let value: Balance = 100 * UNIT;
-		let id = ASSET;
+		let asset = ASSET;
 		let owner = ALICE;
 		let spender = BOB;
 
-		create_asset_and_mint_to(ALICE, id, ALICE, value);
-		assert_eq!(0, Assets::allowance(id, &ALICE, &BOB));
-		assert_ok!(Fungibles::increase_allowance(signed(ALICE), id, BOB, value));
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), value);
-		System::assert_last_event(Event::Approval { id, owner, spender, value }.into());
+		create_asset_and_mint_to(ALICE, asset, ALICE, value);
+		assert_eq!(0, Assets::allowance(asset, &ALICE, &BOB));
+		assert_ok!(Fungibles::increase_allowance(signed(ALICE), asset, BOB, value));
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), value);
+		System::assert_last_event(Event::Approval { asset, owner, spender, value }.into());
 		// Additive.
-		assert_ok!(Fungibles::increase_allowance(signed(ALICE), id, BOB, value));
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), value * 2);
-		System::assert_last_event(Event::Approval { id, owner, spender, value: value * 2 }.into());
+		assert_ok!(Fungibles::increase_allowance(signed(ALICE), asset, BOB, value));
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), value * 2);
+		System::assert_last_event(
+			Event::Approval { asset, owner, spender, value: value * 2 }.into(),
+		);
 	});
 }
 
@@ -109,23 +117,25 @@ fn increase_allowance_works() {
 fn decrease_allowance_works() {
 	new_test_ext().execute_with(|| {
 		let value: Balance = 100 * UNIT;
-		let id = ASSET;
+		let asset = ASSET;
 		let owner = ALICE;
 		let spender = BOB;
 
-		create_asset_mint_and_approve(ALICE, id, ALICE, value, BOB, value);
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), value);
+		create_asset_mint_and_approve(ALICE, asset, ALICE, value, BOB, value);
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), value);
 		// Owner balance is not changed if decreased by zero.
-		assert_ok!(Fungibles::decrease_allowance(signed(ALICE), id, BOB, 0));
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), value);
+		assert_ok!(Fungibles::decrease_allowance(signed(ALICE), asset, BOB, 0));
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), value);
 		// Decrease allowance successfully.
-		assert_ok!(Fungibles::decrease_allowance(signed(ALICE), id, BOB, value / 2));
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), value / 2);
-		System::assert_last_event(Event::Approval { id, owner, spender, value: value / 2 }.into());
+		assert_ok!(Fungibles::decrease_allowance(signed(ALICE), asset, BOB, value / 2));
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), value / 2);
+		System::assert_last_event(
+			Event::Approval { asset, owner, spender, value: value / 2 }.into(),
+		);
 		// Saturating if current allowance is decreased more than the owner balance.
-		assert_ok!(Fungibles::decrease_allowance(signed(ALICE), id, BOB, value));
-		assert_eq!(Assets::allowance(id, &ALICE, &BOB), 0);
-		System::assert_last_event(Event::Approval { id, owner, spender, value: 0 }.into());
+		assert_ok!(Fungibles::decrease_allowance(signed(ALICE), asset, BOB, value));
+		assert_eq!(Assets::allowance(asset, &ALICE, &BOB), 0);
+		System::assert_last_event(Event::Approval { asset, owner, spender, value: 0 }.into());
 	});
 }
 
@@ -146,45 +156,45 @@ fn create_works() {
 #[test]
 fn start_destroy_works() {
 	new_test_ext().execute_with(|| {
-		let id = ASSET;
+		let asset = ASSET;
 
-		create_asset(ALICE, id);
-		assert_ok!(Fungibles::start_destroy(signed(ALICE), id));
+		create_asset(ALICE, asset);
+		assert_ok!(Fungibles::start_destroy(signed(ALICE), asset));
 	});
 }
 
 #[test]
 fn set_metadata_works() {
 	new_test_ext().execute_with(|| {
-		let id = ASSET;
+		let asset = ASSET;
 		let name = vec![42];
 		let symbol = vec![42];
 		let decimals = 42;
 
-		create_asset(ALICE, id);
+		create_asset(ALICE, asset);
 		assert_ok!(Fungibles::set_metadata(
 			signed(ALICE),
-			id,
+			asset,
 			name.clone(),
 			symbol.clone(),
 			decimals
 		));
-		assert_eq!(Assets::name(id), name);
-		assert_eq!(Assets::symbol(id), symbol);
-		assert_eq!(Assets::decimals(id), decimals);
+		assert_eq!(Assets::name(asset), name);
+		assert_eq!(Assets::symbol(asset), symbol);
+		assert_eq!(Assets::decimals(asset), decimals);
 	});
 }
 
 #[test]
 fn clear_metadata_works() {
 	new_test_ext().execute_with(|| {
-		let id = ASSET;
+		let asset = ASSET;
 
-		create_asset_and_set_metadata(ALICE, id, vec![42], vec![42], 42);
-		assert_ok!(Fungibles::clear_metadata(signed(ALICE), id));
-		assert!(Assets::name(id).is_empty());
-		assert!(Assets::symbol(id).is_empty());
-		assert!(Assets::decimals(id).is_zero());
+		create_asset_and_set_metadata(ALICE, asset, vec![42], vec![42], 42);
+		assert_ok!(Fungibles::clear_metadata(signed(ALICE), asset));
+		assert!(Assets::name(asset).is_empty());
+		assert!(Assets::symbol(asset).is_empty());
+		assert!(Assets::decimals(asset).is_zero());
 	});
 }
 
@@ -192,16 +202,16 @@ fn clear_metadata_works() {
 fn mint_works() {
 	new_test_ext().execute_with(|| {
 		let value: Balance = 100 * UNIT;
-		let id = ASSET;
+		let asset = ASSET;
 		let from = None;
 		let to = Some(BOB);
 
-		create_asset(ALICE, id);
-		let balance_before_mint = Assets::balance(id, &BOB);
-		assert_ok!(Fungibles::mint(signed(ALICE), id, BOB, value));
-		let balance_after_mint = Assets::balance(id, &BOB);
+		create_asset(ALICE, asset);
+		let balance_before_mint = Assets::balance(asset, &BOB);
+		assert_ok!(Fungibles::mint(signed(ALICE), asset, BOB, value));
+		let balance_after_mint = Assets::balance(asset, &BOB);
 		assert_eq!(balance_after_mint, balance_before_mint + value);
-		System::assert_last_event(Event::Transfer { id, from, to, value }.into());
+		System::assert_last_event(Event::Transfer { asset, from, to, value }.into());
 	});
 }
 
@@ -209,16 +219,16 @@ fn mint_works() {
 fn burn_works() {
 	new_test_ext().execute_with(|| {
 		let value: Balance = 100 * UNIT;
-		let id = ASSET;
+		let asset = ASSET;
 		let from = Some(BOB);
 		let to = None;
 
-		create_asset_and_mint_to(ALICE, id, BOB, value);
-		let balance_before_burn = Assets::balance(id, &BOB);
-		assert_ok!(Fungibles::burn(signed(ALICE), id, BOB, value));
-		let balance_after_burn = Assets::balance(id, &BOB);
+		create_asset_and_mint_to(ALICE, asset, BOB, value);
+		let balance_before_burn = Assets::balance(asset, &BOB);
+		assert_ok!(Fungibles::burn(signed(ALICE), asset, BOB, value));
+		let balance_after_burn = Assets::balance(asset, &BOB);
 		assert_eq!(balance_after_burn, balance_before_burn - value);
-		System::assert_last_event(Event::Transfer { id, from, to, value }.into());
+		System::assert_last_event(Event::Transfer { asset, from, to, value }.into());
 	});
 }
 
@@ -236,7 +246,7 @@ fn balance_of_works() {
 		create_asset_and_mint_to(ALICE, ASSET, ALICE, 100);
 		assert_eq!(
 			Assets::balance(ASSET, ALICE).encode(),
-			Fungibles::read_state(BalanceOf { id: ASSET, owner: ALICE })
+			Fungibles::read_state(BalanceOf { asset: ASSET, owner: ALICE })
 		);
 	});
 }
@@ -247,7 +257,7 @@ fn allowance_works() {
 		create_asset_mint_and_approve(ALICE, ASSET, BOB, 100, ALICE, 50);
 		assert_eq!(
 			Assets::allowance(ASSET, &ALICE, &BOB).encode(),
-			Fungibles::read_state(Allowance { id: ASSET, owner: ALICE, spender: BOB })
+			Fungibles::read_state(Allowance { asset: ASSET, owner: ALICE, spender: BOB })
 		);
 	});
 }
@@ -277,48 +287,48 @@ fn signed(account: AccountId) -> RuntimeOrigin {
 	RuntimeOrigin::signed(account)
 }
 
-fn create_asset(owner: AccountId, asset_id: AssetId) {
-	assert_ok!(Assets::create(signed(owner), asset_id, owner, 1));
+fn create_asset(owner: AccountId, asset_asset: AssetId) {
+	assert_ok!(Assets::create(signed(owner), asset_asset, owner, 1));
 }
 
-fn mint_asset(owner: AccountId, asset_id: AssetId, to: AccountId, value: Balance) {
-	assert_ok!(Assets::mint(signed(owner), asset_id, to, value));
+fn mint_asset(owner: AccountId, asset_asset: AssetId, to: AccountId, value: Balance) {
+	assert_ok!(Assets::mint(signed(owner), asset_asset, to, value));
 }
 
-fn create_asset_and_mint_to(owner: AccountId, asset_id: AssetId, to: AccountId, value: Balance) {
-	create_asset(owner, asset_id);
-	mint_asset(owner, asset_id, to, value)
+fn create_asset_and_mint_to(owner: AccountId, asset_asset: AssetId, to: AccountId, value: Balance) {
+	create_asset(owner, asset_asset);
+	mint_asset(owner, asset_asset, to, value)
 }
 
 fn create_asset_mint_and_approve(
 	owner: AccountId,
-	asset_id: AssetId,
+	asset_asset: AssetId,
 	to: AccountId,
 	mint: Balance,
 	spender: AccountId,
 	approve: Balance,
 ) {
-	create_asset_and_mint_to(owner, asset_id, to, mint);
-	assert_ok!(Assets::approve_transfer(signed(to), asset_id, spender, approve,));
+	create_asset_and_mint_to(owner, asset_asset, to, mint);
+	assert_ok!(Assets::approve_transfer(signed(to), asset_asset, spender, approve,));
 }
 
 fn create_asset_and_set_metadata(
 	owner: AccountId,
-	asset_id: AssetId,
+	asset_asset: AssetId,
 	name: Vec<u8>,
 	symbol: Vec<u8>,
 	decimals: u8,
 ) {
-	assert_ok!(Assets::create(signed(owner), asset_id, owner, 100));
-	set_metadata_asset(owner, asset_id, name, symbol, decimals);
+	assert_ok!(Assets::create(signed(owner), asset_asset, owner, 100));
+	set_metadata_asset(owner, asset_asset, name, symbol, decimals);
 }
 
 fn set_metadata_asset(
 	owner: AccountId,
-	asset_id: AssetId,
+	asset_asset: AssetId,
 	name: Vec<u8>,
 	symbol: Vec<u8>,
 	decimals: u8,
 ) {
-	assert_ok!(Assets::set_metadata(signed(owner), asset_id, name, symbol, decimals));
+	assert_ok!(Assets::set_metadata(signed(owner), asset_asset, name, symbol, decimals));
 }


### PR DESCRIPTION
Refactors the the error handling in separate functions for easier testing between modules. The tests have also been refactored into separate tests for each error variant and more edge cases. More importantly, the tests don't test the `Error` from primitives but the raw bytes. 

In #192, `Error` is refactored to the pop api crate, note that the pop primitives crate is removed from the extension crate in this PR since here it was forgotten.

In the second commit docs have been added to the `v0` module as well.

Helping with #188 