### PR TITLE
refactor: fallible conversion

### DIFF
--- a/extension/src/mock.rs
+++ b/extension/src/mock.rs
@@ -9,7 +9,7 @@ use frame_support::{
 };
 use frame_system::{pallet_prelude::BlockNumberFor, EnsureSigned};
 use pallet_contracts::{chain_extension::RetVal, DefaultAddressGenerator, Frame, Schedule};
-use sp_runtime::{BuildStorage, Perbill};
+use sp_runtime::{BuildStorage, DispatchError, Perbill};
 
 use crate::{
 	decoding::Identity, environment, matching::WithFuncId, AccountIdOf, ContractWeightsOf,
@@ -373,14 +373,18 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 /// A converter for converting string results to uppercase.
 pub(crate) struct UppercaseConverter;
 impl Converter for UppercaseConverter {
+	type Error = DispatchError;
 	type Source = RuntimeResult;
 	type Target = Vec<u8>;
 
 	const LOG_TARGET: &'static str = "";
 
-	fn convert(value: Self::Source, _env: &impl crate::Environment) -> Self::Target {
+	fn try_convert(
+		value: Self::Source,
+		_env: &impl crate::Environment,
+	) -> Result<Self::Target, Self::Error> {
 		match value {
-			RuntimeResult::Pong(value) => value.to_uppercase().encode(),
+			RuntimeResult::Pong(value) => Ok(value.to_uppercase().encode()),
 		}
 	}
 }

--- a/pallets/api/src/extension.rs
+++ b/pallets/api/src/extension.rs
@@ -70,8 +70,8 @@ impl LogTarget for ReadStateLogTarget {
 
 /// Conversion of a `DispatchError` to a versioned error.
 pub struct VersionedErrorConverter<E>(PhantomData<E>);
-impl<Error: TryFrom<(DispatchError, u8), Error = DispatchError> + Into<u32> + Debug>
-	ErrorConverter for VersionedErrorConverter<Error>
+impl<Error: TryFrom<(DispatchError, u8), Error = DispatchError> + Into<u32> + Debug> ErrorConverter
+	for VersionedErrorConverter<Error>
 {
 	/// The log target.
 	const LOG_TARGET: &'static str = "pop-api::extension::converters::versioned-error";

--- a/runtime/devnet/src/config/api/versioning.rs
+++ b/runtime/devnet/src/config/api/versioning.rs
@@ -45,14 +45,15 @@ pub enum VersionedRuntimeResult {
 	V0(RuntimeResult),
 }
 
-impl From<(RuntimeResult, Version)> for VersionedRuntimeResult {
-	fn from(value: (RuntimeResult, Version)) -> Self {
+impl TryFrom<(RuntimeResult, Version)> for VersionedRuntimeResult {
+	type Error = DispatchError;
+
+	fn try_from(value: (RuntimeResult, Version)) -> Result<Self, Self::Error> {
 		let (result, version) = value;
 		match version {
 			// Allows mapping from current `RuntimeResult` to a specific/prior version
-			0 => VersionedRuntimeResult::V0(result),
-			// TODO: should never occur due to version processing/validation when request received
-			_ => unimplemented!(),
+			0 => Ok(VersionedRuntimeResult::V0(result)),
+			_ => Err(pallet_contracts::Error::<Runtime>::DecodingFailed.into()),
 		}
 	}
 }
@@ -73,14 +74,15 @@ pub enum VersionedError {
 	V0(pop_primitives::v0::Error),
 }
 
-impl From<(DispatchError, Version)> for VersionedError {
-	fn from(value: (DispatchError, Version)) -> Self {
+impl TryFrom<(DispatchError, Version)> for VersionedError {
+	type Error = DispatchError;
+
+	fn try_from(value: (DispatchError, Version)) -> Result<Self, Self::Error> {
 		let (error, version) = value;
 		match version {
 			// Allows mapping from current `DispatchError` to a specific/prior version of `Error`
-			0 => VersionedError::V0(V0Error::from(error).0),
-			// TODO: should never occur due to version processing/validation when request received
-			_ => unimplemented!(),
+			0 => Ok(VersionedError::V0(V0Error::from(error).0)),
+			_ => Err(pallet_contracts::Error::<Runtime>::DecodingFailed.into()),
 		}
 	}
 }


### PR DESCRIPTION
Refactors to allow fallible conversion, required simply to eliminate the `unimplemented!()` statements in the runtime when converting to a versioned result/error.