### PR TITLE
feat(CI): add ismp feature to CI, and choosing runtime for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,16 @@ jobs:
         run: |
           cargo check --release --locked --features=runtime-benchmarks,try-runtime
 
+  check-ismp:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: "./.github/actions/init"
+      - name: Check Build with ISMP
+        run: |
+          cargo check --release --locked --features=ismp,runtime-benchmarks,try-runtime
+
   clippy:
     needs: lint
     runs-on: ubuntu-latest
@@ -62,6 +72,24 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --release --locked --features=runtime-benchmarks
+  clippy-ismp:
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    env:
+      RUSTFLAGS: "-Wmissing_docs"
+      SKIP_WASM_BUILD: 1
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: "./.github/actions/init"
+
+      - name: Annotate with Clippy warnings
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --release --locked --features=runtime-benchmarks,ismp
 
   test:
     needs: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --release --locked --features=runtime-benchmarks
+
   clippy-ismp:
     needs: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
           - devnet
           - testnet
           - mainnet
+          - none
 
 jobs:
   srtool:
@@ -32,7 +33,8 @@ jobs:
       startsWith(github.event.release.tag_name, 'testnet') ||
       startsWith(github.event.release.tag_name, 'devnet') ||
       startsWith(github.event.release.tag_name, 'mainnet') ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.runtime != 'none'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,13 @@ on:
         default: true
       runtime:
         description: 'Runtime to build (devnet, testnet, mainnet)'
-        required: true
-        default: 'devnet'
+        default: ''
         type: choice
         options:
+          - ''
           - devnet
           - testnet
           - mainnet
-          - none
 
 jobs:
   srtool:
@@ -34,7 +33,7 @@ jobs:
       startsWith(github.event.release.tag_name, 'devnet') ||
       startsWith(github.event.release.tag_name, 'mainnet') ||
       github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.runtime != 'none'
+      github.event.inputs.runtime != ''
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,45 +16,73 @@ on:
         description: Build node
         default: true
       runtime:
-        type: boolean
-        description: Build runtimes deterministically
-        default: true
+        description: 'Runtime to build (devnet, testnet, mainnet)'
+        required: true
+        default: 'devnet'
+        type: choice
+        options:
+          - devnet
+          - testnet
+          - mainnet
 
 jobs:
   srtool:
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_dispatch' && 'true' || inputs.runtime
+    if: |
+      startsWith(github.event.release.tag_name, 'testnet') ||
+      startsWith(github.event.release.tag_name, 'devnet') ||
+      startsWith(github.event.release.tag_name, 'mainnet') ||
+      github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
-    strategy:
-      matrix:
-        runtime: [ "devnet", "testnet", "mainnet" ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Determine Runtime and Set Node Build Opts
+        id: determine_runtime
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "RUNTIME=${{ github.event.inputs.runtime }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event.release.tag_name }}" == devnet* ]]; then
+            echo "RUNTIME=devnet" >> $GITHUB_ENV
+          elif [[ "${{ github.event.release.tag_name }}" == testnet* ]]; then
+            echo "RUNTIME=testnet" >> $GITHUB_ENV
+          elif [[ "${{ github.event.release.tag_name }}" == mainnet* ]]; then
+            echo "RUNTIME=mainnet" >> $GITHUB_ENV
+          else
+            echo "RUNTIME=devnet" >> $GITHUB_ENV  # Default to devnet if no tag matches
+          fi
+          
+          # if devnet, build the node with ismp feature
+          if [ "$RUNTIME" == "devnet" ]; then
+            echo "NODE_BUILD_OPTS=--features on-chain-release-build,ismp" >> $GITHUB_ENV
+          else
+            echo "NODE_BUILD_OPTS=--features on-chain-release-build" >> $GITHUB_ENV
+          fi
 
       - name: Cache runtime target dir
         uses: actions/cache@v4
         with:
-          path: "${{ github.workspace }}/runtime/${{ matrix.runtime }}/target"
-          key: srtool-target-${{ matrix.runtime }}-${{ github.sha }}
+          path: "${{ github.workspace }}/runtime/${{ env.RUNTIME }}/target"
+          key: srtool-target-${{ env.RUNTIME }}-${{ github.sha }}
           restore-keys: |
-            srtool-target-${{ matrix.runtime }}-
+            srtool-target-${{ env.RUNTIME }}-
             srtool-target-
 
-      - name: Build ${{ matrix.runtime }} runtime
+      - name: Build ${{ env.RUNTIME }} runtime
         id: srtool_build
         uses: chevdor/srtool-actions@v0.9.2
         env:
-          BUILD_OPTS: "--features on-chain-release-build"
+          # runtimes do not have ismp feature
+          BUILD_OPTS: '--features on-chain-release-build'
         with:
-          chain: ${{ matrix.runtime }}
-          package: "pop-runtime-${{ matrix.runtime }}"
-          runtime_dir: "runtime/${{ matrix.runtime }}"
+          chain: ${{ env.RUNTIME }}
+          package: "pop-runtime-${{ env.RUNTIME }}"
+          runtime_dir: "runtime/${{ env.RUNTIME }}"
 
       - name: Store srtool digest to disk
         run: |
-          echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.runtime }}-srtool-digest.json
+          echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ env.RUNTIME }}-srtool-digest.json
 
       # Manual trigger: add artifacts to run
       - name: Copy artifacts
@@ -65,10 +93,10 @@ jobs:
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.runtime }}-runtime-${{ github.sha }}
+          name: ${{ env.RUNTIME }}-runtime-${{ github.sha }}
           path: |
-            pop_runtime_${{ matrix.runtime }}*.wasm
-            ${{ matrix.runtime }}-srtool-digest.json
+            pop_runtime_${{ env.RUNTIME }}*.wasm
+            ${{ env.RUNTIME }}-srtool-digest.json
 
       # We now get extra information thanks to subwasm,
       - name: Install subwasm ${{ env.SUBWASM_VERSION }}
@@ -81,23 +109,23 @@ jobs:
         run: |
           subwasm info ${{ steps.srtool_build.outputs.wasm }}
           subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
-          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-info.json
-          subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ matrix.runtime }}-info_compressed.json
+          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ env.RUNTIME }}-info.json
+          subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ env.RUNTIME }}-info_compressed.json
 
       - name: Extract the metadata
         run: |
           subwasm meta ${{ steps.srtool_build.outputs.wasm }}
-          subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-metadata.json
+          subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ env.RUNTIME }}-metadata.json
 
       - name: Archive Subwasm results
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.runtime }}-info
+          name: ${{ env.RUNTIME }}-info
           path: |
-            ${{ matrix.runtime }}-info.json
-            ${{ matrix.runtime }}-info_compressed.json
-            ${{ matrix.runtime }}-metadata.json
+            ${{ env.RUNTIME }}-info.json
+            ${{ env.RUNTIME }}-info_compressed.json
+            ${{ env.RUNTIME }}-metadata.json
 
       # Release published: add artifacts to release
       - name: Add artifacts to release
@@ -106,7 +134,7 @@ jobs:
         with:
           append_body: true
           body: |
-            ## Runtime: `${{ matrix.runtime }}`
+            ## Runtime: `${{ env.RUNTIME }}`
             ```
             🏋️ Runtime Size:           ${{ fromJSON(steps.srtool_build.outputs.json).runtimes.compressed.subwasm.size }} bytes
             🔥 Core Version:           ${{ fromJSON(steps.srtool_build.outputs.json).runtimes.compressed.subwasm.core_version.specName }}-${{ fromJSON(steps.srtool_build.outputs.json).runtimes.compressed.subwasm.core_version.specVersion }}
@@ -118,7 +146,7 @@ jobs:
             ```
           files: |
             ${{ steps.srtool_build.outputs.wasm_compressed }}
-            ${{ matrix.runtime }}-srtool-digest.json
+            ${{ env.RUNTIME }}-srtool-digest.json
 
   build-node:
     runs-on: ${{ matrix.platform.os }}
@@ -168,7 +196,7 @@ jobs:
         run: rustup target add ${{ matrix.platform.target }}
 
       - name: Build node
-        run: cargo build --profile=production -p pop-node --features on-chain-release-build --target ${{ matrix.platform.target }}
+        run: cargo build --profile=production -p pop-node $NODE_BUILD_OPTS --target ${{ matrix.platform.target }}
 
       - name: Package binary (Linux)
         if: contains(matrix.platform.target, 'linux')


### PR DESCRIPTION
Related: #270 
Note: 270 is the base branch. Please only review:
- .github/workflows/ci.yml
- .github/workflows/release.yml

No other files changed.

Updates the CI to _also_  build the runtimes with `--features ismp` enabled. It also modifies the release CI to only build one selected runtime or the runtime for a release (see below). If the runtime is devnet, it will build the node with `--features ismp`.

**This means the release CI will now only build ONE runtime.** Considering this is for releases, I do not see a reason we would need to build several runtimes. A testnet and mainnet release should be distinct. There is no reason to have a devnet release. There is also the option for `none`, which skips the srtool build altogether.

![Screenshot 2024-09-13 at 4 04 03 PM](https://github.com/user-attachments/assets/af59e364-f251-4a16-aa33-1a8677a7ad1f)


## Build Runtime on Release
When a release is published, the CI will build that specific runtime only. This requires that the release name abides by a specific format. This format requires the runtime name as the prefix:
```
<runtime_name_prefix>-<*can be whatever>
// testnet-v0.1.0
// devnet-v0.1.0
// mainnet-v0.1.0
```

The CI's running can be confirmed here:
**release.yml**
- Devnet release: https://github.com/peterwht/pop-node/releases/tag/devnet-v01-CI-Test
- Automatic CI run: https://github.com/peterwht/pop-node/actions/runs/10802403850
- Manual dispatch: https://github.com/peterwht/pop-node/actions/runs/10803352479
- node only: https://github.com/peterwht/pop-node/actions/runs/10856692574

**ci.yml**
- https://github.com/peterwht/pop-node/actions/runs/10802399442
