### PR TITLE
refactor: constrain environment associated type bounds to ease mocking

### DIFF
--- a/extension/src/environment.rs
+++ b/extension/src/environment.rs
@@ -186,3 +186,8 @@ impl<'a, T: pallet_contracts::chain_extension::Ext> Ext for ExternalEnvironment<
 		self.0.address()
 	}
 }
+
+#[test]
+fn default_ext_works() {
+	assert_eq!(().address(), &())
+}

--- a/extension/src/environment.rs
+++ b/extension/src/environment.rs
@@ -180,8 +180,8 @@ impl Ext for () {
 /// A wrapper type for a type implementing `pallet_contracts::chain_extension::Ext`.
 pub(crate) struct ExternalEnvironment<'a, T: pallet_contracts::chain_extension::Ext>(&'a mut T);
 
-impl<'a, T: pallet_contracts::chain_extension::Ext> Ext for ExternalEnvironment<'a, T> {
-	type AccountId = AccountIdOf<T::T>;
+impl<'a, E: pallet_contracts::chain_extension::Ext> Ext for ExternalEnvironment<'a, E> {
+	type AccountId = AccountIdOf<E::T>;
 	fn address(&self) -> &Self::AccountId {
 		self.0.address()
 	}

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::Decode as _;
 use core::marker::PhantomData;
 pub use decoding::{Decode, Decodes, DecodingFailed, Identity, Processor};
 pub use environment::{BufIn, BufOut, Environment, Ext};
@@ -34,7 +33,9 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-type ContractWeights<T> = <T as pallet_contracts::Config>::WeightInfo;
+type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+pub type ContractWeightsOf<T> = <T as pallet_contracts::Config>::WeightInfo;
+type RuntimeCallOf<T> = <T as frame_system::Config>::RuntimeCall;
 
 /// A configurable chain extension.
 #[derive(Default)]
@@ -67,14 +68,14 @@ impl<
 {
 	fn call(
 		&mut self,
-		env: &mut (impl Environment<Config = Runtime> + BufIn + BufOut),
+		env: &mut (impl Environment<AccountId = Runtime::AccountId> + BufIn + BufOut),
 	) -> Result<RetVal> {
 		log::trace!(target: Config::LOG_TARGET, "extension called");
 		// Charge weight for making a call from a contract to the runtime.
 		// `debug_message` weight is a good approximation of the additional overhead of going from
 		// contract layer to substrate layer. reference: https://github.com/paritytech/polkadot-sdk/pull/4233/files#:~:text=DebugMessage(len)%20%3D%3E%20T%3A%3AWeightInfo%3A%3Aseal_debug_message(len)%2C
 		let len = env.in_len();
-		let overhead = ContractWeights::<Runtime>::seal_debug_message(len);
+		let overhead = ContractWeightsOf::<Runtime>::seal_debug_message(len);
 		let charged = env.charge_weight(overhead)?;
 		log::debug!(target: Config::LOG_TARGET, "extension call weight charged: len={len}, weight={overhead}, charged={charged:?}");
 		// Execute the function
@@ -212,16 +213,16 @@ mod extension {
 
 	// Weight charged for calling into the runtime from a contract.
 	fn overhead_weight(input_len: u32) -> Weight {
-		ContractWeights::<Test>::seal_debug_message(input_len)
+		ContractWeightsOf::<Test>::seal_debug_message(input_len)
 	}
 
 	// Weight charged for reading function call input from buffer.
 	pub(crate) fn read_from_buffer_weight(input_len: u32) -> Weight {
-		ContractWeights::<Test>::seal_return(input_len)
+		ContractWeightsOf::<Test>::seal_return(input_len)
 	}
 
 	// Weight charged for writing to contract memory.
 	pub(crate) fn write_to_contract_weight(len: u32) -> Weight {
-		ContractWeights::<Test>::seal_input(len)
+		ContractWeightsOf::<Test>::seal_input(len)
 	}
 }

--- a/extension/src/mock.rs
+++ b/extension/src/mock.rs
@@ -1,6 +1,7 @@
 use crate::{
-	decoding::Identity, environment, matching::WithFuncId, Converter, Decodes, DecodingFailed,
-	DefaultConverter, DispatchCall, Extension, Function, Matches, Processor, ReadState, Readable,
+	decoding::Identity, environment, matching::WithFuncId, AccountIdOf, ContractWeightsOf,
+	Converter, Decodes, DecodingFailed, DefaultConverter, DispatchCall, Extension, Function,
+	Matches, Processor, ReadState, Readable,
 };
 use codec::{Decode, Encode};
 use frame_support::{
@@ -21,24 +22,22 @@ pub(crate) const GAS_LIMIT: Weight = Weight::from_parts(500_000_000_000, 3 * 102
 pub(crate) const INIT_AMOUNT: <Test as pallet_balances::Config>::Balance = 100_000_000;
 pub(crate) const INVALID_FUNC_ID: u32 = 0;
 
-pub(crate) type AccountId = <Test as frame_system::Config>::AccountId;
-pub(crate) type Balance = <<Test as pallet_contracts::Config>::Currency as Inspect<
-	<Test as frame_system::Config>::AccountId,
->>::Balance;
+pub(crate) type AccountId = AccountIdOf<Test>;
+pub(crate) type Balance =
+	<<Test as pallet_contracts::Config>::Currency as Inspect<AccountIdOf<Test>>>::Balance;
 type DispatchCallWith<Id, Filter, Processor = Identity<Vec<u8>>> = DispatchCall<
 	// Registered with func id 1
 	WithFuncId<Id>,
 	// Runtime config
 	Test,
 	// Decode inputs to the function as runtime calls
-	Decodes<RuntimeCall, DecodingFailed<Test>, Processor>,
-	// Accept any filterting
+	Decodes<RuntimeCall, ContractWeightsOf<Test>, DecodingFailed<Test>, Processor>,
+	// Accept any filtering
 	Filter,
 >;
-pub(crate) type EventRecord = frame_system::EventRecord<
-	<Test as frame_system::Config>::RuntimeEvent,
-	<Test as frame_system::Config>::Hash,
->;
+pub(crate) type EventRecord =
+	frame_system::EventRecord<<Test as frame_system::Config>::RuntimeEvent, HashOf<Test>>;
+type HashOf<T> = <T as frame_system::Config>::Hash;
 pub(crate) type MockEnvironment = Environment<MockExt>;
 type ReadStateWith<Id, Filter, Processor = Identity<Vec<u8>>> = ReadState<
 	// Registered with func id 1
@@ -48,7 +47,7 @@ type ReadStateWith<Id, Filter, Processor = Identity<Vec<u8>>> = ReadState<
 	// The runtime state reads available.
 	RuntimeRead,
 	// Decode inputs to the function as runtime calls
-	Decodes<RuntimeRead, DecodingFailed<Test>, Processor>,
+	Decodes<RuntimeRead, ContractWeightsOf<Test>, DecodingFailed<Test>, Processor>,
 	// Accept any filtering
 	Filter,
 	// Convert the result of a read into the expected result
@@ -122,10 +121,8 @@ parameter_types! {
 	pub static DefaultDepositLimit: <Test as pallet_balances::Config>::Balance = 10_000_000;
 }
 
-impl frame_support::traits::Randomness<<Test as frame_system::Config>::Hash, BlockNumberFor<Test>>
-	for Test
-{
-	fn random(_subject: &[u8]) -> (<Test as frame_system::Config>::Hash, BlockNumberFor<Test>) {
+impl frame_support::traits::Randomness<HashOf<Test>, BlockNumberFor<Test>> for Test {
+	fn random(_subject: &[u8]) -> (HashOf<Test>, BlockNumberFor<Test>) {
 		(Default::default(), Default::default())
 	}
 }
@@ -229,7 +226,7 @@ impl<Matcher: Matches, Config: pallet_contracts::Config> Function for Noop<Match
 	type Error = ();
 
 	fn execute(
-		_env: &mut (impl environment::Environment<Config = Config> + crate::BufIn),
+		_env: &mut (impl environment::Environment<AccountId = Config::AccountId> + crate::BufIn),
 	) -> pallet_contracts::chain_extension::Result<RetVal> {
 		Ok(RetVal::Converging(0))
 	}
@@ -271,8 +268,10 @@ impl<E: Default> Environment<E> {
 	}
 }
 
-impl<E: environment::Ext<Config = Test> + Clone> environment::Environment for Environment<E> {
-	type Config = Test;
+impl<E: environment::Ext<AccountId = AccountIdOf<Test>> + Clone> environment::Environment
+	for Environment<E>
+{
+	type AccountId = E::AccountId;
 	type ChargedAmount = Weight;
 
 	fn func_id(&self) -> u16 {
@@ -303,7 +302,7 @@ impl<E: environment::Ext<Config = Test> + Clone> environment::Environment for En
 		self.charged.insert(last, actual_weight)
 	}
 
-	fn ext(&mut self) -> impl environment::Ext<Config = Self::Config> {
+	fn ext(&mut self) -> impl environment::Ext<AccountId = Self::AccountId> {
 		self.ext.clone()
 	}
 }
@@ -334,12 +333,12 @@ impl<E> environment::BufOut for Environment<E> {
 /// A mocked smart contract environment.
 #[derive(Clone, Default)]
 pub(crate) struct MockExt {
-	pub(crate) address: <Test as frame_system::Config>::AccountId,
+	pub(crate) address: AccountIdOf<Test>,
 }
 impl environment::Ext for MockExt {
-	type Config = Test;
+	type AccountId = AccountIdOf<Test>;
 
-	fn address(&self) -> &<Self::Config as frame_system::Config>::AccountId {
+	fn address(&self) -> &Self::AccountId {
 		&self.address
 	}
 }

--- a/pallets/api/src/extension.rs
+++ b/pallets/api/src/extension.rs
@@ -1,6 +1,8 @@
 use core::{fmt::Debug, marker::PhantomData};
 use frame_support::traits::Get;
-pub use pop_chain_extension::{Config, DecodingFailed, DispatchCall, ReadState, Readable};
+pub use pop_chain_extension::{
+	Config, ContractWeightsOf, DecodingFailed, DispatchCall, ReadState, Readable,
+};
 use pop_chain_extension::{
 	Converter, Decodes, Environment, LogTarget, Matches, Processor, Result, RetVal,
 };
@@ -16,7 +18,8 @@ pub const LOG_TARGET: &str = "pop-api::extension";
 /// The chain extension used by the API.
 pub type Extension<Functions> = pop_chain_extension::Extension<Functions>;
 /// Decodes output by prepending bytes from ext_id() + func_id()
-pub type DecodesAs<Output, Error, Logger = ()> = Decodes<Output, Error, Prepender, Logger>;
+pub type DecodesAs<Output, Weight, Error, Logger = ()> =
+	Decodes<Output, Weight, Error, Prepender, Logger>;
 
 /// Prepends bytes from ext_id() + func_id() to prefix the encoded input bytes to determine the
 /// versioned output
@@ -133,4 +136,48 @@ fn version(env: &impl Environment) -> u8 {
 	// TODO: update once the encoding scheme order has been finalised: expected to be
 	// env.ext_id().to_le_bytes()[1]
 	env.func_id().to_le_bytes()[0]
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::extension::Prepender;
+	use frame_support::pallet_prelude::Weight;
+	use pop_chain_extension::Ext;
+
+	#[test]
+	fn prepender_works() {
+		let env = MockEnvironment { func_id: 1, ext_id: u16::from_le_bytes([2, 3]) };
+		let value = Vec::<u8>::default();
+		assert_eq!(Prepender::process(value, &env), vec![1, 2, 3]);
+	}
+
+	struct MockEnvironment {
+		func_id: u16,
+		ext_id: u16,
+	}
+	impl Environment for MockEnvironment {
+		type AccountId = ();
+		type ChargedAmount = Weight;
+
+		fn func_id(&self) -> u16 {
+			self.func_id
+		}
+
+		fn ext_id(&self) -> u16 {
+			self.ext_id
+		}
+
+		fn charge_weight(&mut self, _amount: Weight) -> Result<Self::ChargedAmount> {
+			unimplemented!()
+		}
+
+		fn adjust_weight(&mut self, _charged: Self::ChargedAmount, _actual_weight: Weight) {
+			unimplemented!()
+		}
+
+		fn ext(&mut self) -> impl Ext<AccountId = Self::AccountId> {
+			unimplemented!()
+		}
+	}
 }

--- a/pallets/api/src/extension.rs
+++ b/pallets/api/src/extension.rs
@@ -41,9 +41,7 @@ impl Processor for Prepender {
 		let version = version(env);
 		let (module, index) = module_and_index(env);
 		// Prepend bytes
-		value.insert(0, version);
-		value.insert(1, module);
-		value.insert(2, index);
+		value.splice(0..0, [version, module, index]);
 		log::debug!(target: Self::LOG_TARGET, "prepender: version={version}, module={module}, index={index}");
 		value
 	}
@@ -148,8 +146,7 @@ mod tests {
 	#[test]
 	fn prepender_works() {
 		let env = MockEnvironment { func_id: 1, ext_id: u16::from_le_bytes([2, 3]) };
-		let value = Vec::<u8>::default();
-		assert_eq!(Prepender::process(value, &env), vec![1, 2, 3]);
+		assert_eq!(Prepender::process(vec![0u8], &env), vec![1, 2, 3, 0]);
 	}
 
 	struct MockEnvironment {

--- a/runtime/devnet/src/config/api/mod.rs
+++ b/runtime/devnet/src/config/api/mod.rs
@@ -15,8 +15,12 @@ use versioning::*;
 mod versioning;
 
 type DecodingFailedError = DecodingFailed<Runtime>;
-type DecodesAs<Output, Logger = ()> =
-	pallet_api::extension::DecodesAs<Output, DecodingFailedError, Logger>;
+type DecodesAs<Output, Logger = ()> = pallet_api::extension::DecodesAs<
+	Output,
+	ContractWeightsOf<Runtime>,
+	DecodingFailedError,
+	Logger,
+>;
 
 /// A query of runtime state.
 #[derive(Decode, Debug)]


### PR DESCRIPTION
The `pallet_contracts::Config` bound on the associated types within `Environment`/`Ext` means that mocking the environment requires taking a dependency on `pallet-contracts` and requires adding it to the mock runtime. This is overkill for unit tests.

This PR simply constrains the type bounds to the only type currently required - `AccountId`. This can obviously be refactored in the future as more of the `Ext` implementation is used.

Also adds a test for the `Prepender`, which was the original cause of this refactor requirement.