### PR TITLE
refactor: extension unit tests

### DIFF
--- a/extension/src/matching.rs
+++ b/extension/src/matching.rs
@@ -38,42 +38,46 @@ impl<T: Get<u32>> Matches for WithFuncId<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::mock::{Environment, Ext};
+	use crate::mock::{MockEnvironment, MockExt};
 	use sp_core::{ConstU16, ConstU32};
 
 	#[test]
 	fn matching_equals_works() {
-		let env = Environment::new(u32::from_be_bytes([0u8, 1, 0, 2]), vec![], Ext::default());
+		let env =
+			MockEnvironment::new(u32::from_be_bytes([0u8, 1, 0, 2]), vec![], MockExt::default());
 		assert!(Equals::<ConstU16<1>, ConstU16<2>>::matches(&env));
 	}
 
 	#[test]
 	fn matching_equals_invalid() {
-		let env = Environment::new(u32::from_be_bytes([0u8, 1, 0, 3]), vec![], Ext::default());
+		let env =
+			MockEnvironment::new(u32::from_be_bytes([0u8, 1, 0, 3]), vec![], MockExt::default());
 		assert!(!Equals::<ConstU16<1>, ConstU16<2>>::matches(&env));
 	}
 
 	#[test]
 	fn matching_function_id_works() {
-		let env = Environment::new(u32::from_be_bytes([0u8, 1, 0, 2]), vec![], Ext::default());
+		let env =
+			MockEnvironment::new(u32::from_be_bytes([0u8, 1, 0, 2]), vec![], MockExt::default());
 		assert!(FunctionId::<ConstU16<2>>::matches(&env));
 	}
 
 	#[test]
 	fn matching_function_id_invalid() {
-		let env = Environment::new(u32::from_be_bytes([0u8, 1, 0, 3]), vec![], Ext::default());
+		let env =
+			MockEnvironment::new(u32::from_be_bytes([0u8, 1, 0, 3]), vec![], MockExt::default());
 		assert!(!FunctionId::<ConstU16<2>>::matches(&env));
 	}
 
 	#[test]
 	fn matching_with_func_id_works() {
-		let env = Environment::default();
+		let env = MockEnvironment::default();
 		assert!(WithFuncId::<ConstU32<0>>::matches(&env));
 	}
 
 	#[test]
 	fn matching_with_func_id_invalid() {
-		let env = Environment::new(1, vec![], Ext::default());
+		let env = MockEnvironment::new(1, vec![], MockExt::default());
 		assert!(!WithFuncId::<ConstU32<0>>::matches(&env));
 	}
 }

--- a/extension/src/mock.rs
+++ b/extension/src/mock.rs
@@ -233,7 +233,7 @@ impl<M: Matches, C> Matches for Noop<M, C> {
 }
 
 /// A mocked chain extension environment.
-pub(crate) struct Environment<E> {
+pub(crate) struct MockEnvironment<E> {
 	func_id: u16,
 	ext_id: u16,
 	charged: Vec<Weight>,
@@ -241,13 +241,13 @@ pub(crate) struct Environment<E> {
 	ext: E,
 }
 
-impl Default for Environment<Ext> {
+impl Default for MockEnvironment<MockExt> {
 	fn default() -> Self {
-		Environment::new(0, [].to_vec(), Ext::default())
+		MockEnvironment::new(0, [].to_vec(), MockExt::default())
 	}
 }
 
-impl<E> Environment<E> {
+impl<E> MockEnvironment<E> {
 	pub(crate) fn new(id: u32, buffer: Vec<u8>, ext: E) -> Self {
 		Self {
 			func_id: (id & 0x0000FFFF) as u16,
@@ -263,7 +263,7 @@ impl<E> Environment<E> {
 	}
 }
 
-impl<E: environment::Ext<Config = Test> + Clone> environment::Environment for Environment<E> {
+impl<E: environment::Ext<Config = Test> + Clone> environment::Environment for MockEnvironment<E> {
 	type Config = Test;
 	type ChargedAmount = Weight;
 
@@ -300,7 +300,7 @@ impl<E: environment::Ext<Config = Test> + Clone> environment::Environment for En
 	}
 }
 
-impl<E> environment::BufIn for Environment<E> {
+impl<E> environment::BufIn for MockEnvironment<E> {
 	fn in_len(&self) -> u32 {
 		self.buffer.len() as u32
 	}
@@ -311,7 +311,7 @@ impl<E> environment::BufIn for Environment<E> {
 	}
 }
 
-impl<E> environment::BufOut for Environment<E> {
+impl<E> environment::BufOut for MockEnvironment<E> {
 	fn write(
 		&mut self,
 		buffer: &[u8],
@@ -326,10 +326,10 @@ impl<E> environment::BufOut for Environment<E> {
 
 /// A mocked smart contract environment.
 #[derive(Clone, Default)]
-pub(crate) struct Ext {
+pub(crate) struct MockExt {
 	pub(crate) address: <Test as frame_system::Config>::AccountId,
 }
-impl environment::Ext for Ext {
+impl environment::Ext for MockExt {
 	type Config = Test;
 
 	fn address(&self) -> &<Self::Config as frame_system::Config>::AccountId {

--- a/extension/src/tests/mod.rs
+++ b/extension/src/tests/mod.rs
@@ -1,9 +1,20 @@
+use crate::mock::RuntimeResult;
+use crate::tests::utils::decoding_failed_weight;
 use crate::{
-	mock::{Config, Environment, Ext, NoopFuncId, ReadStateEverthingFuncId, Test},
-	ContractWeights, Extension,
+	environment::Ext,
+	mock::{
+		new_test_ext, Config, DispatchCallEverthingFuncId, MockEnvironment, MockExt, NoopFuncId,
+		ReadStateEverthingFuncId, RuntimeCall, RuntimeRead, Test, INVALID_FUNC_ID,
+	},
+	BufIn, ContractWeights, Dispatchable, Environment, Extension, GetDispatchInfo,
 };
-use pallet_contracts::chain_extension::RetVal::Converging;
-use pallet_contracts::WeightInfo;
+use codec::Encode;
+use frame_system::Call;
+use pallet_contracts::{chain_extension::RetVal::Converging, WeightInfo};
+pub(crate) use utils::{
+	extension_call_dispatch_call_weight, extension_call_read_state_weight,
+	function_dispatch_call_weight, function_read_state_weight, overhead_weight, read_from_buffer,
+};
 
 mod contract;
 mod utils;
@@ -11,45 +22,103 @@ mod utils;
 #[test]
 fn extension_call_works() {
 	let input = vec![2, 2];
-	let mut env = Environment::new(NoopFuncId::get(), input.clone(), Ext::default());
+	let mut env = MockEnvironment::new(NoopFuncId::get(), input.clone(), MockExt::default());
 	let mut extension = Extension::<Config>::default();
 	assert!(matches!(extension.call(&mut env), Ok(Converging(0))));
-	assert_eq!(env.charged(), ContractWeights::<Test>::seal_debug_message(input.len() as u32))
+	assert_eq!(env.charged(), overhead_weight(input.len() as u32))
 }
 
 #[test]
-fn extension_returns_decoding_failed_for_unknown_function() {
-	// no function registered for id 0
-	let mut env = Environment::new(0, Vec::default(), Ext::default());
+fn extension_for_unknown_function_works() {
+	let input = vec![2, 2];
+	// No function registered for id 0.
+	let mut env = MockEnvironment::new(0, input.clone(), MockExt::default());
 	let mut extension = Extension::<Config>::default();
 	assert!(matches!(
 		extension.call(&mut env),
 		Err(error) if error == pallet_contracts::Error::<Test>::DecodingFailed.into()
 	));
+	// Charges weight.
+	assert_eq!(env.charged(), overhead_weight(input.len() as u32))
 }
 
 #[test]
-fn extension_call_charges_weight() {
-	// specify invalid function
-	let mut env = Environment::new(0, [0u8; 42].to_vec(), Ext::default());
+fn extension_call_dispatch_call_works() {
+	new_test_ext().execute_with(|| {
+		let call =
+			RuntimeCall::System(Call::remark_with_event { remark: "pop".as_bytes().to_vec() });
+		// Insert one byte due to the `RemoveFirstByte` conversion configuration of `DispatchCallEverythingFuncId`.
+		let encoded_call = [0u8.encode(), call.encode()].concat();
+		let mut default_env = MockEnvironment::default();
+		let mut env = MockEnvironment::new(
+			DispatchCallEverthingFuncId::get(),
+			encoded_call.clone(),
+			MockExt::default(),
+		);
+		let mut extension = Extension::<Config>::default();
+		assert!(matches!(extension.call(&mut env), Ok(Converging(0))));
+		assert_eq!(
+			env.charged(),
+			extension_call_dispatch_call_weight(
+				&mut default_env,
+				encoded_call.len() as u32,
+				call,
+				env.ext().address().clone()
+			)
+		);
+	});
+}
+
+#[test]
+fn extension_call_dispatch_call_invalid() {
+	// Invalid encoded runtime call.
+	let input = vec![0u8, 99];
+	let mut env =
+		MockEnvironment::new(DispatchCallEverthingFuncId::get(), input.clone(), MockExt::default());
 	let mut extension = Extension::<Config>::default();
 	assert!(extension.call(&mut env).is_err());
-	assert_eq!(env.charged(), ContractWeights::<Test>::seal_debug_message(42))
+	assert_eq!(env.charged(), decoding_failed_weight(input.len() as u32));
 }
 
 #[test]
 fn extension_call_read_state_works() {
-	let mut env =
-		Environment::new(ReadStateEverthingFuncId::get(), [0u8, 1].to_vec(), Ext::default());
+	let read = RuntimeRead::Ping;
+	// Insert one byte due to the `RemoveFirstByte` conversion configuration of `ReadStateEverythingFuncId`.
+	let encoded_read = [0u8.encode(), read.encode()].concat();
+	let read_result = RuntimeResult::Pong("pop".to_string());
+	let expected = "pop".as_bytes().encode();
+	let mut default_env = MockEnvironment::default();
+	let mut env = MockEnvironment::new(
+		ReadStateEverthingFuncId::get(),
+		encoded_read.clone(),
+		MockExt::default(),
+	);
 	let mut extension = Extension::<Config>::default();
 	assert!(matches!(extension.call(&mut env), Ok(Converging(0))));
+	// Check that the two environments charged the same weights.
+	assert_eq!(
+		env.charged(),
+		extension_call_read_state_weight(
+			&mut default_env,
+			encoded_read.len() as u32,
+			read,
+			read_result,
+		)
+	);
+	// Check if the contract environment buffer is written correctly.
+	assert_eq!(env.buffer, expected);
 }
 
 #[test]
 fn extension_call_read_state_invalid() {
-	let mut env =
-		Environment::new(ReadStateEverthingFuncId::get(), [0u8, 99].to_vec(), Ext::default());
+	let input = vec![0u8, 99];
+	let mut env = MockEnvironment::new(
+		ReadStateEverthingFuncId::get(),
+		// Invalid runtime state read.
+		input.clone(),
+		MockExt::default(),
+	);
 	let mut extension = Extension::<Config>::default();
-	// Failed due to the invalid read index.
 	assert!(extension.call(&mut env).is_err());
+	assert_eq!(env.charged(), decoding_failed_weight(input.len() as u32));
 }

--- a/extension/src/tests/utils.rs
+++ b/extension/src/tests/utils.rs
@@ -1,8 +1,18 @@
-use crate::mock::*;
+use crate::mock::{MockExt, *};
+use crate::{
+	environment::{BufOut, Ext},
+	functions::{Converter, Readable},
+	BufIn, ContractWeights, DefaultConverter, Dispatchable, Environment, Extension,
+	GetDispatchInfo, RawOrigin, Weight,
+};
 use codec::Encode;
 use core::fmt::Debug;
-use frame_support::pallet_prelude::Weight;
-use pallet_contracts::{Code, CollectEvents, ContractExecResult, Determinism};
+use frame_support::assert_ok;
+use frame_system::Call;
+use pallet_contracts::{
+	chain_extension::RetVal::Converging, Code, CollectEvents, ContractExecResult, Determinism,
+	WeightInfo,
+};
 use std::path::Path;
 
 /// Initializing a new contract file if it does not exist.
@@ -70,4 +80,78 @@ pub(crate) fn call(
 /// Construct the hashed bytes as a selector of function.
 pub(crate) fn function_selector(name: &str) -> Vec<u8> {
 	sp_io::hashing::blake2_256(name.as_bytes())[0..4].to_vec()
+}
+
+// Weight charged for calling into the runtime from a contract.
+pub(crate) fn overhead_weight(input_len: u32) -> Weight {
+	ContractWeights::<Test>::seal_debug_message(input_len)
+}
+
+// Weight charged for reading function call input from buffer.
+pub(crate) fn read_from_buffer(input_len: u32) -> Weight {
+	ContractWeights::<Test>::seal_return(input_len)
+}
+
+// Weight charged after decoding failed.
+pub(crate) fn decoding_failed_weight(input_len: u32) -> Weight {
+	overhead_weight(input_len) + read_from_buffer(input_len)
+}
+
+// Weight charged for executing a dispatch call with the chain extension.
+pub(crate) fn extension_call_dispatch_call_weight<E: Ext<Config = Test> + Clone>(
+	default_env: &mut MockEnvironment<E>,
+	input_len: u32,
+	call: RuntimeCall,
+	contract: <Test as frame_system::Config>::AccountId,
+) -> Weight {
+	assert_ok!(default_env.charge_weight(ContractWeights::<Test>::seal_debug_message(input_len)));
+	function_dispatch_call_weight(default_env, input_len, call, contract)
+}
+
+// Weight charged for executing the function dispatch call.
+pub(crate) fn function_dispatch_call_weight<E: Ext<Config = Test> + Clone>(
+	default_env: &mut MockEnvironment<E>,
+	input_len: u32,
+	call: RuntimeCall,
+	contract: <Test as frame_system::Config>::AccountId,
+) -> Weight {
+	assert_ok!(default_env.charge_weight(read_from_buffer(input_len)));
+	// Charge pre-dispatch weight.
+	let dispatch_info = call.get_dispatch_info();
+	let charged = default_env.charge_weight(dispatch_info.weight).expect("should work");
+	// Dispatch call.
+	let origin: <Test as frame_system::Config>::RuntimeOrigin = RawOrigin::Signed(contract).into();
+	let result = call.dispatch(origin);
+	// Adjust weight.
+	let weight = frame_support::dispatch::extract_actual_weight(&result, &dispatch_info);
+	default_env.adjust_weight(charged, weight);
+	default_env.charged()
+}
+
+// Weight charged for executing a runtime state read with the chain extension.
+pub(crate) fn extension_call_read_state_weight<E: Ext<Config = Test> + Clone>(
+	default_env: &mut MockEnvironment<E>,
+	input_len: u32,
+	read: RuntimeRead,
+	read_result: RuntimeResult,
+) -> Weight {
+	assert_ok!(default_env.charge_weight(ContractWeights::<Test>::seal_debug_message(input_len)));
+	function_read_state_weight(default_env, input_len, read, read_result)
+}
+
+// Weight charged for executing the function runtime read state.
+pub(crate) fn function_read_state_weight<E: Ext<Config = Test> + Clone>(
+	default_env: &mut MockEnvironment<E>,
+	input_len: u32,
+	read: RuntimeRead,
+	read_result: RuntimeResult,
+) -> Weight {
+	assert_ok!(default_env.charge_weight(read_from_buffer(input_len)));
+	// Charge weight for reading state.
+	assert_ok!(default_env.charge_weight(read.weight()));
+	// Charge weight for writing to contract buffer, based on input length, after conversion.
+	let result = DefaultConverter::<RuntimeResult>::convert(read_result, default_env);
+	let weight_per_byte = ContractWeights::<Test>::seal_input_per_byte(1);
+	assert_ok!(default_env.write(&result, false, Some(weight_per_byte)));
+	default_env.charged()
 }


### PR DESCRIPTION
Refactored the tests so that all the functionality is tested in a more accumulative way. Starting as small as possible and then bubbling up, also reusing helper functions for weight that help readers understand how it works.
