### PR TITLE
docs(readme): fix instruction in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cargo install pop-cli
 You can spawn a local network as follows:
 
 ```shell
-pop up parachain -f ./networks/paseo.toml
+pop up parachain -f ./networks/testnet.toml
 ```
 
 Note: `pop` will automatically source the necessary `polkadot` binaries. Currently, these will have to be built if on a


### PR DESCRIPTION
_Small fix:_ I was testing pop-node locally and noticed that the `README` was pointing to a config file that doesn't exist anymore. Just updated it.