### PR TITLE
fix: mutable `self` required for dispatchable ink! methods

### DIFF
--- a/pop-api/examples/fungibles/lib.rs
+++ b/pop-api/examples/fungibles/lib.rs
@@ -60,13 +60,13 @@ mod fungibles {
 		}
 
 		#[ink(message)]
-		pub fn transfer(&self, id: AssetId, to: AccountId, value: Balance) -> Result<()> {
+		pub fn transfer(&mut self, id: AssetId, to: AccountId, value: Balance) -> Result<()> {
 			api::transfer(id, to, value)
 		}
 
 		#[ink(message)]
 		pub fn transfer_from(
-			&self,
+			&mut self,
 			id: AssetId,
 			from: AccountId,
 			to: AccountId,
@@ -78,13 +78,13 @@ mod fungibles {
 		}
 
 		#[ink(message)]
-		pub fn approve(&self, id: AssetId, spender: AccountId, value: Balance) -> Result<()> {
+		pub fn approve(&mut self, id: AssetId, spender: AccountId, value: Balance) -> Result<()> {
 			api::approve(id, spender, value)
 		}
 
 		#[ink(message)]
 		pub fn increase_allowance(
-			&self,
+			&mut self,
 			id: AssetId,
 			spender: AccountId,
 			value: Balance,
@@ -94,7 +94,7 @@ mod fungibles {
 
 		#[ink(message)]
 		pub fn decrease_allowance(
-			&self,
+			&mut self,
 			id: AssetId,
 			spender: AccountId,
 			value: Balance,

--- a/pop-api/integration-tests/contracts/fungibles/lib.rs
+++ b/pop-api/integration-tests/contracts/fungibles/lib.rs
@@ -60,13 +60,13 @@ mod fungibles {
 		}
 
 		#[ink(message)]
-		pub fn transfer(&self, id: AssetId, to: AccountId, value: Balance) -> Result<()> {
+		pub fn transfer(&mut self, id: AssetId, to: AccountId, value: Balance) -> Result<()> {
 			api::transfer(id, to, value)
 		}
 
 		#[ink(message)]
 		pub fn transfer_from(
-			&self,
+			&mut self,
 			id: AssetId,
 			from: AccountId,
 			to: AccountId,
@@ -78,13 +78,13 @@ mod fungibles {
 		}
 
 		#[ink(message)]
-		pub fn approve(&self, id: AssetId, spender: AccountId, value: Balance) -> Result<()> {
+		pub fn approve(&mut self, id: AssetId, spender: AccountId, value: Balance) -> Result<()> {
 			api::approve(id, spender, value)
 		}
 
 		#[ink(message)]
 		pub fn increase_allowance(
-			&self,
+			&mut self,
 			id: AssetId,
 			spender: AccountId,
 			value: Balance,
@@ -94,7 +94,7 @@ mod fungibles {
 
 		#[ink(message)]
 		pub fn decrease_allowance(
-			&self,
+			&mut self,
 			id: AssetId,
 			spender: AccountId,
 			value: Balance,
@@ -130,18 +130,23 @@ mod fungibles {
 		/// - asset_exists
 
 		#[ink(message)]
-		pub fn create(&self, id: AssetId, admin: AccountId, min_balance: Balance) -> Result<()> {
+		pub fn create(
+			&mut self,
+			id: AssetId,
+			admin: AccountId,
+			min_balance: Balance,
+		) -> Result<()> {
 			api::create(id, admin, min_balance)
 		}
 
 		#[ink(message)]
-		pub fn start_destroy(&self, id: AssetId) -> Result<()> {
+		pub fn start_destroy(&mut self, id: AssetId) -> Result<()> {
 			api::start_destroy(id)
 		}
 
 		#[ink(message)]
 		pub fn set_metadata(
-			&self,
+			&mut self,
 			id: AssetId,
 			name: Vec<u8>,
 			symbol: Vec<u8>,
@@ -165,12 +170,12 @@ mod fungibles {
 		/// - burn
 
 		#[ink(message)]
-		pub fn mint(&self, id: AssetId, account: AccountId, amount: Balance) -> Result<()> {
+		pub fn mint(&mut self, id: AssetId, account: AccountId, amount: Balance) -> Result<()> {
 			api::mint(id, account, amount)
 		}
 
 		#[ink(message)]
-		pub fn burn(&self, id: AssetId, account: AccountId, amount: Balance) -> Result<()> {
+		pub fn burn(&mut self, id: AssetId, account: AccountId, amount: Balance) -> Result<()> {
 			api::burn(id, account, amount)
 		}
 	}


### PR DESCRIPTION
In our current `pop-api` contracts, we do not mark `self` as `mutable` because the contract storage is not being modified directly; instead, the runtime storage is mutated by the `pop-api`. However, on the client side, when using libraries that support ink! (such as PJS or Dedot), these methods are perceived as `query` rather than `tx`, as the contract itself does not undergo changes.

While it's unclear whether `pop-api` will be utilized in immutable methods in production, it is crucial to clearly state this requirement in the documentation. This will help ensure that developers understand how pop-api behaves and how it might impact the perception and execution of methods in client-side libraries.

cc: @Daanvdplas @peterwht