### PR TITLE
feat(devnet): runtime non-fungibles extensions

### DIFF
--- a/pallets/api/src/non_fungibles/mod.rs
+++ b/pallets/api/src/non_fungibles/mod.rs
@@ -254,9 +254,7 @@ pub mod pallet {
 				CollectionOwner(collection) => NftsOf::<T>::collection_owner(collection).encode(),
 				TotalSupply(collection) => (NftsOf::<T>::items(&collection).count() as u8).encode(),
 				Collection(collection) => pallet_nfts::Collection::<T>::get(&collection).encode(),
-				Item { collection, item } => {
-					pallet_nfts::Item::<T>::get(&collection, &item).encode()
-				},
+				Item { collection, item } => pallet_nfts::Item::<T>::get(collection, item).encode(),
 				Allowance { collection, item, spender } => {
 					Self::allowance(collection, item, spender).encode()
 				},


### PR DESCRIPTION
Implement runtime pallet functionality extensions of the non-fungibles use case

> [!Important]
> Questionable approach in the `set_attribute` method and `ItemAttribute` state query: How can we handle the namespace? Should we dynamically identify the namespace based on the provided origin address? For `ItemAttribute`, should we simplify it by returning all attributes of the collection item or only one single key-value per call. 