### PR TITLE
chore(testnet): bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "pop-runtime-testnet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -6,7 +6,7 @@ homepage.workspace = true
 license = "Unlicense"
 name = "pop-runtime-testnet"
 repository.workspace = true
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -181,7 +181,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("pop"),
 	authoring_version: 1,
 	#[allow(clippy::zero_prefixed_literal)]
-	spec_version: 00_04_00,
+	spec_version: 00_04_01,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This is a small version bump to 0.4.1 for adding XCM ExecuteFilter=Everything.