### PR TITLE
fix: missing migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10275,7 +10275,7 @@ dependencies = [
 
 [[package]]
 name = "pop-node"
-version = "0.1.0-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "clap",
  "color-print",
@@ -10436,7 +10436,7 @@ dependencies = [
 
 [[package]]
 name = "pop-runtime-testnet"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pop-node"
-version = "0.1.0-alpha"
+version = "0.2.0-alpha"
 authors.workspace = true
 description.workspace = true
 license = "Unlicense"

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pop-runtime-testnet"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 description.workspace = true
 license = "Unlicense"

--- a/runtime/testnet/src/config/contracts.rs
+++ b/runtime/testnet/src/config/contracts.rs
@@ -88,6 +88,6 @@ impl pallet_contracts::Config for Runtime {
 	type ApiVersion = ();
 	type Environment = ();
 	type Debug = ();
-	type Migrations = ();
+	type Migrations = (pallet_contracts::migration::v16::Migration<Runtime>,);
 	type Xcm = pallet_xcm::Pallet<Self>;
 }

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -187,7 +187,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("pop"),
 	authoring_version: 1,
 	#[allow(clippy::zero_prefixed_literal)]
-	spec_version: 00_03_00,
+	spec_version: 00_04_00,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Adds a missing migration necessary for `testnet-runtime` `0.4.0`.
Bumps spec version of testnet-runtime to `00_04_00` 