### PR TITLE
refactor: api integration tests

### DIFF
--- a/pop-api/examples/fungibles/lib.rs
+++ b/pop-api/examples/fungibles/lib.rs
@@ -1,14 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-/// Local Fungibles:
-/// 1. PSP-22 Interface
-/// 2. PSP-22 Metadata Interface
-/// 3. Asset Management
-///
 use ink::prelude::vec::Vec;
 use pop_api::{
 	assets::fungibles::{self as api},
-	primitives::AssetId,
+	primitives::TokenId,
 	StatusCode,
 };
 
@@ -29,30 +24,20 @@ mod fungibles {
 			Default::default()
 		}
 
-		/// 1. PSP-22 Interface:
-		/// - total_supply
-		/// - balance_of
-		/// - allowance
-		/// - transfer
-		/// - transfer_from
-		/// - approve
-		/// - increase_allowance
-		/// - decrease_allowance
-
 		#[ink(message)]
-		pub fn total_supply(&self, id: AssetId) -> Result<Balance> {
+		pub fn total_supply(&self, id: TokenId) -> Result<Balance> {
 			api::total_supply(id)
 		}
 
 		#[ink(message)]
-		pub fn balance_of(&self, id: AssetId, owner: AccountId) -> Result<Balance> {
+		pub fn balance_of(&self, id: TokenId, owner: AccountId) -> Result<Balance> {
 			api::balance_of(id, owner)
 		}
 
 		#[ink(message)]
 		pub fn allowance(
 			&self,
-			id: AssetId,
+			id: TokenId,
 			owner: AccountId,
 			spender: AccountId,
 		) -> Result<Balance> {
@@ -60,32 +45,31 @@ mod fungibles {
 		}
 
 		#[ink(message)]
-		pub fn transfer(&mut self, id: AssetId, to: AccountId, value: Balance) -> Result<()> {
+		pub fn transfer(&mut self, id: TokenId, to: AccountId, value: Balance) -> Result<()> {
 			api::transfer(id, to, value)
 		}
 
 		#[ink(message)]
 		pub fn transfer_from(
 			&mut self,
-			id: AssetId,
+			id: TokenId,
 			from: AccountId,
 			to: AccountId,
 			value: Balance,
-			// In the PSP-22 standard a `[u8]`, but the size needs to be known at compile time.
 			_data: Vec<u8>,
 		) -> Result<()> {
 			api::transfer_from(id, from, to, value)
 		}
 
 		#[ink(message)]
-		pub fn approve(&mut self, id: AssetId, spender: AccountId, value: Balance) -> Result<()> {
+		pub fn approve(&mut self, id: TokenId, spender: AccountId, value: Balance) -> Result<()> {
 			api::approve(id, spender, value)
 		}
 
 		#[ink(message)]
 		pub fn increase_allowance(
 			&mut self,
-			id: AssetId,
+			id: TokenId,
 			spender: AccountId,
 			value: Balance,
 		) -> Result<()> {
@@ -95,82 +79,27 @@ mod fungibles {
 		#[ink(message)]
 		pub fn decrease_allowance(
 			&mut self,
-			id: AssetId,
+			id: TokenId,
 			spender: AccountId,
 			value: Balance,
 		) -> Result<()> {
 			api::decrease_allowance(id, spender, value)
 		}
 
-		/// 2. PSP-22 Metadata Interface:
-		/// - token_name
-		/// - token_symbol
-		/// - token_decimals
-
 		#[ink(message)]
-		pub fn token_name(&self, id: AssetId) -> Result<Vec<u8>> {
+		pub fn token_name(&self, id: TokenId) -> Result<Vec<u8>> {
 			api::token_name(id)
 		}
 
 		#[ink(message)]
-		pub fn token_symbol(&self, id: AssetId) -> Result<Vec<u8>> {
+		pub fn token_symbol(&self, id: TokenId) -> Result<Vec<u8>> {
 			api::token_symbol(id)
 		}
 
 		#[ink(message)]
-		pub fn token_decimals(&self, id: AssetId) -> Result<u8> {
+		pub fn token_decimals(&self, id: TokenId) -> Result<u8> {
 			api::token_decimals(id)
 		}
-
-		// 3. Asset Management:
-		// - create
-		// - start_destroy
-		// - destroy_accounts
-		// - destroy_approvals
-		// - finish_destroy
-		// - set_metadata
-		// - clear_metadata
-
-		// #[ink(message)]
-		// pub fn create(&self, id: AssetId, admin: AccountId, min_balance: Balance) -> Result<()> {
-		// 	ink::env::debug_println!(
-		// 		"PopApiFungiblesExample::create: id: {:?} admin: {:?} min_balance: {:?}",
-		// 		id,
-		// 		admin,
-		// 		min_balance,
-		// 	);
-		// 	let result = api::create(id, admin, min_balance);
-		// 	ink::env::debug_println!("Result: {:?}", result);
-		// result.map_err(|e| e.into())
-		// result
-		// }
-
-		// #[ink(message)]
-		// pub fn set_metadata(
-		// 	&self,
-		// 	id: AssetId,
-		// 	name: Vec<u8>,
-		// 	symbol: Vec<u8>,
-		// 	decimals: u8,
-		// ) -> Result<()> {
-		// 	ink::env::debug_println!(
-		// 		"PopApiFungiblesExample::set_metadata: id: {:?} name: {:?} symbol: {:?}, decimals: {:?}",
-		// 		id,
-		// 		name,
-		// 		symbol,
-		// 		decimals,
-		// 	);
-		// 	let result = api::set_metadata(id, name, symbol, decimals);
-		// 	ink::env::debug_println!("Result: {:?}", result);
-		// 	// result.map_err(|e| e.into())
-		// 	result
-		// }
-		//
-		// #[ink(message)]
-		// pub fn asset_exists(&self, id: AssetId) -> Result<bool> {
-		// 	// api::asset_exists(id).map_err(|e| e.into())
-		// 	api::asset_exists(id)
-		// }
 	}
 
 	#[cfg(test)]
@@ -178,8 +107,6 @@ mod fungibles {
 		use super::*;
 
 		#[ink::test]
-		fn default_works() {
-			PopApiFungiblesExample::new();
-		}
+		fn default_works() {}
 	}
 }

--- a/pop-api/examples/fungibles/lib.rs
+++ b/pop-api/examples/fungibles/lib.rs
@@ -2,7 +2,7 @@
 
 use ink::prelude::vec::Vec;
 use pop_api::{
-	assets::fungibles::{self as api},
+	fungibles::{self as api},
 	primitives::TokenId,
 	StatusCode,
 };
@@ -20,93 +20,89 @@ mod fungibles {
 	impl Fungibles {
 		#[ink(constructor, payable)]
 		pub fn new() -> Self {
-			ink::env::debug_println!("PopApiFungiblesExample::new");
 			Default::default()
 		}
 
 		#[ink(message)]
-		pub fn total_supply(&self, id: TokenId) -> Result<Balance> {
-			api::total_supply(id)
+		pub fn total_supply(&self, token: TokenId) -> Result<Balance> {
+			api::total_supply(token)
 		}
 
 		#[ink(message)]
-		pub fn balance_of(&self, id: TokenId, owner: AccountId) -> Result<Balance> {
-			api::balance_of(id, owner)
+		pub fn balance_of(&self, token: TokenId, owner: AccountId) -> Result<Balance> {
+			api::balance_of(token, owner)
 		}
 
 		#[ink(message)]
 		pub fn allowance(
 			&self,
-			id: TokenId,
+			token: TokenId,
 			owner: AccountId,
 			spender: AccountId,
 		) -> Result<Balance> {
-			api::allowance(id, owner, spender)
+			api::allowance(token, owner, spender)
 		}
 
 		#[ink(message)]
-		pub fn transfer(&mut self, id: TokenId, to: AccountId, value: Balance) -> Result<()> {
-			api::transfer(id, to, value)
+		pub fn transfer(&mut self, token: TokenId, to: AccountId, value: Balance) -> Result<()> {
+			api::transfer(token, to, value)
 		}
 
 		#[ink(message)]
 		pub fn transfer_from(
 			&mut self,
-			id: TokenId,
+			token: TokenId,
 			from: AccountId,
 			to: AccountId,
 			value: Balance,
 			_data: Vec<u8>,
 		) -> Result<()> {
-			api::transfer_from(id, from, to, value)
+			api::transfer_from(token, from, to, value)
 		}
 
 		#[ink(message)]
-		pub fn approve(&mut self, id: TokenId, spender: AccountId, value: Balance) -> Result<()> {
-			api::approve(id, spender, value)
+		pub fn approve(
+			&mut self,
+			token: TokenId,
+			spender: AccountId,
+			value: Balance,
+		) -> Result<()> {
+			api::approve(token, spender, value)
 		}
 
 		#[ink(message)]
 		pub fn increase_allowance(
 			&mut self,
-			id: TokenId,
+			token: TokenId,
 			spender: AccountId,
 			value: Balance,
 		) -> Result<()> {
-			api::increase_allowance(id, spender, value)
+			api::increase_allowance(token, spender, value)
 		}
 
 		#[ink(message)]
 		pub fn decrease_allowance(
 			&mut self,
-			id: TokenId,
+			token: TokenId,
 			spender: AccountId,
 			value: Balance,
 		) -> Result<()> {
-			api::decrease_allowance(id, spender, value)
+			api::decrease_allowance(token, spender, value)
 		}
 
 		#[ink(message)]
-		pub fn token_name(&self, id: TokenId) -> Result<Vec<u8>> {
-			api::token_name(id)
+		pub fn token_name(&self, token: TokenId) -> Result<Vec<u8>> {
+			api::token_name(token)
 		}
 
 		#[ink(message)]
-		pub fn token_symbol(&self, id: TokenId) -> Result<Vec<u8>> {
-			api::token_symbol(id)
+		pub fn token_symbol(&self, token: TokenId) -> Result<Vec<u8>> {
+			api::token_symbol(token)
 		}
 
 		#[ink(message)]
-		pub fn token_decimals(&self, id: TokenId) -> Result<u8> {
-			api::token_decimals(id)
+		pub fn token_decimals(&self, token: TokenId) -> Result<u8> {
+			api::token_decimals(token)
 		}
-	}
-
-	#[cfg(test)]
-	mod tests {
-		use super::*;
-
-		#[ink::test]
-		fn default_works() {}
 	}
 }

--- a/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.toml
+++ b/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.toml
@@ -5,16 +5,16 @@ version = "0.1.0"
 
 [dependencies]
 ink = { version = "5.0.0", default-features = false }
-pop-api = { path = "../../..", default-features = false, features = ["fungibles"] }
+pop-api = { path = "../../..", default-features = false, features = [ "fungibles" ] }
 
 [lib]
 path = "lib.rs"
 
 [features]
-default = ["std"]
-e2e-tests = []
-ink-as-dependency = []
+default = [ "std" ]
+e2e-tests = [  ]
+ink-as-dependency = [  ]
 std = [
-    "ink/std",
-    "pop-api/std",
+	"ink/std",
+	"pop-api/std",
 ]

--- a/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.toml
+++ b/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.toml
@@ -1,21 +1,20 @@
 [package]
-authors = [ "[your_name] <[your_email]>" ]
 edition = "2021"
 name = "create_token_in_constructor"
 version = "0.1.0"
 
 [dependencies]
 ink = { version = "5.0.0", default-features = false }
-pop-api = { path = "../../..", default-features = false, features = [ "fungibles" ] }
+pop-api = { path = "../../..", default-features = false, features = ["fungibles"] }
 
 [lib]
 path = "lib.rs"
 
 [features]
-default = [ "std" ]
-e2e-tests = [  ]
-ink-as-dependency = [  ]
+default = ["std"]
+e2e-tests = []
+ink-as-dependency = []
 std = [
-	"ink/std",
-	"pop-api/std",
+    "ink/std",
+    "pop-api/std",
 ]

--- a/pop-api/integration-tests/contracts/fungibles/Cargo.toml
+++ b/pop-api/integration-tests/contracts/fungibles/Cargo.toml
@@ -1,21 +1,20 @@
 [package]
-authors = [ "[your_name] <[your_email]>" ]
 edition = "2021"
 name = "fungibles"
 version = "0.1.0"
 
 [dependencies]
 ink = { version = "5.0.0", default-features = false }
-pop-api = { path = "../../../../pop-api", default-features = false, features = [ "fungibles" ] }
+pop-api = { path = "../../../../pop-api", default-features = false, features = ["fungibles"] }
 
 [lib]
 path = "lib.rs"
 
 [features]
-default = [ "std" ]
-e2e-tests = [  ]
-ink-as-dependency = [  ]
+default = ["std"]
+e2e-tests = []
+ink-as-dependency = []
 std = [
-	"ink/std",
-	"pop-api/std",
+    "ink/std",
+    "pop-api/std",
 ]

--- a/pop-api/integration-tests/contracts/fungibles/Cargo.toml
+++ b/pop-api/integration-tests/contracts/fungibles/Cargo.toml
@@ -5,16 +5,16 @@ version = "0.1.0"
 
 [dependencies]
 ink = { version = "5.0.0", default-features = false }
-pop-api = { path = "../../../../pop-api", default-features = false, features = ["fungibles"] }
+pop-api = { path = "../../../../pop-api", default-features = false, features = [ "fungibles" ] }
 
 [lib]
 path = "lib.rs"
 
 [features]
-default = ["std"]
-e2e-tests = []
-ink-as-dependency = []
+default = [ "std" ]
+e2e-tests = [  ]
+ink-as-dependency = [  ]
 std = [
-    "ink/std",
-    "pop-api/std",
+	"ink/std",
+	"pop-api/std",
 ]

--- a/pop-api/integration-tests/src/fungibles/mod.rs
+++ b/pop-api/integration-tests/src/fungibles/mod.rs
@@ -1,4 +1,4 @@
-use pop_primitives::{ArithmeticError::*, Error::*, TokenError::*, TokenId, *};
+use pop_primitives::{ArithmeticError::*, Error, Error::*, TokenError::*, TokenId};
 use utils::*;
 
 use super::*;
@@ -29,7 +29,7 @@ fn total_supply_works() {
 		assert_eq!(total_supply(addr.clone(), TOKEN_ID), Ok(0));
 
 		// Tokens in circulation.
-		create_asset_and_mint_to(addr.clone(), TOKEN_ID, BOB, 100);
+		pallet_assets_create_and_mint_to(addr.clone(), TOKEN_ID, BOB, 100);
 		assert_eq!(total_supply(addr.clone(), TOKEN_ID), Ok(Assets::total_supply(TOKEN_ID)));
 		assert_eq!(total_supply(addr, TOKEN_ID), Ok(100));
 	});
@@ -46,7 +46,7 @@ fn balance_of_works() {
 		assert_eq!(balance_of(addr.clone(), TOKEN_ID, BOB), Ok(0));
 
 		// Tokens in circulation.
-		create_asset_and_mint_to(addr.clone(), TOKEN_ID, BOB, 100);
+		pallet_assets_create_and_mint_to(addr.clone(), TOKEN_ID, BOB, 100);
 		assert_eq!(balance_of(addr.clone(), TOKEN_ID, BOB), Ok(Assets::balance(TOKEN_ID, BOB)));
 		assert_eq!(balance_of(addr, TOKEN_ID, BOB), Ok(100));
 	});
@@ -66,7 +66,7 @@ fn allowance_works() {
 		assert_eq!(allowance(addr.clone(), TOKEN_ID, BOB, ALICE), Ok(0));
 
 		// Tokens in circulation.
-		create_asset_mint_and_approve(addr.clone(), TOKEN_ID, BOB, 100, ALICE, 50);
+		pallet_assets_create_mint_and_approve(addr.clone(), TOKEN_ID, BOB, 100, ALICE, 50);
 		assert_eq!(
 			allowance(addr.clone(), TOKEN_ID, BOB, ALICE),
 			Ok(Assets::allowance(TOKEN_ID, &BOB, &ALICE))
@@ -82,41 +82,41 @@ fn transfer_works() {
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let amount: Balance = 100 * UNIT;
 
-		// Asset does not exist.
+		// Token does not exist.
 		assert_eq!(
 			transfer(addr.clone(), 1, BOB, amount),
 			Err(Module { index: 52, error: [3, 0] })
 		);
-		// Create asset with Alice as owner and mint `amount` to contract address.
-		let asset = create_asset_and_mint_to(ALICE, 1, addr.clone(), amount);
-		// Asset is not live, i.e. frozen or being destroyed.
-		freeze_asset(ALICE, asset);
+		// Create token with Alice as owner and mint `amount` to contract address.
+		let token = pallet_assets_create_and_mint_to(ALICE, 1, addr.clone(), amount);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_freeze(ALICE, token);
 		assert_eq!(
-			transfer(addr.clone(), asset, BOB, amount),
+			transfer(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] })
 		);
-		thaw_asset(ALICE, asset);
+		pallet_assets_thaw(ALICE, token);
 		// Not enough balance.
 		assert_eq!(
-			transfer(addr.clone(), asset, BOB, amount + 1 * UNIT),
+			transfer(addr.clone(), token, BOB, amount + 1 * UNIT),
 			Err(Module { index: 52, error: [0, 0] })
 		);
 		// Not enough balance due to ED.
 		assert_eq!(
-			transfer(addr.clone(), asset, BOB, amount),
+			transfer(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [0, 0] })
 		);
 		// Successful transfer.
-		let balance_before_transfer = Assets::balance(asset, &BOB);
-		assert_ok!(transfer(addr.clone(), asset, BOB, amount / 2));
-		let balance_after_transfer = Assets::balance(asset, &BOB);
+		let balance_before_transfer = Assets::balance(token, &BOB);
+		assert_ok!(transfer(addr.clone(), token, BOB, amount / 2));
+		let balance_after_transfer = Assets::balance(token, &BOB);
 		assert_eq!(balance_after_transfer, balance_before_transfer + amount / 2);
-		// Transfer asset to account that does not exist.
-		assert_eq!(transfer(addr.clone(), asset, FERDIE, amount / 4), Err(Token(CannotCreate)));
-		// Asset is not live, i.e. frozen or being destroyed.
-		start_destroy_asset(ALICE, asset);
+		// Transfer token to account that does not exist.
+		assert_eq!(transfer(addr.clone(), token, FERDIE, amount / 4), Err(Token(CannotCreate)));
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_start_destroy(ALICE, token);
 		assert_eq!(
-			transfer(addr.clone(), asset, BOB, amount / 4),
+			transfer(addr.clone(), token, BOB, amount / 4),
 			Err(Module { index: 52, error: [16, 0] })
 		);
 	});
@@ -129,40 +129,40 @@ fn transfer_from_works() {
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let amount: Balance = 100 * UNIT;
 
-		// Asset does not exist.
+		// Token does not exist.
 		assert_eq!(
 			transfer_from(addr.clone(), 1, ALICE, BOB, amount / 2),
 			Err(Module { index: 52, error: [3, 0] }),
 		);
-		// Create asset with Alice as owner and mint `amount` to contract address.
-		let asset = create_asset_and_mint_to(ALICE, 1, ALICE, amount);
+		// Create token with Alice as owner and mint `amount` to contract address.
+		let token = pallet_assets_create_and_mint_to(ALICE, 1, ALICE, amount);
 		// Unapproved transfer.
 		assert_eq!(
-			transfer_from(addr.clone(), asset, ALICE, BOB, amount / 2),
+			transfer_from(addr.clone(), token, ALICE, BOB, amount / 2),
 			Err(Module { index: 52, error: [10, 0] })
 		);
 		assert_ok!(Assets::approve_transfer(
 			RuntimeOrigin::signed(ALICE.into()),
-			asset.into(),
+			token.into(),
 			addr.clone().into(),
 			amount + 1 * UNIT,
 		));
-		// Asset is not live, i.e. frozen or being destroyed.
-		freeze_asset(ALICE, asset);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_freeze(ALICE, token);
 		assert_eq!(
-			transfer_from(addr.clone(), asset, ALICE, BOB, amount),
+			transfer_from(addr.clone(), token, ALICE, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] }),
 		);
-		thaw_asset(ALICE, asset);
+		pallet_assets_thaw(ALICE, token);
 		// Not enough balance.
 		assert_eq!(
-			transfer_from(addr.clone(), asset, ALICE, BOB, amount + 1 * UNIT),
+			transfer_from(addr.clone(), token, ALICE, BOB, amount + 1 * UNIT),
 			Err(Module { index: 52, error: [0, 0] }),
 		);
 		// Successful transfer.
-		let balance_before_transfer = Assets::balance(asset, &BOB);
-		assert_ok!(transfer_from(addr.clone(), asset, ALICE, BOB, amount / 2));
-		let balance_after_transfer = Assets::balance(asset, &BOB);
+		let balance_before_transfer = Assets::balance(token, &BOB);
+		assert_ok!(transfer_from(addr.clone(), token, ALICE, BOB, amount / 2));
+		let balance_after_transfer = Assets::balance(token, &BOB);
 		assert_eq!(balance_after_transfer, balance_before_transfer + amount / 2);
 	});
 }
@@ -174,31 +174,31 @@ fn approve_works() {
 		let addr = instantiate(CONTRACT, 0, vec![]);
 		let amount: Balance = 100 * UNIT;
 
-		// Asset does not exist.
+		// Token does not exist.
 		assert_eq!(approve(addr.clone(), 0, BOB, amount), Err(Module { index: 52, error: [3, 0] }));
-		let asset = create_asset_and_mint_to(ALICE, 0, addr.clone(), amount);
-		assert_eq!(approve(addr.clone(), asset, BOB, amount), Err(ConsumerRemaining));
+		let token = pallet_assets_create_and_mint_to(ALICE, 0, addr.clone(), amount);
+		assert_eq!(approve(addr.clone(), token, BOB, amount), Err(ConsumerRemaining));
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![1]);
-		// Create asset with Alice as owner and mint `amount` to contract address.
-		let asset = create_asset_and_mint_to(ALICE, 1, addr.clone(), amount);
-		// Asset is not live, i.e. frozen or being destroyed.
-		freeze_asset(ALICE, asset);
+		// Create token with Alice as owner and mint `amount` to contract address.
+		let token = pallet_assets_create_and_mint_to(ALICE, 1, addr.clone(), amount);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_freeze(ALICE, token);
 		assert_eq!(
-			approve(addr.clone(), asset, BOB, amount),
+			approve(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] })
 		);
-		thaw_asset(ALICE, asset);
+		pallet_assets_thaw(ALICE, token);
 		// Successful approvals:
-		assert_eq!(0, Assets::allowance(asset, &addr, &BOB));
-		assert_ok!(approve(addr.clone(), asset, BOB, amount));
-		assert_eq!(Assets::allowance(asset, &addr, &BOB), amount);
+		assert_eq!(0, Assets::allowance(token, &addr, &BOB));
+		assert_ok!(approve(addr.clone(), token, BOB, amount));
+		assert_eq!(Assets::allowance(token, &addr, &BOB), amount);
 		// Non-additive, sets new value.
-		assert_ok!(approve(addr.clone(), asset, BOB, amount / 2));
-		assert_eq!(Assets::allowance(asset, &addr, &BOB), amount / 2);
-		// Asset is not live, i.e. frozen or being destroyed.
-		start_destroy_asset(ALICE, asset);
+		assert_ok!(approve(addr.clone(), token, BOB, amount / 2));
+		assert_eq!(Assets::allowance(token, &addr, &BOB), amount / 2);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_start_destroy(ALICE, token);
 		assert_eq!(
-			approve(addr.clone(), asset, BOB, amount),
+			approve(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] })
 		);
 	});
@@ -211,36 +211,36 @@ fn increase_allowance_works() {
 		let amount: Balance = 100 * UNIT;
 		// Instantiate a contract without balance - test `ConsumerRemaining.
 		let addr = instantiate(CONTRACT, 0, vec![]);
-		// Asset does not exist.
+		// Token does not exist.
 		assert_eq!(
 			increase_allowance(addr.clone(), 0, BOB, amount),
 			Err(Module { index: 52, error: [3, 0] })
 		);
-		let asset = create_asset_and_mint_to(ALICE, 0, addr.clone(), amount);
-		assert_eq!(increase_allowance(addr.clone(), asset, BOB, amount), Err(ConsumerRemaining));
+		let token = pallet_assets_create_and_mint_to(ALICE, 0, addr.clone(), amount);
+		assert_eq!(increase_allowance(addr.clone(), token, BOB, amount), Err(ConsumerRemaining));
 
 		// Instantiate a contract with balance.
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![1]);
-		// Create asset with Alice as owner and mint `amount` to contract address.
-		let asset = create_asset_and_mint_to(ALICE, 1, addr.clone(), amount);
-		// Asset is not live, i.e. frozen or being destroyed.
-		freeze_asset(ALICE, asset);
+		// Create token with Alice as owner and mint `amount` to contract address.
+		let token = pallet_assets_create_and_mint_to(ALICE, 1, addr.clone(), amount);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_freeze(ALICE, token);
 		assert_eq!(
-			increase_allowance(addr.clone(), asset, BOB, amount),
+			increase_allowance(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] })
 		);
-		thaw_asset(ALICE, asset);
+		pallet_assets_thaw(ALICE, token);
 		// Successful approvals:
-		assert_eq!(0, Assets::allowance(asset, &addr, &BOB));
-		assert_ok!(increase_allowance(addr.clone(), asset, BOB, amount));
-		assert_eq!(Assets::allowance(asset, &addr, &BOB), amount);
+		assert_eq!(0, Assets::allowance(token, &addr, &BOB));
+		assert_ok!(increase_allowance(addr.clone(), token, BOB, amount));
+		assert_eq!(Assets::allowance(token, &addr, &BOB), amount);
 		// Additive.
-		assert_ok!(increase_allowance(addr.clone(), asset, BOB, amount));
-		assert_eq!(Assets::allowance(asset, &addr, &BOB), amount * 2);
-		// Asset is not live, i.e. frozen or being destroyed.
-		start_destroy_asset(ALICE, asset);
+		assert_ok!(increase_allowance(addr.clone(), token, BOB, amount));
+		assert_eq!(Assets::allowance(token, &addr, &BOB), amount * 2);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_start_destroy(ALICE, token);
 		assert_eq!(
-			increase_allowance(addr.clone(), asset, BOB, amount),
+			increase_allowance(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] })
 		);
 	});
@@ -253,30 +253,36 @@ fn decrease_allowance_works() {
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let amount: Balance = 100 * UNIT;
 
-		// Asset does not exist.
+		// Token does not exist.
 		assert_eq!(
 			decrease_allowance(addr.clone(), 0, BOB, amount),
 			Err(Module { index: 52, error: [3, 0] }),
 		);
-		// Create asset and mint `amount` to contract address, then approve Bob to spend `amount`.
-		let asset =
-			create_asset_mint_and_approve(addr.clone(), 0, addr.clone(), amount, BOB, amount);
-		// Asset is not live, i.e. frozen or being destroyed.
-		freeze_asset(addr.clone(), asset);
+		// Create token and mint `amount` to contract address, then approve Bob to spend `amount`.
+		let token = pallet_assets_create_mint_and_approve(
+			addr.clone(),
+			0,
+			addr.clone(),
+			amount,
+			BOB,
+			amount,
+		);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_freeze(addr.clone(), token);
 		assert_eq!(
-			decrease_allowance(addr.clone(), asset, BOB, amount),
+			decrease_allowance(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] }),
 		);
-		thaw_asset(addr.clone(), asset);
+		pallet_assets_thaw(addr.clone(), token);
 		// Successfully decrease allowance.
-		let allowance_before = Assets::allowance(asset, &addr, &BOB);
+		let allowance_before = Assets::allowance(token, &addr, &BOB);
 		assert_ok!(decrease_allowance(addr.clone(), 0, BOB, amount / 2 - 1 * UNIT));
-		let allowance_after = Assets::allowance(asset, &addr, &BOB);
+		let allowance_after = Assets::allowance(token, &addr, &BOB);
 		assert_eq!(allowance_before - allowance_after, amount / 2 - 1 * UNIT);
-		// Asset is not live, i.e. frozen or being destroyed.
-		start_destroy_asset(addr.clone(), asset);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_start_destroy(addr.clone(), token);
 		assert_eq!(
-			decrease_allowance(addr.clone(), asset, BOB, amount),
+			decrease_allowance(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] }),
 		);
 	});
@@ -297,30 +303,36 @@ fn token_metadata_works() {
 		let decimals: u8 = 69;
 
 		// Token does not exist.
-		assert_eq!(token_name(addr.clone(), TOKEN_ID), Ok(token_name_asset(TOKEN_ID)));
+		assert_eq!(token_name(addr.clone(), TOKEN_ID), Ok(pallet_assets_token_name(TOKEN_ID)));
 		assert_eq!(token_name(addr.clone(), TOKEN_ID), Ok(Vec::<u8>::new()));
-		assert_eq!(token_symbol(addr.clone(), TOKEN_ID), Ok(token_symbol_asset(TOKEN_ID)));
+		assert_eq!(token_symbol(addr.clone(), TOKEN_ID), Ok(pallet_assets_token_symbol(TOKEN_ID)));
 		assert_eq!(token_symbol(addr.clone(), TOKEN_ID), Ok(Vec::<u8>::new()));
-		assert_eq!(token_decimals(addr.clone(), TOKEN_ID), Ok(token_decimals_asset(TOKEN_ID)));
+		assert_eq!(
+			token_decimals(addr.clone(), TOKEN_ID),
+			Ok(pallet_assets_token_decimals(TOKEN_ID))
+		);
 		assert_eq!(token_decimals(addr.clone(), TOKEN_ID), Ok(0));
 		// Create Token.
-		create_asset_and_set_metadata(
+		pallet_assets_create_and_set_metadata(
 			addr.clone(),
 			TOKEN_ID,
 			name.clone(),
 			symbol.clone(),
 			decimals,
 		);
-		assert_eq!(token_name(addr.clone(), TOKEN_ID), Ok(token_name_asset(TOKEN_ID)));
+		assert_eq!(token_name(addr.clone(), TOKEN_ID), Ok(pallet_assets_token_name(TOKEN_ID)));
 		assert_eq!(token_name(addr.clone(), TOKEN_ID), Ok(name));
-		assert_eq!(token_symbol(addr.clone(), TOKEN_ID), Ok(token_symbol_asset(TOKEN_ID)));
+		assert_eq!(token_symbol(addr.clone(), TOKEN_ID), Ok(pallet_assets_token_symbol(TOKEN_ID)));
 		assert_eq!(token_symbol(addr.clone(), TOKEN_ID), Ok(symbol));
-		assert_eq!(token_decimals(addr.clone(), TOKEN_ID), Ok(token_decimals_asset(TOKEN_ID)));
+		assert_eq!(
+			token_decimals(addr.clone(), TOKEN_ID),
+			Ok(pallet_assets_token_decimals(TOKEN_ID))
+		);
 		assert_eq!(token_decimals(addr.clone(), TOKEN_ID), Ok(decimals));
 	});
 }
 
-/// 3. Asset Management:
+/// 3. Management:
 /// - create
 /// - start_destroy
 /// - set_metadata
@@ -353,14 +365,14 @@ fn create_works() {
 			create(addr.clone(), TOKEN_ID, BOB, 0),
 			Err(Module { index: 52, error: [7, 0] }),
 		);
-		// The minimal balance for an asset must be non zero.
+		// The minimal balance for an token must be non zero.
 		assert_eq!(
 			create(addr.clone(), TOKEN_ID, BOB, 0),
 			Err(Module { index: 52, error: [7, 0] }),
 		);
-		// Create asset successfully.
+		// Create token successfully.
 		assert_ok!(create(addr.clone(), TOKEN_ID, BOB, 1));
-		// Asset ID is already taken.
+		// Token ID is already taken.
 		assert_eq!(
 			create(addr.clone(), TOKEN_ID, BOB, 1),
 			Err(Module { index: 52, error: [5, 0] }),
@@ -368,20 +380,20 @@ fn create_works() {
 	});
 }
 
-// Testing a contract that creates an asset in the constructor.
+// Testing a contract that creates an token in the constructor.
 #[test]
 fn instantiate_and_create_fungible_works() {
 	new_test_ext().execute_with(|| {
 		let _ = env_logger::try_init();
 		let contract =
 			"contracts/create_token_in_constructor/target/ink/create_token_in_constructor.wasm";
-		// Asset already exists.
-		create_asset(ALICE, 0, 1);
+		// Token already exists.
+		pallet_assets_create(ALICE, 0, 1);
 		assert_eq!(
 			instantiate_and_create_fungible(contract, 0, 1),
 			Err(Module { index: 52, error: [5, 0] })
 		);
-		// Successfully create an asset when instantiating the contract.
+		// Successfully create an token when instantiating the contract.
 		assert_ok!(instantiate_and_create_fungible(contract, TOKEN_ID, 1));
 		assert!(Assets::asset_exists(TOKEN_ID));
 	});
@@ -393,14 +405,14 @@ fn start_destroy_works() {
 		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![2]);
 
-		// Asset does not exist.
+		// Token does not exist.
 		assert_eq!(start_destroy(addr.clone(), TOKEN_ID), Err(Module { index: 52, error: [3, 0] }),);
-		// Create assets where contract is not the owner.
-		let asset = create_asset(ALICE, 0, 1);
+		// Create tokens where contract is not the owner.
+		let token = pallet_assets_create(ALICE, 0, 1);
 		// No Permission.
-		assert_eq!(start_destroy(addr.clone(), asset), Err(Module { index: 52, error: [2, 0] }),);
-		let asset = create_asset(addr.clone(), TOKEN_ID, 1);
-		assert_ok!(start_destroy(addr.clone(), asset));
+		assert_eq!(start_destroy(addr.clone(), token), Err(Module { index: 52, error: [2, 0] }),);
+		let token = pallet_assets_create(addr.clone(), TOKEN_ID, 1);
+		assert_ok!(start_destroy(addr.clone(), token));
 	});
 }
 
@@ -413,26 +425,26 @@ fn set_metadata_works() {
 		let decimals = 42u8;
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 
-		// Asset does not exist.
+		// Token does not exist.
 		assert_eq!(
 			set_metadata(addr.clone(), TOKEN_ID, vec![0], vec![0], 0u8),
 			Err(Module { index: 52, error: [3, 0] }),
 		);
-		// Create assets where contract is not the owner.
-		let asset = create_asset(ALICE, 0, 1);
+		// Create token where contract is not the owner.
+		let token = pallet_assets_create(ALICE, 0, 1);
 		// No Permission.
 		assert_eq!(
-			set_metadata(addr.clone(), asset, vec![0], vec![0], 0u8),
+			set_metadata(addr.clone(), token, vec![0], vec![0], 0u8),
 			Err(Module { index: 52, error: [2, 0] }),
 		);
-		let asset = create_asset(addr.clone(), TOKEN_ID, 1);
-		// Asset is not live, i.e. frozen or being destroyed.
-		freeze_asset(addr.clone(), asset);
+		let token = pallet_assets_create(addr.clone(), TOKEN_ID, 1);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_freeze(addr.clone(), token);
 		assert_eq!(
 			set_metadata(addr.clone(), TOKEN_ID, vec![0], vec![0], 0u8),
 			Err(Module { index: 52, error: [16, 0] }),
 		);
-		thaw_asset(addr.clone(), asset);
+		pallet_assets_thaw(addr.clone(), token);
 		// TODO: calling the below with a vector of length `100_000` errors in pallet contracts
 		//  `OutputBufferTooSmall. Added to security analysis issue #131 to revisit.
 		// Set bad metadata - too large values.
@@ -442,8 +454,8 @@ fn set_metadata_works() {
 		);
 		// Set metadata successfully.
 		assert_ok!(set_metadata(addr.clone(), TOKEN_ID, name, symbol, decimals));
-		// Asset is not live, i.e. frozen or being destroyed.
-		start_destroy_asset(addr.clone(), asset);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_start_destroy(addr.clone(), token);
 		assert_eq!(
 			set_metadata(addr.clone(), TOKEN_ID, vec![0], vec![0], 0),
 			Err(Module { index: 52, error: [16, 0] }),
@@ -460,24 +472,24 @@ fn clear_metadata_works() {
 		let decimals = 42u8;
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 
-		// Asset does not exist.
+		// Token does not exist.
 		assert_eq!(clear_metadata(addr.clone(), 0), Err(Module { index: 52, error: [3, 0] }),);
-		// Create assets where contract is not the owner.
-		let asset = create_asset_and_set_metadata(ALICE, 0, vec![0], vec![0], 0);
+		// Create token where contract is not the owner.
+		let token = pallet_assets_create_and_set_metadata(ALICE, 0, vec![0], vec![0], 0);
 		// No Permission.
-		assert_eq!(clear_metadata(addr.clone(), asset), Err(Module { index: 52, error: [2, 0] }),);
-		let asset = create_asset(addr.clone(), TOKEN_ID, 1);
-		// Asset is not live, i.e. frozen or being destroyed.
-		freeze_asset(addr.clone(), asset);
-		assert_eq!(clear_metadata(addr.clone(), asset), Err(Module { index: 52, error: [16, 0] }),);
-		thaw_asset(addr.clone(), asset);
+		assert_eq!(clear_metadata(addr.clone(), token), Err(Module { index: 52, error: [2, 0] }),);
+		let token = pallet_assets_create(addr.clone(), TOKEN_ID, 1);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_freeze(addr.clone(), token);
+		assert_eq!(clear_metadata(addr.clone(), token), Err(Module { index: 52, error: [16, 0] }),);
+		pallet_assets_thaw(addr.clone(), token);
 		// No metadata set.
-		assert_eq!(clear_metadata(addr.clone(), asset), Err(Module { index: 52, error: [3, 0] }),);
-		set_metadata_asset(addr.clone(), asset, name, symbol, decimals);
+		assert_eq!(clear_metadata(addr.clone(), token), Err(Module { index: 52, error: [3, 0] }),);
+		pallet_assets_set_metadata(addr.clone(), token, name, symbol, decimals);
 		// Clear metadata successfully.
 		assert_ok!(clear_metadata(addr.clone(), TOKEN_ID));
-		// Asset is not live, i.e. frozen or being destroyed.
-		start_destroy_asset(addr.clone(), asset);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_start_destroy(addr.clone(), token);
 		assert_eq!(
 			set_metadata(addr.clone(), TOKEN_ID, vec![0], vec![0], decimals),
 			Err(Module { index: 52, error: [16, 0] }),
@@ -495,7 +507,7 @@ fn token_exists_works() {
 		assert_eq!(token_exists(addr.clone(), TOKEN_ID), Ok(Assets::asset_exists(TOKEN_ID)));
 
 		// Tokens in circulation.
-		create_asset(addr.clone(), TOKEN_ID, 1);
+		pallet_assets_create(addr.clone(), TOKEN_ID, 1);
 		assert_eq!(token_exists(addr.clone(), TOKEN_ID), Ok(Assets::asset_exists(TOKEN_ID)));
 	});
 }
@@ -507,32 +519,32 @@ fn mint_works() {
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let amount: Balance = 100 * UNIT;
 
-		// Asset does not exist.
+		// Token does not exist.
 		assert_eq!(mint(addr.clone(), 1, BOB, amount), Err(Token(UnknownAsset)));
-		let asset = create_asset(ALICE, 1, 1);
+		let token = pallet_assets_create(ALICE, 1, 1);
 		// Minting can only be done by the owner.
-		assert_eq!(mint(addr.clone(), asset, BOB, 1), Err(Module { index: 52, error: [2, 0] }));
-		let asset = create_asset(addr.clone(), 2, 2);
-		// Minimum balance of an asset can not be zero.
-		assert_eq!(mint(addr.clone(), asset, BOB, 1), Err(Token(BelowMinimum)));
-		// Asset is not live, i.e. frozen or being destroyed.
-		freeze_asset(addr.clone(), asset);
+		assert_eq!(mint(addr.clone(), token, BOB, 1), Err(Module { index: 52, error: [2, 0] }));
+		let token = pallet_assets_create(addr.clone(), 2, 2);
+		// Minimum balance of an token can not be zero.
+		assert_eq!(mint(addr.clone(), token, BOB, 1), Err(Token(BelowMinimum)));
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_freeze(addr.clone(), token);
 		assert_eq!(
-			mint(addr.clone(), asset, BOB, amount),
+			mint(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] })
 		);
-		thaw_asset(addr.clone(), asset);
+		pallet_assets_thaw(addr.clone(), token);
 		// Successful mint.
-		let balance_before_mint = Assets::balance(asset, &BOB);
-		assert_ok!(mint(addr.clone(), asset, BOB, amount));
-		let balance_after_mint = Assets::balance(asset, &BOB);
+		let balance_before_mint = Assets::balance(token, &BOB);
+		assert_ok!(mint(addr.clone(), token, BOB, amount));
+		let balance_after_mint = Assets::balance(token, &BOB);
 		assert_eq!(balance_after_mint, balance_before_mint + amount);
 		// Account can not hold more tokens than Balance::MAX.
-		assert_eq!(mint(addr.clone(), asset, BOB, Balance::MAX,), Err(Arithmetic(Overflow)));
-		// Asset is not live, i.e. frozen or being destroyed.
-		start_destroy_asset(addr.clone(), asset);
+		assert_eq!(mint(addr.clone(), token, BOB, Balance::MAX,), Err(Arithmetic(Overflow)));
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_start_destroy(addr.clone(), token);
 		assert_eq!(
-			mint(addr.clone(), asset, BOB, amount),
+			mint(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] })
 		);
 	});
@@ -545,31 +557,31 @@ fn burn_works() {
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let amount: Balance = 100 * UNIT;
 
-		// Asset does not exist.
+		// Token does not exist.
 		assert_eq!(burn(addr.clone(), 1, BOB, amount), Err(Module { index: 52, error: [3, 0] }));
-		let asset = create_asset(ALICE, 1, 1);
-		// Bob has no tokens and thus pallet assets doesn't know the account.
-		assert_eq!(burn(addr.clone(), asset, BOB, 1), Err(Module { index: 52, error: [1, 0] }));
+		let token = pallet_assets_create(ALICE, 1, 1);
+		// Bob has no tokens and therefore doesn't exist.
+		assert_eq!(burn(addr.clone(), token, BOB, 1), Err(Module { index: 52, error: [1, 0] }));
 		// Burning can only be done by the manager.
-		mint_asset(ALICE, asset, BOB, amount);
-		assert_eq!(burn(addr.clone(), asset, BOB, 1), Err(Module { index: 52, error: [2, 0] }));
-		let asset = create_asset_and_mint_to(addr.clone(), 2, BOB, amount);
-		// Asset is not live, i.e. frozen or being destroyed.
-		freeze_asset(addr.clone(), asset);
+		pallet_assets_mint(ALICE, token, BOB, amount);
+		assert_eq!(burn(addr.clone(), token, BOB, 1), Err(Module { index: 52, error: [2, 0] }));
+		let token = pallet_assets_create_and_mint_to(addr.clone(), 2, BOB, amount);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_freeze(addr.clone(), token);
 		assert_eq!(
-			burn(addr.clone(), asset, BOB, amount),
+			burn(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] })
 		);
-		thaw_asset(addr.clone(), asset);
+		pallet_assets_thaw(addr.clone(), token);
 		// Successful mint.
-		let balance_before_burn = Assets::balance(asset, &BOB);
-		assert_ok!(burn(addr.clone(), asset, BOB, amount));
-		let balance_after_burn = Assets::balance(asset, &BOB);
+		let balance_before_burn = Assets::balance(token, &BOB);
+		assert_ok!(burn(addr.clone(), token, BOB, amount));
+		let balance_after_burn = Assets::balance(token, &BOB);
 		assert_eq!(balance_after_burn, balance_before_burn - amount);
-		// Asset is not live, i.e. frozen or being destroyed.
-		start_destroy_asset(addr.clone(), asset);
+		// Token is not live, i.e. frozen or being destroyed.
+		pallet_assets_start_destroy(addr.clone(), token);
 		assert_eq!(
-			burn(addr.clone(), asset, BOB, amount),
+			burn(addr.clone(), token, BOB, amount),
 			Err(Module { index: 52, error: [17, 0] })
 		);
 	});

--- a/pop-api/integration-tests/src/fungibles/mod.rs
+++ b/pop-api/integration-tests/src/fungibles/mod.rs
@@ -21,102 +21,89 @@ const CONTRACT: &str = "contracts/fungibles/target/ink/fungibles.wasm";
 #[test]
 fn total_supply_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 
 		// No tokens in circulation.
-		assert_eq!(total_supply(addr.clone(), TOKEN_ID), Ok(Assets::total_supply(TOKEN_ID)));
-		assert_eq!(total_supply(addr.clone(), TOKEN_ID), Ok(0));
+		assert_eq!(total_supply(&addr, TOKEN_ID), Ok(Assets::total_supply(TOKEN_ID)));
+		assert_eq!(total_supply(&addr, TOKEN_ID), Ok(0));
 
 		// Tokens in circulation.
-		pallet_assets_create_and_mint_to(addr.clone(), TOKEN_ID, BOB, 100);
-		assert_eq!(total_supply(addr.clone(), TOKEN_ID), Ok(Assets::total_supply(TOKEN_ID)));
-		assert_eq!(total_supply(addr, TOKEN_ID), Ok(100));
+		pallet_assets_create_and_mint_to(&addr, TOKEN_ID, &BOB, 100);
+		assert_eq!(total_supply(&addr, TOKEN_ID), Ok(Assets::total_supply(TOKEN_ID)));
+		assert_eq!(total_supply(&addr, TOKEN_ID), Ok(100));
 	});
 }
 
 #[test]
 fn balance_of_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 
 		// No tokens in circulation.
-		assert_eq!(balance_of(addr.clone(), TOKEN_ID, BOB), Ok(Assets::balance(TOKEN_ID, BOB)));
-		assert_eq!(balance_of(addr.clone(), TOKEN_ID, BOB), Ok(0));
+		assert_eq!(balance_of(&addr, TOKEN_ID, BOB), Ok(Assets::balance(TOKEN_ID, BOB)));
+		assert_eq!(balance_of(&addr, TOKEN_ID, BOB), Ok(0));
 
 		// Tokens in circulation.
-		pallet_assets_create_and_mint_to(addr.clone(), TOKEN_ID, BOB, 100);
-		assert_eq!(balance_of(addr.clone(), TOKEN_ID, BOB), Ok(Assets::balance(TOKEN_ID, BOB)));
-		assert_eq!(balance_of(addr, TOKEN_ID, BOB), Ok(100));
+		pallet_assets_create_and_mint_to(&addr, TOKEN_ID, &BOB, 100);
+		assert_eq!(balance_of(&addr, TOKEN_ID, BOB), Ok(Assets::balance(TOKEN_ID, BOB)));
+		assert_eq!(balance_of(&addr, TOKEN_ID, BOB), Ok(100));
 	});
 }
 
 #[test]
 fn allowance_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 
 		// No tokens in circulation.
 		assert_eq!(
-			allowance(addr.clone(), TOKEN_ID, BOB, ALICE),
+			allowance(&addr, TOKEN_ID, BOB, ALICE),
 			Ok(Assets::allowance(TOKEN_ID, &BOB, &ALICE))
 		);
-		assert_eq!(allowance(addr.clone(), TOKEN_ID, BOB, ALICE), Ok(0));
+		assert_eq!(allowance(&addr, TOKEN_ID, BOB, ALICE), Ok(0));
 
 		// Tokens in circulation.
-		pallet_assets_create_mint_and_approve(addr.clone(), TOKEN_ID, BOB, 100, ALICE, 50);
+		pallet_assets_create_mint_and_approve(&addr, TOKEN_ID, &BOB, 100, &ALICE, 50);
 		assert_eq!(
-			allowance(addr.clone(), TOKEN_ID, BOB, ALICE),
+			allowance(&addr, TOKEN_ID, BOB, ALICE),
 			Ok(Assets::allowance(TOKEN_ID, &BOB, &ALICE))
 		);
-		assert_eq!(allowance(addr, TOKEN_ID, BOB, ALICE), Ok(50));
+		assert_eq!(allowance(&addr, TOKEN_ID, BOB, ALICE), Ok(50));
 	});
 }
 
 #[test]
 fn transfer_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let amount: Balance = 100 * UNIT;
 
 		// Token does not exist.
-		assert_eq!(
-			transfer(addr.clone(), 1, BOB, amount),
-			Err(Module { index: 52, error: [3, 0] })
-		);
+		assert_eq!(transfer(&addr, 1, BOB, amount), Err(Module { index: 52, error: [3, 0] }));
 		// Create token with Alice as owner and mint `amount` to contract address.
-		let token = pallet_assets_create_and_mint_to(ALICE, 1, addr.clone(), amount);
+		let token = pallet_assets_create_and_mint_to(&ALICE, 1, &addr, amount);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_freeze(ALICE, token);
-		assert_eq!(
-			transfer(addr.clone(), token, BOB, amount),
-			Err(Module { index: 52, error: [16, 0] })
-		);
-		pallet_assets_thaw(ALICE, token);
+		pallet_assets_freeze(&ALICE, token);
+		assert_eq!(transfer(&addr, token, BOB, amount), Err(Module { index: 52, error: [16, 0] }));
+		pallet_assets_thaw(&ALICE, token);
 		// Not enough balance.
 		assert_eq!(
-			transfer(addr.clone(), token, BOB, amount + 1 * UNIT),
+			transfer(&addr, token, BOB, amount + 1 * UNIT),
 			Err(Module { index: 52, error: [0, 0] })
 		);
 		// Not enough balance due to ED.
-		assert_eq!(
-			transfer(addr.clone(), token, BOB, amount),
-			Err(Module { index: 52, error: [0, 0] })
-		);
+		assert_eq!(transfer(&addr, token, BOB, amount), Err(Module { index: 52, error: [0, 0] }));
 		// Successful transfer.
 		let balance_before_transfer = Assets::balance(token, &BOB);
-		assert_ok!(transfer(addr.clone(), token, BOB, amount / 2));
+		assert_ok!(transfer(&addr, token, BOB, amount / 2));
 		let balance_after_transfer = Assets::balance(token, &BOB);
 		assert_eq!(balance_after_transfer, balance_before_transfer + amount / 2);
 		// Transfer token to account that does not exist.
-		assert_eq!(transfer(addr.clone(), token, FERDIE, amount / 4), Err(Token(CannotCreate)));
+		assert_eq!(transfer(&addr, token, FERDIE, amount / 4), Err(Token(CannotCreate)));
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_start_destroy(ALICE, token);
+		pallet_assets_start_destroy(&ALICE, token);
 		assert_eq!(
-			transfer(addr.clone(), token, BOB, amount / 4),
+			transfer(&addr, token, BOB, amount / 4),
 			Err(Module { index: 52, error: [16, 0] })
 		);
 	});
@@ -125,20 +112,19 @@ fn transfer_works() {
 #[test]
 fn transfer_from_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let amount: Balance = 100 * UNIT;
 
 		// Token does not exist.
 		assert_eq!(
-			transfer_from(addr.clone(), 1, ALICE, BOB, amount / 2),
+			transfer_from(&addr, 1, ALICE, BOB, amount / 2),
 			Err(Module { index: 52, error: [3, 0] }),
 		);
 		// Create token with Alice as owner and mint `amount` to contract address.
-		let token = pallet_assets_create_and_mint_to(ALICE, 1, ALICE, amount);
+		let token = pallet_assets_create_and_mint_to(&ALICE, 1, &ALICE, amount);
 		// Unapproved transfer.
 		assert_eq!(
-			transfer_from(addr.clone(), token, ALICE, BOB, amount / 2),
+			transfer_from(&addr, token, ALICE, BOB, amount / 2),
 			Err(Module { index: 52, error: [10, 0] })
 		);
 		assert_ok!(Assets::approve_transfer(
@@ -148,20 +134,20 @@ fn transfer_from_works() {
 			amount + 1 * UNIT,
 		));
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_freeze(ALICE, token);
+		pallet_assets_freeze(&ALICE, token);
 		assert_eq!(
-			transfer_from(addr.clone(), token, ALICE, BOB, amount),
+			transfer_from(&addr, token, ALICE, BOB, amount),
 			Err(Module { index: 52, error: [16, 0] }),
 		);
-		pallet_assets_thaw(ALICE, token);
+		pallet_assets_thaw(&ALICE, token);
 		// Not enough balance.
 		assert_eq!(
-			transfer_from(addr.clone(), token, ALICE, BOB, amount + 1 * UNIT),
+			transfer_from(&addr, token, ALICE, BOB, amount + 1 * UNIT),
 			Err(Module { index: 52, error: [0, 0] }),
 		);
 		// Successful transfer.
 		let balance_before_transfer = Assets::balance(token, &BOB);
-		assert_ok!(transfer_from(addr.clone(), token, ALICE, BOB, amount / 2));
+		assert_ok!(transfer_from(&addr, token, ALICE, BOB, amount / 2));
 		let balance_after_transfer = Assets::balance(token, &BOB);
 		assert_eq!(balance_after_transfer, balance_before_transfer + amount / 2);
 	});
@@ -170,77 +156,69 @@ fn transfer_from_works() {
 #[test]
 fn approve_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, 0, vec![]);
 		let amount: Balance = 100 * UNIT;
 
 		// Token does not exist.
-		assert_eq!(approve(addr.clone(), 0, BOB, amount), Err(Module { index: 52, error: [3, 0] }));
-		let token = pallet_assets_create_and_mint_to(ALICE, 0, addr.clone(), amount);
-		assert_eq!(approve(addr.clone(), token, BOB, amount), Err(ConsumerRemaining));
+		assert_eq!(approve(&addr, 0, &BOB, amount), Err(Module { index: 52, error: [3, 0] }));
+		let token = pallet_assets_create_and_mint_to(&ALICE, 0, &addr, amount);
+		assert_eq!(approve(&addr, token, &BOB, amount), Err(ConsumerRemaining));
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![1]);
 		// Create token with Alice as owner and mint `amount` to contract address.
-		let token = pallet_assets_create_and_mint_to(ALICE, 1, addr.clone(), amount);
+		let token = pallet_assets_create_and_mint_to(&ALICE, 1, &addr, amount);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_freeze(ALICE, token);
-		assert_eq!(
-			approve(addr.clone(), token, BOB, amount),
-			Err(Module { index: 52, error: [16, 0] })
-		);
-		pallet_assets_thaw(ALICE, token);
+		pallet_assets_freeze(&ALICE, token);
+		assert_eq!(approve(&addr, token, &BOB, amount), Err(Module { index: 52, error: [16, 0] }));
+		pallet_assets_thaw(&ALICE, token);
 		// Successful approvals:
 		assert_eq!(0, Assets::allowance(token, &addr, &BOB));
-		assert_ok!(approve(addr.clone(), token, BOB, amount));
+		assert_ok!(approve(&addr, token, &BOB, amount));
 		assert_eq!(Assets::allowance(token, &addr, &BOB), amount);
 		// Non-additive, sets new value.
-		assert_ok!(approve(addr.clone(), token, BOB, amount / 2));
+		assert_ok!(approve(&addr, token, &BOB, amount / 2));
 		assert_eq!(Assets::allowance(token, &addr, &BOB), amount / 2);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_start_destroy(ALICE, token);
-		assert_eq!(
-			approve(addr.clone(), token, BOB, amount),
-			Err(Module { index: 52, error: [16, 0] })
-		);
+		pallet_assets_start_destroy(&ALICE, token);
+		assert_eq!(approve(&addr, token, &BOB, amount), Err(Module { index: 52, error: [16, 0] }));
 	});
 }
 
 #[test]
 fn increase_allowance_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let amount: Balance = 100 * UNIT;
 		// Instantiate a contract without balance - test `ConsumerRemaining.
 		let addr = instantiate(CONTRACT, 0, vec![]);
 		// Token does not exist.
 		assert_eq!(
-			increase_allowance(addr.clone(), 0, BOB, amount),
+			increase_allowance(&addr, 0, &BOB, amount),
 			Err(Module { index: 52, error: [3, 0] })
 		);
-		let token = pallet_assets_create_and_mint_to(ALICE, 0, addr.clone(), amount);
-		assert_eq!(increase_allowance(addr.clone(), token, BOB, amount), Err(ConsumerRemaining));
+		let token = pallet_assets_create_and_mint_to(&ALICE, 0, &addr, amount);
+		assert_eq!(increase_allowance(&addr, token, &BOB, amount), Err(ConsumerRemaining));
 
 		// Instantiate a contract with balance.
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![1]);
 		// Create token with Alice as owner and mint `amount` to contract address.
-		let token = pallet_assets_create_and_mint_to(ALICE, 1, addr.clone(), amount);
+		let token = pallet_assets_create_and_mint_to(&ALICE, 1, &addr, amount);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_freeze(ALICE, token);
+		pallet_assets_freeze(&ALICE, token);
 		assert_eq!(
-			increase_allowance(addr.clone(), token, BOB, amount),
+			increase_allowance(&addr, token, &BOB, amount),
 			Err(Module { index: 52, error: [16, 0] })
 		);
-		pallet_assets_thaw(ALICE, token);
+		pallet_assets_thaw(&ALICE, token);
 		// Successful approvals:
 		assert_eq!(0, Assets::allowance(token, &addr, &BOB));
-		assert_ok!(increase_allowance(addr.clone(), token, BOB, amount));
+		assert_ok!(increase_allowance(&addr, token, &BOB, amount));
 		assert_eq!(Assets::allowance(token, &addr, &BOB), amount);
 		// Additive.
-		assert_ok!(increase_allowance(addr.clone(), token, BOB, amount));
+		assert_ok!(increase_allowance(&addr, token, &BOB, amount));
 		assert_eq!(Assets::allowance(token, &addr, &BOB), amount * 2);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_start_destroy(ALICE, token);
+		pallet_assets_start_destroy(&ALICE, token);
 		assert_eq!(
-			increase_allowance(addr.clone(), token, BOB, amount),
+			increase_allowance(&addr, token, &BOB, amount),
 			Err(Module { index: 52, error: [16, 0] })
 		);
 	});
@@ -249,40 +227,32 @@ fn increase_allowance_works() {
 #[test]
 fn decrease_allowance_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let amount: Balance = 100 * UNIT;
 
 		// Token does not exist.
 		assert_eq!(
-			decrease_allowance(addr.clone(), 0, BOB, amount),
+			decrease_allowance(&addr, 0, &BOB, amount),
 			Err(Module { index: 52, error: [3, 0] }),
 		);
 		// Create token and mint `amount` to contract address, then approve Bob to spend `amount`.
-		let token = pallet_assets_create_mint_and_approve(
-			addr.clone(),
-			0,
-			addr.clone(),
-			amount,
-			BOB,
-			amount,
-		);
+		let token = pallet_assets_create_mint_and_approve(&addr, 0, &addr, amount, &BOB, amount);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_freeze(addr.clone(), token);
+		pallet_assets_freeze(&addr, token);
 		assert_eq!(
-			decrease_allowance(addr.clone(), token, BOB, amount),
+			decrease_allowance(&addr, token, &BOB, amount),
 			Err(Module { index: 52, error: [16, 0] }),
 		);
-		pallet_assets_thaw(addr.clone(), token);
+		pallet_assets_thaw(&addr, token);
 		// Successfully decrease allowance.
 		let allowance_before = Assets::allowance(token, &addr, &BOB);
-		assert_ok!(decrease_allowance(addr.clone(), 0, BOB, amount / 2 - 1 * UNIT));
+		assert_ok!(decrease_allowance(&addr, 0, &BOB, amount / 2 - 1 * UNIT));
 		let allowance_after = Assets::allowance(token, &addr, &BOB);
 		assert_eq!(allowance_before - allowance_after, amount / 2 - 1 * UNIT);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_start_destroy(addr.clone(), token);
+		pallet_assets_start_destroy(&addr, token);
 		assert_eq!(
-			decrease_allowance(addr.clone(), token, BOB, amount),
+			decrease_allowance(&addr, token, &BOB, amount),
 			Err(Module { index: 52, error: [16, 0] }),
 		);
 	});
@@ -296,42 +266,34 @@ fn decrease_allowance_works() {
 #[test]
 fn token_metadata_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let name: Vec<u8> = vec![11, 12, 13];
 		let symbol: Vec<u8> = vec![21, 22, 23];
 		let decimals: u8 = 69;
 
 		// Token does not exist.
-		assert_eq!(token_name(addr.clone(), TOKEN_ID), Ok(pallet_assets_token_name(TOKEN_ID)));
-		assert_eq!(token_name(addr.clone(), TOKEN_ID), Ok(Vec::<u8>::new()));
-		assert_eq!(token_symbol(addr.clone(), TOKEN_ID), Ok(pallet_assets_token_symbol(TOKEN_ID)));
-		assert_eq!(token_symbol(addr.clone(), TOKEN_ID), Ok(Vec::<u8>::new()));
-		assert_eq!(
-			token_decimals(addr.clone(), TOKEN_ID),
-			Ok(pallet_assets_token_decimals(TOKEN_ID))
-		);
-		assert_eq!(token_decimals(addr.clone(), TOKEN_ID), Ok(0));
+		assert_eq!(token_name(&addr, TOKEN_ID), Ok(pallet_assets_token_name(TOKEN_ID)));
+		assert_eq!(token_name(&addr, TOKEN_ID), Ok(Vec::<u8>::new()));
+		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(pallet_assets_token_symbol(TOKEN_ID)));
+		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(Vec::<u8>::new()));
+		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(pallet_assets_token_decimals(TOKEN_ID)));
+		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(0));
 		// Create Token.
 		pallet_assets_create_and_set_metadata(
-			addr.clone(),
+			&addr,
 			TOKEN_ID,
 			name.clone(),
 			symbol.clone(),
 			decimals,
 		);
-		assert_eq!(token_name(addr.clone(), TOKEN_ID), Ok(pallet_assets_token_name(TOKEN_ID)));
-		assert_eq!(token_name(addr.clone(), TOKEN_ID), Ok(name));
-		assert_eq!(token_symbol(addr.clone(), TOKEN_ID), Ok(pallet_assets_token_symbol(TOKEN_ID)));
-		assert_eq!(token_symbol(addr.clone(), TOKEN_ID), Ok(symbol));
-		assert_eq!(
-			token_decimals(addr.clone(), TOKEN_ID),
-			Ok(pallet_assets_token_decimals(TOKEN_ID))
-		);
-		assert_eq!(token_decimals(addr.clone(), TOKEN_ID), Ok(decimals));
+		assert_eq!(token_name(&addr, TOKEN_ID), Ok(pallet_assets_token_name(TOKEN_ID)));
+		assert_eq!(token_name(&addr, TOKEN_ID), Ok(name));
+		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(pallet_assets_token_symbol(TOKEN_ID)));
+		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(symbol));
+		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(pallet_assets_token_decimals(TOKEN_ID)));
+		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(decimals));
 	});
 }
-
 /// 3. Management:
 /// - create
 /// - start_destroy
@@ -342,41 +304,25 @@ fn token_metadata_works() {
 #[test]
 fn create_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		// Instantiate a contract without balance for fees.
 		let addr = instantiate(CONTRACT, 0, vec![0]);
 		// No balance to pay for fees.
-		assert_eq!(
-			create(addr.clone(), TOKEN_ID, addr.clone(), 1),
-			Err(Module { index: 10, error: [2, 0] }),
-		);
+		assert_eq!(create(&addr, TOKEN_ID, &addr, 1), Err(Module { index: 10, error: [2, 0] }),);
 
 		// Instantiate a contract without balance for deposit.
 		let addr = instantiate(CONTRACT, 100, vec![1]);
 		// No balance to pay the deposit.
-		assert_eq!(
-			create(addr.clone(), TOKEN_ID, addr.clone(), 1),
-			Err(Module { index: 10, error: [2, 0] }),
-		);
+		assert_eq!(create(&addr, TOKEN_ID, &addr, 1), Err(Module { index: 10, error: [2, 0] }),);
 
 		// Instantiate a contract with enough balance.
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![2]);
-		assert_eq!(
-			create(addr.clone(), TOKEN_ID, BOB, 0),
-			Err(Module { index: 52, error: [7, 0] }),
-		);
+		assert_eq!(create(&addr, TOKEN_ID, &BOB, 0), Err(Module { index: 52, error: [7, 0] }),);
 		// The minimal balance for an token must be non zero.
-		assert_eq!(
-			create(addr.clone(), TOKEN_ID, BOB, 0),
-			Err(Module { index: 52, error: [7, 0] }),
-		);
+		assert_eq!(create(&addr, TOKEN_ID, &BOB, 0), Err(Module { index: 52, error: [7, 0] }),);
 		// Create token successfully.
-		assert_ok!(create(addr.clone(), TOKEN_ID, BOB, 1));
+		assert_ok!(create(&addr, TOKEN_ID, &BOB, 1));
 		// Token ID is already taken.
-		assert_eq!(
-			create(addr.clone(), TOKEN_ID, BOB, 1),
-			Err(Module { index: 52, error: [5, 0] }),
-		);
+		assert_eq!(create(&addr, TOKEN_ID, &BOB, 1), Err(Module { index: 52, error: [5, 0] }),);
 	});
 }
 
@@ -384,11 +330,10 @@ fn create_works() {
 #[test]
 fn instantiate_and_create_fungible_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let contract =
 			"contracts/create_token_in_constructor/target/ink/create_token_in_constructor.wasm";
 		// Token already exists.
-		pallet_assets_create(ALICE, 0, 1);
+		pallet_assets_create(&ALICE, 0, 1);
 		assert_eq!(
 			instantiate_and_create_fungible(contract, 0, 1),
 			Err(Module { index: 52, error: [5, 0] })
@@ -402,24 +347,22 @@ fn instantiate_and_create_fungible_works() {
 #[test]
 fn start_destroy_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![2]);
 
 		// Token does not exist.
-		assert_eq!(start_destroy(addr.clone(), TOKEN_ID), Err(Module { index: 52, error: [3, 0] }),);
+		assert_eq!(start_destroy(&addr, TOKEN_ID), Err(Module { index: 52, error: [3, 0] }),);
 		// Create tokens where contract is not the owner.
-		let token = pallet_assets_create(ALICE, 0, 1);
+		let token = pallet_assets_create(&ALICE, 0, 1);
 		// No Permission.
-		assert_eq!(start_destroy(addr.clone(), token), Err(Module { index: 52, error: [2, 0] }),);
-		let token = pallet_assets_create(addr.clone(), TOKEN_ID, 1);
-		assert_ok!(start_destroy(addr.clone(), token));
+		assert_eq!(start_destroy(&addr, token), Err(Module { index: 52, error: [2, 0] }),);
+		let token = pallet_assets_create(&addr, TOKEN_ID, 1);
+		assert_ok!(start_destroy(&addr, token));
 	});
 }
 
 #[test]
 fn set_metadata_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let name = vec![42];
 		let symbol = vec![42];
 		let decimals = 42u8;
@@ -427,37 +370,37 @@ fn set_metadata_works() {
 
 		// Token does not exist.
 		assert_eq!(
-			set_metadata(addr.clone(), TOKEN_ID, vec![0], vec![0], 0u8),
+			set_metadata(&addr, TOKEN_ID, vec![0], vec![0], 0u8),
 			Err(Module { index: 52, error: [3, 0] }),
 		);
 		// Create token where contract is not the owner.
-		let token = pallet_assets_create(ALICE, 0, 1);
+		let token = pallet_assets_create(&ALICE, 0, 1);
 		// No Permission.
 		assert_eq!(
-			set_metadata(addr.clone(), token, vec![0], vec![0], 0u8),
+			set_metadata(&addr, token, vec![0], vec![0], 0u8),
 			Err(Module { index: 52, error: [2, 0] }),
 		);
-		let token = pallet_assets_create(addr.clone(), TOKEN_ID, 1);
+		let token = pallet_assets_create(&addr, TOKEN_ID, 1);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_freeze(addr.clone(), token);
+		pallet_assets_freeze(&addr, token);
 		assert_eq!(
-			set_metadata(addr.clone(), TOKEN_ID, vec![0], vec![0], 0u8),
+			set_metadata(&addr, TOKEN_ID, vec![0], vec![0], 0u8),
 			Err(Module { index: 52, error: [16, 0] }),
 		);
-		pallet_assets_thaw(addr.clone(), token);
+		pallet_assets_thaw(&addr, token);
 		// TODO: calling the below with a vector of length `100_000` errors in pallet contracts
 		//  `OutputBufferTooSmall. Added to security analysis issue #131 to revisit.
 		// Set bad metadata - too large values.
 		assert_eq!(
-			set_metadata(addr.clone(), TOKEN_ID, vec![0; 1000], vec![0; 1000], 0u8),
+			set_metadata(&addr, TOKEN_ID, vec![0; 1000], vec![0; 1000], 0u8),
 			Err(Module { index: 52, error: [9, 0] }),
 		);
 		// Set metadata successfully.
-		assert_ok!(set_metadata(addr.clone(), TOKEN_ID, name, symbol, decimals));
+		assert_ok!(set_metadata(&addr, TOKEN_ID, name, symbol, decimals));
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_start_destroy(addr.clone(), token);
+		pallet_assets_start_destroy(&addr, token);
 		assert_eq!(
-			set_metadata(addr.clone(), TOKEN_ID, vec![0], vec![0], 0),
+			set_metadata(&addr, TOKEN_ID, vec![0], vec![0], 0),
 			Err(Module { index: 52, error: [16, 0] }),
 		);
 	});
@@ -466,32 +409,31 @@ fn set_metadata_works() {
 #[test]
 fn clear_metadata_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let name = vec![42];
 		let symbol = vec![42];
 		let decimals = 42u8;
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 
 		// Token does not exist.
-		assert_eq!(clear_metadata(addr.clone(), 0), Err(Module { index: 52, error: [3, 0] }),);
+		assert_eq!(clear_metadata(&addr, 0), Err(Module { index: 52, error: [3, 0] }),);
 		// Create token where contract is not the owner.
-		let token = pallet_assets_create_and_set_metadata(ALICE, 0, vec![0], vec![0], 0);
+		let token = pallet_assets_create_and_set_metadata(&ALICE, 0, vec![0], vec![0], 0);
 		// No Permission.
-		assert_eq!(clear_metadata(addr.clone(), token), Err(Module { index: 52, error: [2, 0] }),);
-		let token = pallet_assets_create(addr.clone(), TOKEN_ID, 1);
+		assert_eq!(clear_metadata(&addr, token), Err(Module { index: 52, error: [2, 0] }),);
+		let token = pallet_assets_create(&addr, TOKEN_ID, 1);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_freeze(addr.clone(), token);
-		assert_eq!(clear_metadata(addr.clone(), token), Err(Module { index: 52, error: [16, 0] }),);
-		pallet_assets_thaw(addr.clone(), token);
+		pallet_assets_freeze(&addr, token);
+		assert_eq!(clear_metadata(&addr, token), Err(Module { index: 52, error: [16, 0] }),);
+		pallet_assets_thaw(&addr, token);
 		// No metadata set.
-		assert_eq!(clear_metadata(addr.clone(), token), Err(Module { index: 52, error: [3, 0] }),);
-		pallet_assets_set_metadata(addr.clone(), token, name, symbol, decimals);
+		assert_eq!(clear_metadata(&addr, token), Err(Module { index: 52, error: [3, 0] }),);
+		pallet_assets_set_metadata(&addr, token, name, symbol, decimals);
 		// Clear metadata successfully.
-		assert_ok!(clear_metadata(addr.clone(), TOKEN_ID));
+		assert_ok!(clear_metadata(&addr, TOKEN_ID));
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_start_destroy(addr.clone(), token);
+		pallet_assets_start_destroy(&addr, token);
 		assert_eq!(
-			set_metadata(addr.clone(), TOKEN_ID, vec![0], vec![0], decimals),
+			set_metadata(&addr, TOKEN_ID, vec![0], vec![0], decimals),
 			Err(Module { index: 52, error: [16, 0] }),
 		);
 	});
@@ -500,89 +442,74 @@ fn clear_metadata_works() {
 #[test]
 fn token_exists_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 
 		// No tokens in circulation.
-		assert_eq!(token_exists(addr.clone(), TOKEN_ID), Ok(Assets::asset_exists(TOKEN_ID)));
+		assert_eq!(token_exists(&addr, TOKEN_ID), Ok(Assets::asset_exists(TOKEN_ID)));
 
 		// Tokens in circulation.
-		pallet_assets_create(addr.clone(), TOKEN_ID, 1);
-		assert_eq!(token_exists(addr.clone(), TOKEN_ID), Ok(Assets::asset_exists(TOKEN_ID)));
+		pallet_assets_create(&addr, TOKEN_ID, 1);
+		assert_eq!(token_exists(&addr, TOKEN_ID), Ok(Assets::asset_exists(TOKEN_ID)));
 	});
 }
 
 #[test]
 fn mint_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let amount: Balance = 100 * UNIT;
 
 		// Token does not exist.
-		assert_eq!(mint(addr.clone(), 1, BOB, amount), Err(Token(UnknownAsset)));
-		let token = pallet_assets_create(ALICE, 1, 1);
+		assert_eq!(mint(&addr, 1, &BOB, amount), Err(Token(UnknownAsset)));
+		let token = pallet_assets_create(&ALICE, 1, 1);
 		// Minting can only be done by the owner.
-		assert_eq!(mint(addr.clone(), token, BOB, 1), Err(Module { index: 52, error: [2, 0] }));
-		let token = pallet_assets_create(addr.clone(), 2, 2);
+		assert_eq!(mint(&addr, token, &BOB, 1), Err(Module { index: 52, error: [2, 0] }));
+		let token = pallet_assets_create(&addr, 2, 2);
 		// Minimum balance of an token can not be zero.
-		assert_eq!(mint(addr.clone(), token, BOB, 1), Err(Token(BelowMinimum)));
+		assert_eq!(mint(&addr, token, &BOB, 1), Err(Token(BelowMinimum)));
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_freeze(addr.clone(), token);
-		assert_eq!(
-			mint(addr.clone(), token, BOB, amount),
-			Err(Module { index: 52, error: [16, 0] })
-		);
-		pallet_assets_thaw(addr.clone(), token);
+		pallet_assets_freeze(&addr, token);
+		assert_eq!(mint(&addr, token, &BOB, amount), Err(Module { index: 52, error: [16, 0] }));
+		pallet_assets_thaw(&addr, token);
 		// Successful mint.
 		let balance_before_mint = Assets::balance(token, &BOB);
-		assert_ok!(mint(addr.clone(), token, BOB, amount));
+		assert_ok!(mint(&addr, token, &BOB, amount));
 		let balance_after_mint = Assets::balance(token, &BOB);
 		assert_eq!(balance_after_mint, balance_before_mint + amount);
 		// Account can not hold more tokens than Balance::MAX.
-		assert_eq!(mint(addr.clone(), token, BOB, Balance::MAX,), Err(Arithmetic(Overflow)));
+		assert_eq!(mint(&addr, token, &BOB, Balance::MAX,), Err(Arithmetic(Overflow)));
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_start_destroy(addr.clone(), token);
-		assert_eq!(
-			mint(addr.clone(), token, BOB, amount),
-			Err(Module { index: 52, error: [16, 0] })
-		);
+		pallet_assets_start_destroy(&addr, token);
+		assert_eq!(mint(&addr, token, &BOB, amount), Err(Module { index: 52, error: [16, 0] }));
 	});
 }
 
 #[test]
 fn burn_works() {
 	new_test_ext().execute_with(|| {
-		let _ = env_logger::try_init();
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![]);
 		let amount: Balance = 100 * UNIT;
 
 		// Token does not exist.
-		assert_eq!(burn(addr.clone(), 1, BOB, amount), Err(Module { index: 52, error: [3, 0] }));
-		let token = pallet_assets_create(ALICE, 1, 1);
+		assert_eq!(burn(&addr, 1, &BOB, amount), Err(Module { index: 52, error: [3, 0] }));
+		let token = pallet_assets_create(&ALICE, 1, 1);
 		// Bob has no tokens and therefore doesn't exist.
-		assert_eq!(burn(addr.clone(), token, BOB, 1), Err(Module { index: 52, error: [1, 0] }));
+		assert_eq!(burn(&addr, token, &BOB, 1), Err(Module { index: 52, error: [1, 0] }));
 		// Burning can only be done by the manager.
-		pallet_assets_mint(ALICE, token, BOB, amount);
-		assert_eq!(burn(addr.clone(), token, BOB, 1), Err(Module { index: 52, error: [2, 0] }));
-		let token = pallet_assets_create_and_mint_to(addr.clone(), 2, BOB, amount);
+		pallet_assets_mint(&ALICE, token, &BOB, amount);
+		assert_eq!(burn(&addr, token, &BOB, 1), Err(Module { index: 52, error: [2, 0] }));
+		let token = pallet_assets_create_and_mint_to(&addr, 2, &BOB, amount);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_freeze(addr.clone(), token);
-		assert_eq!(
-			burn(addr.clone(), token, BOB, amount),
-			Err(Module { index: 52, error: [16, 0] })
-		);
-		pallet_assets_thaw(addr.clone(), token);
+		pallet_assets_freeze(&addr, token);
+		assert_eq!(burn(&addr, token, &BOB, amount), Err(Module { index: 52, error: [16, 0] }));
+		pallet_assets_thaw(&addr, token);
 		// Successful mint.
 		let balance_before_burn = Assets::balance(token, &BOB);
-		assert_ok!(burn(addr.clone(), token, BOB, amount));
+		assert_ok!(burn(&addr, token, &BOB, amount));
 		let balance_after_burn = Assets::balance(token, &BOB);
 		assert_eq!(balance_after_burn, balance_before_burn - amount);
 		// Token is not live, i.e. frozen or being destroyed.
-		pallet_assets_start_destroy(addr.clone(), token);
-		assert_eq!(
-			burn(addr.clone(), token, BOB, amount),
-			Err(Module { index: 52, error: [17, 0] })
-		);
+		pallet_assets_start_destroy(&addr, token);
+		assert_eq!(burn(&addr, token, &BOB, amount), Err(Module { index: 52, error: [17, 0] }));
 	});
 }

--- a/pop-api/integration-tests/src/fungibles/mod.rs
+++ b/pop-api/integration-tests/src/fungibles/mod.rs
@@ -272,19 +272,19 @@ fn token_metadata_works() {
 		let decimals: u8 = 69;
 
 		// Token does not exist.
-		assert_eq!(token_name(&addr, TOKEN_ID), Ok(assets::token_name(TOKEN_ID)));
+		assert_eq!(token_name(&addr, TOKEN_ID), Ok(Assets::name(TOKEN_ID)));
 		assert_eq!(token_name(&addr, TOKEN_ID), Ok(Vec::<u8>::new()));
-		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(assets::token_symbol(TOKEN_ID)));
+		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(Assets::symbol(TOKEN_ID)));
 		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(Vec::<u8>::new()));
-		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(assets::token_decimals(TOKEN_ID)));
+		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(Assets::decimals(TOKEN_ID)));
 		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(0));
 		// Create Token.
 		assets::create_and_set_metadata(&addr, TOKEN_ID, name.clone(), symbol.clone(), decimals);
-		assert_eq!(token_name(&addr, TOKEN_ID), Ok(assets::token_name(TOKEN_ID)));
+		assert_eq!(token_name(&addr, TOKEN_ID), Ok(Assets::name(TOKEN_ID)));
 		assert_eq!(token_name(&addr, TOKEN_ID), Ok(name));
-		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(assets::token_symbol(TOKEN_ID)));
+		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(Assets::symbol(TOKEN_ID)));
 		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(symbol));
-		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(assets::token_decimals(TOKEN_ID)));
+		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(Assets::decimals(TOKEN_ID)));
 		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(decimals));
 	});
 }

--- a/pop-api/integration-tests/src/fungibles/mod.rs
+++ b/pop-api/integration-tests/src/fungibles/mod.rs
@@ -317,16 +317,17 @@ fn create_works() {
 		// Instantiate a contract with enough balance.
 		let addr = instantiate(CONTRACT, INIT_VALUE, vec![2]);
 		assert_eq!(create(&addr, TOKEN_ID, &BOB, 0), Err(Module { index: 52, error: [7, 0] }),);
-		// The minimal balance for an token must be non zero.
+		// The minimal balance for a token must be non zero.
 		assert_eq!(create(&addr, TOKEN_ID, &BOB, 0), Err(Module { index: 52, error: [7, 0] }),);
 		// Create token successfully.
 		assert_ok!(create(&addr, TOKEN_ID, &BOB, 1));
+		assert_eq!(Assets::owner(TOKEN_ID), Some(addr.clone()));
 		// Token ID is already taken.
 		assert_eq!(create(&addr, TOKEN_ID, &BOB, 1), Err(Module { index: 52, error: [5, 0] }),);
 	});
 }
 
-// Testing a contract that creates an token in the constructor.
+// Testing a contract that creates a token in the constructor.
 #[test]
 fn instantiate_and_create_fungible_works() {
 	new_test_ext().execute_with(|| {
@@ -338,8 +339,10 @@ fn instantiate_and_create_fungible_works() {
 			instantiate_and_create_fungible(contract, 0, 1),
 			Err(Module { index: 52, error: [5, 0] })
 		);
-		// Successfully create an token when instantiating the contract.
-		assert_ok!(instantiate_and_create_fungible(contract, TOKEN_ID, 1));
+		// Successfully create a token when instantiating the contract.
+		let result_with_address = instantiate_and_create_fungible(contract, TOKEN_ID, 1);
+		assert_ok!(result_with_address.clone());
+		assert_eq!(Assets::owner(TOKEN_ID), result_with_address.ok());
 		assert!(Assets::asset_exists(TOKEN_ID));
 	});
 }
@@ -465,7 +468,7 @@ fn mint_works() {
 		// Minting can only be done by the owner.
 		assert_eq!(mint(&addr, token, &BOB, 1), Err(Module { index: 52, error: [2, 0] }));
 		let token = pallet_assets_create(&addr, 2, 2);
-		// Minimum balance of an token can not be zero.
+		// Minimum balance of a token can not be zero.
 		assert_eq!(mint(&addr, token, &BOB, 1), Err(Token(BelowMinimum)));
 		// Token is not live, i.e. frozen or being destroyed.
 		pallet_assets_freeze(&addr, token);

--- a/pop-api/integration-tests/src/fungibles/utils.rs
+++ b/pop-api/integration-tests/src/fungibles/utils.rs
@@ -2,10 +2,10 @@ use super::*;
 
 type AssetId = TokenId;
 
-fn do_bare_call(function: &str, addr: AccountId32, params: Vec<u8>) -> ExecReturnValue {
+fn do_bare_call(function: &str, addr: &AccountId32, params: Vec<u8>) -> ExecReturnValue {
 	let function = function_selector(function);
 	let params = [function, params].concat();
-	bare_call(addr, params, 0).expect("should work")
+	bare_call(addr.clone(), params, 0).expect("should work")
 }
 
 // TODO - issue #263 - why result.data[1..]
@@ -13,61 +13,61 @@ pub(super) fn decoded<T: Decode>(result: ExecReturnValue) -> Result<T, ExecRetur
 	<T>::decode(&mut &result.data[1..]).map_err(|_| result)
 }
 
-pub(super) fn total_supply(addr: AccountId32, token_id: TokenId) -> Result<Balance, Error> {
+pub(super) fn total_supply(addr: &AccountId32, token_id: TokenId) -> Result<Balance, Error> {
 	let result = do_bare_call("total_supply", addr, token_id.encode());
 	decoded::<Result<Balance, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
 pub(super) fn balance_of(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
 	owner: AccountId32,
 ) -> Result<Balance, Error> {
 	let params = [token_id.encode(), owner.encode()].concat();
-	let result = do_bare_call("balance_of", addr, params);
+	let result = do_bare_call("balance_of", &addr, params);
 	decoded::<Result<Balance, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
 pub(super) fn allowance(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
 	owner: AccountId32,
 	spender: AccountId32,
 ) -> Result<Balance, Error> {
 	let params = [token_id.encode(), owner.encode(), spender.encode()].concat();
-	let result = do_bare_call("allowance", addr, params);
+	let result = do_bare_call("allowance", &addr, params);
 	decoded::<Result<Balance, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn token_name(addr: AccountId32, token_id: TokenId) -> Result<Vec<u8>, Error> {
+pub(super) fn token_name(addr: &AccountId32, token_id: TokenId) -> Result<Vec<u8>, Error> {
 	let result = do_bare_call("token_name", addr, token_id.encode());
 	decoded::<Result<Vec<u8>, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn token_symbol(addr: AccountId32, token_id: TokenId) -> Result<Vec<u8>, Error> {
+pub(super) fn token_symbol(addr: &AccountId32, token_id: TokenId) -> Result<Vec<u8>, Error> {
 	let result = do_bare_call("token_symbol", addr, token_id.encode());
 	decoded::<Result<Vec<u8>, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn token_decimals(addr: AccountId32, token_id: TokenId) -> Result<u8, Error> {
+pub(super) fn token_decimals(addr: &AccountId32, token_id: TokenId) -> Result<u8, Error> {
 	let result = do_bare_call("token_decimals", addr, token_id.encode());
 	decoded::<Result<u8, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn token_exists(addr: AccountId32, token_id: TokenId) -> Result<bool, Error> {
+pub(super) fn token_exists(addr: &AccountId32, token_id: TokenId) -> Result<bool, Error> {
 	let result = do_bare_call("token_exists", addr, token_id.encode());
 	decoded::<Result<bool, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
 pub(super) fn transfer(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
 	to: AccountId32,
 	value: Balance,
@@ -79,7 +79,7 @@ pub(super) fn transfer(
 }
 
 pub(super) fn transfer_from(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
 	from: AccountId32,
 	to: AccountId32,
@@ -94,9 +94,9 @@ pub(super) fn transfer_from(
 }
 
 pub(super) fn approve(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
-	spender: AccountId32,
+	spender: &AccountId32,
 	value: Balance,
 ) -> Result<(), Error> {
 	let params = [token_id.encode(), spender.encode(), value.encode()].concat();
@@ -106,9 +106,9 @@ pub(super) fn approve(
 }
 
 pub(super) fn increase_allowance(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
-	spender: AccountId32,
+	spender: &AccountId32,
 	value: Balance,
 ) -> Result<(), Error> {
 	let params = [token_id.encode(), spender.encode(), value.encode()].concat();
@@ -118,9 +118,9 @@ pub(super) fn increase_allowance(
 }
 
 pub(super) fn decrease_allowance(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
-	spender: AccountId32,
+	spender: &AccountId32,
 	value: Balance,
 ) -> Result<(), Error> {
 	let params = [token_id.encode(), spender.encode(), value.encode()].concat();
@@ -130,9 +130,9 @@ pub(super) fn decrease_allowance(
 }
 
 pub(super) fn create(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
-	admin: AccountId32,
+	admin: &AccountId32,
 	min_balance: Balance,
 ) -> Result<(), Error> {
 	let params = [token_id.encode(), admin.encode(), min_balance.encode()].concat();
@@ -141,7 +141,7 @@ pub(super) fn create(
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn start_destroy(addr: AccountId32, token_id: TokenId) -> Result<(), Error> {
+pub(super) fn start_destroy(addr: &AccountId32, token_id: TokenId) -> Result<(), Error> {
 	let result = do_bare_call("start_destroy", addr, token_id.encode());
 	match decoded::<Result<(), Error>>(result) {
 		Ok(x) => x,
@@ -150,7 +150,7 @@ pub(super) fn start_destroy(addr: AccountId32, token_id: TokenId) -> Result<(), 
 }
 
 pub(super) fn set_metadata(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
 	name: Vec<u8>,
 	symbol: Vec<u8>,
@@ -162,16 +162,16 @@ pub(super) fn set_metadata(
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn clear_metadata(addr: AccountId32, token_id: TokenId) -> Result<(), Error> {
+pub(super) fn clear_metadata(addr: &AccountId32, token_id: TokenId) -> Result<(), Error> {
 	let result = do_bare_call("clear_metadata", addr, token_id.encode());
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
 pub(super) fn mint(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
-	account: AccountId32,
+	account: &AccountId32,
 	amount: Balance,
 ) -> Result<(), Error> {
 	let params = [token_id.encode(), account.encode(), amount.encode()].concat();
@@ -181,9 +181,9 @@ pub(super) fn mint(
 }
 
 pub(super) fn burn(
-	addr: AccountId32,
+	addr: &AccountId32,
 	token_id: TokenId,
-	account: AccountId32,
+	account: &AccountId32,
 	amount: Balance,
 ) -> Result<(), Error> {
 	let params = [token_id.encode(), account.encode(), amount.encode()].concat();
@@ -193,81 +193,81 @@ pub(super) fn burn(
 }
 
 pub(super) fn pallet_assets_create(
-	owner: AccountId32,
+	owner: &AccountId32,
 	asset_id: AssetId,
 	min_balance: Balance,
 ) -> AssetId {
 	assert_ok!(Assets::create(
 		RuntimeOrigin::signed(owner.clone()),
 		asset_id.into(),
-		owner.into(),
+		owner.clone().into(),
 		min_balance
 	));
 	asset_id
 }
 
 pub(super) fn pallet_assets_mint(
-	owner: AccountId32,
+	owner: &AccountId32,
 	asset_id: AssetId,
-	to: AccountId32,
+	to: &AccountId32,
 	value: Balance,
 ) -> AssetId {
 	assert_ok!(Assets::mint(
 		RuntimeOrigin::signed(owner.clone()),
 		asset_id.into(),
-		to.into(),
+		to.clone().into(),
 		value
 	));
 	asset_id
 }
 
 pub(super) fn pallet_assets_create_and_mint_to(
-	owner: AccountId32,
+	owner: &AccountId32,
 	asset_id: AssetId,
-	to: AccountId32,
+	to: &AccountId32,
 	value: Balance,
 ) -> AssetId {
-	pallet_assets_create(owner.clone(), asset_id, 1);
+	pallet_assets_create(owner, asset_id, 1);
 	pallet_assets_mint(owner, asset_id, to, value)
 }
 
 // Create an asset, mints to, and approves spender.
 pub(super) fn pallet_assets_create_mint_and_approve(
-	owner: AccountId32,
+	owner: &AccountId32,
 	asset_id: AssetId,
-	to: AccountId32,
+	to: &AccountId32,
 	mint: Balance,
-	spender: AccountId32,
+	spender: &AccountId32,
 	approve: Balance,
 ) -> AssetId {
-	pallet_assets_create_and_mint_to(owner.clone(), asset_id, to.clone(), mint);
+	pallet_assets_create_and_mint_to(owner, asset_id, to, mint);
 	assert_ok!(Assets::approve_transfer(
-		RuntimeOrigin::signed(to.into()),
+		RuntimeOrigin::signed(to.clone().into()),
 		asset_id.into(),
-		spender.into(),
+		spender.clone().into(),
 		approve,
 	));
 	asset_id
 }
 
 // Freeze an asset.
-pub(super) fn pallet_assets_freeze(owner: AccountId32, asset_id: AssetId) {
-	assert_ok!(Assets::freeze_asset(RuntimeOrigin::signed(owner.into()), asset_id.into()));
+pub(super) fn pallet_assets_freeze(owner: &AccountId32, asset_id: AssetId) {
+	assert_ok!(Assets::freeze_asset(RuntimeOrigin::signed(owner.clone().into()), asset_id.into()));
 }
 
 // Thaw an asset.
-pub(super) fn pallet_assets_thaw(owner: AccountId32, asset_id: AssetId) {
-	assert_ok!(Assets::thaw_asset(RuntimeOrigin::signed(owner.into()), asset_id.into()));
+pub(super) fn pallet_assets_thaw(owner: &AccountId32, asset_id: AssetId) {
+	assert_ok!(Assets::thaw_asset(RuntimeOrigin::signed(owner.clone().into()), asset_id.into()));
 }
 
 // Start destroying an asset.
-pub(super) fn pallet_assets_start_destroy(owner: AccountId32, asset_id: AssetId) {
-	assert_ok!(Assets::start_destroy(RuntimeOrigin::signed(owner.into()), asset_id.into()));
+pub(super) fn pallet_assets_start_destroy(owner: &AccountId32, asset_id: AssetId) {
+	assert_ok!(Assets::start_destroy(RuntimeOrigin::signed(owner.clone().into()), asset_id.into()));
 }
 
 // Create an asset and set metadata.
 pub(super) fn pallet_assets_create_and_set_metadata(
-	owner: AccountId32,
+	owner: &AccountId32,
 	asset_id: AssetId,
 	name: Vec<u8>,
 	symbol: Vec<u8>,
@@ -285,14 +285,14 @@ pub(super) fn pallet_assets_create_and_set_metadata(
 
 // Set metadata of an asset.
 pub(super) fn pallet_assets_set_metadata(
-	owner: AccountId32,
+	owner: &AccountId32,
 	asset_id: AssetId,
 	name: Vec<u8>,
 	symbol: Vec<u8>,
 	decimals: u8,
 ) {
 	assert_ok!(Assets::set_metadata(
-		RuntimeOrigin::signed(owner.into()),
+		RuntimeOrigin::signed(owner.clone().into()),
 		asset_id.into(),
 		name,
 		symbol,

--- a/pop-api/integration-tests/src/fungibles/utils.rs
+++ b/pop-api/integration-tests/src/fungibles/utils.rs
@@ -322,7 +322,7 @@ pub(super) fn instantiate_and_create_fungible(
 	contract: &str,
 	token_id: TokenId,
 	min_balance: Balance,
-) -> Result<(), Error> {
+) -> Result<AccountId32, Error> {
 	let function = function_selector("new");
 	let input = [function, token_id.encode(), min_balance.encode()].concat();
 	let wasm_binary = load_wasm_module::<Runtime>(contract).expect("could not read .wasm file");
@@ -338,8 +338,10 @@ pub(super) fn instantiate_and_create_fungible(
 		CollectEvents::Skip,
 	)
 	.result
-	.expect("should work")
-	.result;
+	.expect("should work");
+	let address = result.account_id;
+	let result = result.result;
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+		.map(|_| address)
 }

--- a/pop-api/integration-tests/src/fungibles/utils.rs
+++ b/pop-api/integration-tests/src/fungibles/utils.rs
@@ -308,18 +308,6 @@ pub(super) mod assets {
 			decimals
 		));
 	}
-
-	pub(crate) fn token_name(asset_id: AssetId) -> Vec<u8> {
-		Assets::name(asset_id)
-	}
-
-	pub(crate) fn token_symbol(asset_id: AssetId) -> Vec<u8> {
-		Assets::symbol(asset_id)
-	}
-
-	pub(crate) fn token_decimals(asset_id: AssetId) -> u8 {
-		Assets::decimals(asset_id)
-	}
 }
 
 pub(super) fn instantiate_and_create_fungible(

--- a/pop-api/integration-tests/src/fungibles/utils.rs
+++ b/pop-api/integration-tests/src/fungibles/utils.rs
@@ -1,27 +1,30 @@
 use super::*;
 
+type AssetId = TokenId;
+
 fn do_bare_call(function: &str, addr: AccountId32, params: Vec<u8>) -> ExecReturnValue {
 	let function = function_selector(function);
 	let params = [function, params].concat();
 	bare_call(addr, params, 0).expect("should work")
 }
 
+// TODO - issue #263 - why result.data[1..]
 pub(super) fn decoded<T: Decode>(result: ExecReturnValue) -> Result<T, ExecReturnValue> {
 	<T>::decode(&mut &result.data[1..]).map_err(|_| result)
 }
 
-pub(super) fn total_supply(addr: AccountId32, asset_id: AssetId) -> Result<Balance, Error> {
-	let result = do_bare_call("total_supply", addr, asset_id.encode());
+pub(super) fn total_supply(addr: AccountId32, token_id: TokenId) -> Result<Balance, Error> {
+	let result = do_bare_call("total_supply", addr, token_id.encode());
 	decoded::<Result<Balance, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
 pub(super) fn balance_of(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	owner: AccountId32,
 ) -> Result<Balance, Error> {
-	let params = [asset_id.encode(), owner.encode()].concat();
+	let params = [token_id.encode(), owner.encode()].concat();
 	let result = do_bare_call("balance_of", addr, params);
 	decoded::<Result<Balance, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
@@ -29,47 +32,47 @@ pub(super) fn balance_of(
 
 pub(super) fn allowance(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	owner: AccountId32,
 	spender: AccountId32,
 ) -> Result<Balance, Error> {
-	let params = [asset_id.encode(), owner.encode(), spender.encode()].concat();
+	let params = [token_id.encode(), owner.encode(), spender.encode()].concat();
 	let result = do_bare_call("allowance", addr, params);
 	decoded::<Result<Balance, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn token_name(addr: AccountId32, asset_id: AssetId) -> Result<Vec<u8>, Error> {
-	let result = do_bare_call("token_name", addr, asset_id.encode());
+pub(super) fn token_name(addr: AccountId32, token_id: TokenId) -> Result<Vec<u8>, Error> {
+	let result = do_bare_call("token_name", addr, token_id.encode());
 	decoded::<Result<Vec<u8>, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn token_symbol(addr: AccountId32, asset_id: AssetId) -> Result<Vec<u8>, Error> {
-	let result = do_bare_call("token_symbol", addr, asset_id.encode());
+pub(super) fn token_symbol(addr: AccountId32, token_id: TokenId) -> Result<Vec<u8>, Error> {
+	let result = do_bare_call("token_symbol", addr, token_id.encode());
 	decoded::<Result<Vec<u8>, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn token_decimals(addr: AccountId32, asset_id: AssetId) -> Result<u8, Error> {
-	let result = do_bare_call("token_decimals", addr, asset_id.encode());
+pub(super) fn token_decimals(addr: AccountId32, token_id: TokenId) -> Result<u8, Error> {
+	let result = do_bare_call("token_decimals", addr, token_id.encode());
 	decoded::<Result<u8, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn token_exists(addr: AccountId32, asset_id: AssetId) -> Result<bool, Error> {
-	let result = do_bare_call("token_exists", addr, asset_id.encode());
+pub(super) fn token_exists(addr: AccountId32, token_id: TokenId) -> Result<bool, Error> {
+	let result = do_bare_call("token_exists", addr, token_id.encode());
 	decoded::<Result<bool, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
 pub(super) fn transfer(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	to: AccountId32,
 	value: Balance,
 ) -> Result<(), Error> {
-	let params = [asset_id.encode(), to.encode(), value.encode()].concat();
+	let params = [token_id.encode(), to.encode(), value.encode()].concat();
 	let result = do_bare_call("transfer", addr, params);
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
@@ -77,14 +80,14 @@ pub(super) fn transfer(
 
 pub(super) fn transfer_from(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	from: AccountId32,
 	to: AccountId32,
 	value: Balance,
 ) -> Result<(), Error> {
 	let data: Vec<u8> = vec![];
 	let params =
-		[asset_id.encode(), from.encode(), to.encode(), value.encode(), data.encode()].concat();
+		[token_id.encode(), from.encode(), to.encode(), value.encode(), data.encode()].concat();
 	let result = do_bare_call("transfer_from", addr, params);
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
@@ -92,11 +95,11 @@ pub(super) fn transfer_from(
 
 pub(super) fn approve(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	spender: AccountId32,
 	value: Balance,
 ) -> Result<(), Error> {
-	let params = [asset_id.encode(), spender.encode(), value.encode()].concat();
+	let params = [token_id.encode(), spender.encode(), value.encode()].concat();
 	let result = do_bare_call("approve", addr, params);
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
@@ -104,11 +107,11 @@ pub(super) fn approve(
 
 pub(super) fn increase_allowance(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	spender: AccountId32,
 	value: Balance,
 ) -> Result<(), Error> {
-	let params = [asset_id.encode(), spender.encode(), value.encode()].concat();
+	let params = [token_id.encode(), spender.encode(), value.encode()].concat();
 	let result = do_bare_call("increase_allowance", addr, params);
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
@@ -116,11 +119,11 @@ pub(super) fn increase_allowance(
 
 pub(super) fn decrease_allowance(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	spender: AccountId32,
 	value: Balance,
 ) -> Result<(), Error> {
-	let params = [asset_id.encode(), spender.encode(), value.encode()].concat();
+	let params = [token_id.encode(), spender.encode(), value.encode()].concat();
 	let result = do_bare_call("decrease_allowance", addr, params);
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
@@ -128,18 +131,18 @@ pub(super) fn decrease_allowance(
 
 pub(super) fn create(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	admin: AccountId32,
 	min_balance: Balance,
 ) -> Result<(), Error> {
-	let params = [asset_id.encode(), admin.encode(), min_balance.encode()].concat();
+	let params = [token_id.encode(), admin.encode(), min_balance.encode()].concat();
 	let result = do_bare_call("create", addr, params);
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn start_destroy(addr: AccountId32, asset_id: AssetId) -> Result<(), Error> {
-	let result = do_bare_call("start_destroy", addr, asset_id.encode());
+pub(super) fn start_destroy(addr: AccountId32, token_id: TokenId) -> Result<(), Error> {
+	let result = do_bare_call("start_destroy", addr, token_id.encode());
 	match decoded::<Result<(), Error>>(result) {
 		Ok(x) => x,
 		Err(result) => panic!("Contract reverted: {:?}", result),
@@ -148,30 +151,30 @@ pub(super) fn start_destroy(addr: AccountId32, asset_id: AssetId) -> Result<(), 
 
 pub(super) fn set_metadata(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	name: Vec<u8>,
 	symbol: Vec<u8>,
 	decimals: u8,
 ) -> Result<(), Error> {
-	let params = [asset_id.encode(), name.encode(), symbol.encode(), decimals.encode()].concat();
+	let params = [token_id.encode(), name.encode(), symbol.encode(), decimals.encode()].concat();
 	let result = do_bare_call("set_metadata", addr, params);
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn clear_metadata(addr: AccountId32, asset_id: AssetId) -> Result<(), Error> {
-	let result = do_bare_call("clear_metadata", addr, asset_id.encode());
+pub(super) fn clear_metadata(addr: AccountId32, token_id: TokenId) -> Result<(), Error> {
+	let result = do_bare_call("clear_metadata", addr, token_id.encode());
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
 pub(super) fn mint(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	account: AccountId32,
 	amount: Balance,
 ) -> Result<(), Error> {
-	let params = [asset_id.encode(), account.encode(), amount.encode()].concat();
+	let params = [token_id.encode(), account.encode(), amount.encode()].concat();
 	let result = do_bare_call("mint", addr, params);
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
@@ -179,17 +182,21 @@ pub(super) fn mint(
 
 pub(super) fn burn(
 	addr: AccountId32,
-	asset_id: AssetId,
+	token_id: TokenId,
 	account: AccountId32,
 	amount: Balance,
 ) -> Result<(), Error> {
-	let params = [asset_id.encode(), account.encode(), amount.encode()].concat();
+	let params = [token_id.encode(), account.encode(), amount.encode()].concat();
 	let result = do_bare_call("burn", addr, params);
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn create_asset(owner: AccountId32, asset_id: AssetId, min_balance: Balance) -> AssetId {
+pub(super) fn pallet_assets_create(
+	owner: AccountId32,
+	asset_id: AssetId,
+	min_balance: Balance,
+) -> AssetId {
 	assert_ok!(Assets::create(
 		RuntimeOrigin::signed(owner.clone()),
 		asset_id.into(),
@@ -199,7 +206,7 @@ pub(super) fn create_asset(owner: AccountId32, asset_id: AssetId, min_balance: B
 	asset_id
 }
 
-pub(super) fn mint_asset(
+pub(super) fn pallet_assets_mint(
 	owner: AccountId32,
 	asset_id: AssetId,
 	to: AccountId32,
@@ -214,18 +221,18 @@ pub(super) fn mint_asset(
 	asset_id
 }
 
-pub(super) fn create_asset_and_mint_to(
+pub(super) fn pallet_assets_create_and_mint_to(
 	owner: AccountId32,
 	asset_id: AssetId,
 	to: AccountId32,
 	value: Balance,
 ) -> AssetId {
-	create_asset(owner.clone(), asset_id, 1);
-	mint_asset(owner, asset_id, to, value)
+	pallet_assets_create(owner.clone(), asset_id, 1);
+	pallet_assets_mint(owner, asset_id, to, value)
 }
 
 // Create an asset, mints to, and approves spender.
-pub(super) fn create_asset_mint_and_approve(
+pub(super) fn pallet_assets_create_mint_and_approve(
 	owner: AccountId32,
 	asset_id: AssetId,
 	to: AccountId32,
@@ -233,7 +240,7 @@ pub(super) fn create_asset_mint_and_approve(
 	spender: AccountId32,
 	approve: Balance,
 ) -> AssetId {
-	create_asset_and_mint_to(owner.clone(), asset_id, to.clone(), mint);
+	pallet_assets_create_and_mint_to(owner.clone(), asset_id, to.clone(), mint);
 	assert_ok!(Assets::approve_transfer(
 		RuntimeOrigin::signed(to.into()),
 		asset_id.into(),
@@ -244,22 +251,22 @@ pub(super) fn create_asset_mint_and_approve(
 }
 
 // Freeze an asset.
-pub(super) fn freeze_asset(owner: AccountId32, asset_id: AssetId) {
+pub(super) fn pallet_assets_freeze(owner: AccountId32, asset_id: AssetId) {
 	assert_ok!(Assets::freeze_asset(RuntimeOrigin::signed(owner.into()), asset_id.into()));
 }
 
 // Thaw an asset.
-pub(super) fn thaw_asset(owner: AccountId32, asset_id: AssetId) {
+pub(super) fn pallet_assets_thaw(owner: AccountId32, asset_id: AssetId) {
 	assert_ok!(Assets::thaw_asset(RuntimeOrigin::signed(owner.into()), asset_id.into()));
 }
 
 // Start destroying an asset.
-pub(super) fn start_destroy_asset(owner: AccountId32, asset_id: AssetId) {
+pub(super) fn pallet_assets_start_destroy(owner: AccountId32, asset_id: AssetId) {
 	assert_ok!(Assets::start_destroy(RuntimeOrigin::signed(owner.into()), asset_id.into()));
 }
 
 // Create an asset and set metadata.
-pub(super) fn create_asset_and_set_metadata(
+pub(super) fn pallet_assets_create_and_set_metadata(
 	owner: AccountId32,
 	asset_id: AssetId,
 	name: Vec<u8>,
@@ -272,12 +279,12 @@ pub(super) fn create_asset_and_set_metadata(
 		owner.clone().into(),
 		100
 	));
-	set_metadata_asset(owner, asset_id, name, symbol, decimals);
+	pallet_assets_set_metadata(owner, asset_id, name, symbol, decimals);
 	asset_id
 }
 
 // Set metadata of an asset.
-pub(super) fn set_metadata_asset(
+pub(super) fn pallet_assets_set_metadata(
 	owner: AccountId32,
 	asset_id: AssetId,
 	name: Vec<u8>,
@@ -293,33 +300,32 @@ pub(super) fn set_metadata_asset(
 	));
 }
 
-pub(super) fn token_name_asset(asset_id: AssetId) -> Vec<u8> {
+pub(super) fn pallet_assets_token_name(asset_id: AssetId) -> Vec<u8> {
 	<pallet_assets::Pallet<Runtime, TrustBackedAssetsInstance> as MetadataInspect<AccountId32>>::name(
-        asset_id,
-    )
+		asset_id,
+	)
 }
 
-pub(super) fn token_symbol_asset(asset_id: AssetId) -> Vec<u8> {
+pub(super) fn pallet_assets_token_symbol(asset_id: AssetId) -> Vec<u8> {
 	<pallet_assets::Pallet<Runtime, TrustBackedAssetsInstance> as MetadataInspect<AccountId32>>::symbol(
-        asset_id,
-    )
+		asset_id,
+	)
 }
 
-pub(super) fn token_decimals_asset(asset_id: AssetId) -> u8 {
+pub(super) fn pallet_assets_token_decimals(asset_id: AssetId) -> u8 {
 	<pallet_assets::Pallet<Runtime, TrustBackedAssetsInstance> as MetadataInspect<AccountId32>>::decimals(
-        asset_id,
-    )
+		asset_id,
+	)
 }
 
 pub(super) fn instantiate_and_create_fungible(
 	contract: &str,
-	asset_id: AssetId,
+	token_id: TokenId,
 	min_balance: Balance,
 ) -> Result<(), Error> {
 	let function = function_selector("new");
-	let input = [function, asset_id.encode(), min_balance.encode()].concat();
-	let (wasm_binary, _) =
-		load_wasm_module::<Runtime>(contract).expect("could not read .wasm file");
+	let input = [function, token_id.encode(), min_balance.encode()].concat();
+	let wasm_binary = load_wasm_module::<Runtime>(contract).expect("could not read .wasm file");
 	let result = Contracts::bare_instantiate(
 		ALICE,
 		INIT_VALUE,

--- a/pop-api/integration-tests/src/fungibles/utils.rs
+++ b/pop-api/integration-tests/src/fungibles/utils.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-type AssetId = TokenId;
-
 fn do_bare_call(function: &str, addr: &AccountId32, params: Vec<u8>) -> ExecReturnValue {
 	let function = function_selector(function);
 	let params = [function, params].concat();
@@ -195,6 +193,9 @@ pub(super) fn burn(
 // Helper functions for interacting with pallet-assets.
 pub(super) mod assets {
 	use super::*;
+
+	type AssetId = TokenId;
+
 	pub(crate) fn create(owner: &AccountId32, asset_id: AssetId, min_balance: Balance) -> AssetId {
 		assert_ok!(Assets::create(
 			RuntimeOrigin::signed(owner.clone()),
@@ -309,21 +310,15 @@ pub(super) mod assets {
 	}
 
 	pub(crate) fn token_name(asset_id: AssetId) -> Vec<u8> {
-		<pallet_assets::Pallet<Runtime, TrustBackedAssetsInstance> as MetadataInspect<
-			AccountId32,
-		>>::name(asset_id)
+		Assets::name(asset_id)
 	}
 
 	pub(crate) fn token_symbol(asset_id: AssetId) -> Vec<u8> {
-		<pallet_assets::Pallet<Runtime, TrustBackedAssetsInstance> as MetadataInspect<
-			AccountId32,
-		>>::symbol(asset_id)
+		Assets::symbol(asset_id)
 	}
 
 	pub(crate) fn token_decimals(asset_id: AssetId) -> u8 {
-		<pallet_assets::Pallet<Runtime, TrustBackedAssetsInstance> as MetadataInspect<
-			AccountId32,
-		>>::decimals(asset_id)
+		Assets::decimals(asset_id)
 	}
 }
 
@@ -334,7 +329,7 @@ pub(super) fn instantiate_and_create_fungible(
 ) -> Result<AccountId32, Error> {
 	let function = function_selector("new");
 	let input = [function, token_id.encode(), min_balance.encode()].concat();
-	let wasm_binary = load_wasm_module::<Runtime>(contract).expect("could not read .wasm file");
+	let wasm_binary = std::fs::read(contract).expect("could not read .wasm file");
 	let result = Contracts::bare_instantiate(
 		ALICE,
 		INIT_VALUE,

--- a/pop-api/integration-tests/src/lib.rs
+++ b/pop-api/integration-tests/src/lib.rs
@@ -28,6 +28,8 @@ const INIT_AMOUNT: Balance = 100_000_000 * UNIT;
 const INIT_VALUE: Balance = 100 * UNIT;
 
 fn new_test_ext() -> sp_io::TestExternalities {
+	let _ = env_logger::try_init();
+
 	let mut t = frame_system::GenesisConfig::<Runtime>::default()
 		.build_storage()
 		.expect("Frame system builds valid default genesis config");

--- a/pop-api/integration-tests/src/lib.rs
+++ b/pop-api/integration-tests/src/lib.rs
@@ -8,23 +8,20 @@ use frame_support::{
 	weights::Weight,
 };
 use pallet_contracts::{Code, CollectEvents, Determinism, ExecReturnValue};
-use scale::{Decode, Encode};
-use sp_runtime::{traits::Hash, AccountId32, BuildStorage, DispatchError};
-
 use pop_runtime_devnet::{
 	config::assets::TrustBackedAssetsInstance, Assets, Contracts, Runtime, RuntimeOrigin, System,
 	UNIT,
 };
+use scale::{Decode, Encode};
+use sp_runtime::{AccountId32, BuildStorage, DispatchError};
 
 mod fungibles;
 
-type AssetId = u32;
 type Balance = u128;
 
 const ALICE: AccountId32 = AccountId32::new([1_u8; 32]);
 const BOB: AccountId32 = AccountId32::new([2_u8; 32]);
 const DEBUG_OUTPUT: pallet_contracts::DebugInfo = pallet_contracts::DebugInfo::UnsafeDebug;
-// FERDIE has no initial balance.
 const FERDIE: AccountId32 = AccountId32::new([3_u8; 32]);
 const GAS_LIMIT: Weight = Weight::from_parts(100_000_000_000, 3 * 1024 * 1024);
 const INIT_AMOUNT: Balance = 100_000_000 * UNIT;
@@ -36,6 +33,7 @@ fn new_test_ext() -> sp_io::TestExternalities {
 		.expect("Frame system builds valid default genesis config");
 
 	pallet_balances::GenesisConfig::<Runtime> {
+		// FERDIE has no initial balance.
 		balances: vec![(ALICE, INIT_AMOUNT), (BOB, INIT_AMOUNT)],
 	}
 	.assimilate_storage(&mut t)
@@ -46,13 +44,12 @@ fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
-fn load_wasm_module<T>(path: &str) -> std::io::Result<(Vec<u8>, <T::Hashing as Hash>::Output)>
+fn load_wasm_module<T>(path: &str) -> std::io::Result<Vec<u8>>
 where
 	T: frame_system::Config,
 {
 	let wasm_binary = std::fs::read(path)?;
-	let code_hash = T::Hashing::hash(&wasm_binary);
-	Ok((wasm_binary, code_hash))
+	Ok(wasm_binary)
 }
 
 fn function_selector(name: &str) -> Vec<u8> {
@@ -82,8 +79,7 @@ fn bare_call(
 
 // Deploy, instantiate and return contract address.
 fn instantiate(contract: &str, init_value: u128, salt: Vec<u8>) -> AccountId32 {
-	let (wasm_binary, _) =
-		load_wasm_module::<Runtime>(contract).expect("could not read .wasm file");
+	let wasm_binary = load_wasm_module::<Runtime>(contract).expect("could not read .wasm file");
 	let result = Contracts::bare_instantiate(
 		ALICE,
 		init_value,

--- a/pop-api/integration-tests/src/lib.rs
+++ b/pop-api/integration-tests/src/lib.rs
@@ -3,16 +3,12 @@
 use frame_support::{
 	assert_ok,
 	traits::fungibles::{
-		approvals::Inspect as ApprovalInspect, metadata::Inspect as MetadataInspect,
-		roles::Inspect as RolesInspect, Inspect,
+		approvals::Inspect as _, metadata::Inspect as _, roles::Inspect as _, Inspect,
 	},
 	weights::Weight,
 };
 use pallet_contracts::{Code, CollectEvents, Determinism, ExecReturnValue};
-use pop_runtime_devnet::{
-	config::assets::TrustBackedAssetsInstance, Assets, Contracts, Runtime, RuntimeOrigin, System,
-	UNIT,
-};
+use pop_runtime_devnet::{Assets, Contracts, Runtime, RuntimeOrigin, System, UNIT};
 use scale::{Decode, Encode};
 use sp_runtime::{AccountId32, BuildStorage, DispatchError};
 
@@ -47,14 +43,6 @@ fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
-fn load_wasm_module<T>(path: &str) -> std::io::Result<Vec<u8>>
-where
-	T: frame_system::Config,
-{
-	let wasm_binary = std::fs::read(path)?;
-	Ok(wasm_binary)
-}
-
 fn function_selector(name: &str) -> Vec<u8> {
 	let hash = sp_io::hashing::blake2_256(name.as_bytes());
 	[hash[0..4].to_vec()].concat()
@@ -82,7 +70,8 @@ fn bare_call(
 
 // Deploy, instantiate and return contract address.
 fn instantiate(contract: &str, init_value: u128, salt: Vec<u8>) -> AccountId32 {
-	let wasm_binary = load_wasm_module::<Runtime>(contract).expect("could not read .wasm file");
+	let wasm_binary = std::fs::read(contract).expect("could not read .wasm file");
+
 	let result = Contracts::bare_instantiate(
 		ALICE,
 		init_value,

--- a/pop-api/integration-tests/src/lib.rs
+++ b/pop-api/integration-tests/src/lib.rs
@@ -3,7 +3,8 @@
 use frame_support::{
 	assert_ok,
 	traits::fungibles::{
-		approvals::Inspect as ApprovalInspect, metadata::Inspect as MetadataInspect, Inspect,
+		approvals::Inspect as ApprovalInspect, metadata::Inspect as MetadataInspect,
+		roles::Inspect as RolesInspect, Inspect,
 	},
 	weights::Weight,
 };

--- a/pop-api/src/lib.rs
+++ b/pop-api/src/lib.rs
@@ -1,9 +1,10 @@
-//! The `pop-api` crate provides an API for smart contracts to interact with the Pop Network runtime.
+//! The `pop-api` crate provides an API for smart contracts to interact with the Pop Network
+//! runtime.
 //!
-//! This crate abstracts away complexities to deliver a streamlined developer experience while supporting
-//! multiple API versions to ensure backward compatibility. It is designed with a focus on stability,
-//! future-proofing, and storage efficiency, allowing developers to easily integrate powerful runtime
-//! features into their contracts without unnecessary overhead.
+//! This crate abstracts away complexities to deliver a streamlined developer experience while
+//! supporting multiple API versions to ensure backward compatibility. It is designed with a focus
+//! on stability, future-proofing, and storage efficiency, allowing developers to easily integrate
+//! powerful runtime features into their contracts without unnecessary overhead.
 
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
@@ -16,49 +17,16 @@ pub mod primitives;
 /// The first version of the API.
 pub mod v0;
 
-/// A result type used by the API, with the `StatusCode` as the error type.
+type ChainExtensionMethodApi = ChainExtensionMethod<(), (), (), false>;
+/// The result type used by the API, with the `StatusCode` as the error type.
 pub type Result<T> = core::result::Result<T, StatusCode>;
-
-mod constants {
-	// Errors:
-	pub(crate) const DECODING_FAILED: u32 = 255;
-	// TODO: will be used in the future when the remaining fungibles features will be implemented.
-	pub(crate) const _MODULE_ERROR: u8 = 3;
-
-	// Function IDs:
-	pub(crate) const DISPATCH: u8 = 0;
-	pub(crate) const READ_STATE: u8 = 1;
-
-	// Modules:
-	pub(crate) const ASSETS: u8 = 52;
-	pub(crate) const BALANCES: u8 = 10;
-	pub(crate) const FUNGIBLES: u8 = 150;
-}
-
-// Helper method to build a dispatch call or a call to read state.
-//
-// Parameters:
-// - 'version': The version of the chain extension.
-// - 'function': The ID of the function.
-// - 'module': The index of the runtime module.
-// - 'dispatchable': The index of the module dispatchable functions.
-fn build_extension_method(
-	version: u8,
-	function: u8,
-	module: u8,
-	dispatchable: u8,
-) -> ChainExtensionMethod<(), (), (), false> {
-	ChainExtensionMethod::build(u32::from_le_bytes([version, function, module, dispatchable]))
-}
 
 /// Represents a status code returned by the runtime.
 ///
-/// `StatusCode` encapsulates a `u32` value that indicates the status of an operation performed by
-/// the runtime. It helps to communicate the success or failure of a Pop API call to the contract,
-/// providing a standardized way to handle errors.
+/// `StatusCode` encapsulates a `u32` value that indicates the success or failure of a runtime call
+/// via Pop API.
 ///
-/// This status code can be used to determine if an operation succeeded or if it encountered an
-/// error. A `StatusCode` of `0` typically indicates success, while any other value represents an
+/// A `StatusCode` of `0` indicates success, while any other value represents an
 /// error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[ink::scale_derive(Encode, Decode, TypeInfo)]
@@ -89,4 +57,34 @@ impl From<ink::scale::Error> for StatusCode {
 	fn from(_: ink::scale::Error) -> Self {
 		StatusCode(DECODING_FAILED)
 	}
+}
+
+mod constants {
+	// Error.
+	pub(crate) const DECODING_FAILED: u32 = 255;
+
+	// Function IDs.
+	pub(crate) const DISPATCH: u8 = 0;
+	pub(crate) const READ_STATE: u8 = 1;
+
+	// Modules.
+	pub(crate) const ASSETS: u8 = 52;
+	pub(crate) const BALANCES: u8 = 10;
+	pub(crate) const FUNGIBLES: u8 = 150;
+}
+
+// Helper method to build a dispatch call or a call to read state.
+//
+// Parameters:
+// - 'version': The version of the chain extension.
+// - 'function': The ID of the function.
+// - 'module': The index of the runtime module.
+// - 'dispatchable': The index of the module dispatchable functions.
+fn build_extension_method(
+	version: u8,
+	function: u8,
+	module: u8,
+	dispatchable: u8,
+) -> ChainExtensionMethodApi {
+	ChainExtensionMethod::build(u32::from_le_bytes([version, function, module, dispatchable]))
 }

--- a/pop-api/src/v0/fungibles.rs
+++ b/pop-api/src/v0/fungibles.rs
@@ -7,21 +7,21 @@
 //! 4. PSP-22 Mintable & Burnable
 
 use constants::*;
-use ink::{env::chain_extension::ChainExtensionMethod, prelude::vec::Vec};
+use ink::prelude::vec::Vec;
 pub use management::*;
 pub use metadata::*;
 
 use crate::{
 	constants::{ASSETS, BALANCES, FUNGIBLES},
 	primitives::{AccountId, Balance, TokenId},
-	Result, StatusCode,
+	ChainExtensionMethodApi, Result, StatusCode,
 };
 
 // Helper method to build a dispatch call.
 //
 // Parameters:
 // - 'dispatchable': The index of the dispatchable function within the module.
-fn build_dispatch(dispatchable: u8) -> ChainExtensionMethod<(), (), (), false> {
+fn build_dispatch(dispatchable: u8) -> ChainExtensionMethodApi {
 	crate::v0::build_dispatch(FUNGIBLES, dispatchable)
 }
 
@@ -29,7 +29,7 @@ fn build_dispatch(dispatchable: u8) -> ChainExtensionMethod<(), (), (), false> {
 //
 // Parameters:
 // - 'state_query': The index of the runtime state query.
-fn build_read_state(state_query: u8) -> ChainExtensionMethod<(), (), (), false> {
+fn build_read_state(state_query: u8) -> ChainExtensionMethodApi {
 	crate::v0::build_read_state(FUNGIBLES, state_query)
 }
 
@@ -99,7 +99,7 @@ pub mod events {
 		pub value: u128,
 	}
 
-	/// Event emitted when an token is created.
+	/// Event emitted when a token is created.
 	#[ink::event]
 	pub struct Create {
 		/// The token identifier.
@@ -296,7 +296,7 @@ pub fn burn(token: TokenId, account: AccountId, value: Balance) -> Result<()> {
 		.call(&(token, account, value))
 }
 
-/// The PSP-22 Metadata interface for querying metadata.
+/// The PSP-22 compliant interface for querying metadata.
 pub mod metadata {
 	use super::*;
 
@@ -526,7 +526,7 @@ mod tests {
 	}
 
 	#[test]
-	fn conversion_status_code_into_fungibles_error_works() {
+	fn converting_status_code_into_fungibles_error_works() {
 		let other_errors = vec![
 			Other,
 			CannotLookup,

--- a/pop-api/src/v0/mod.rs
+++ b/pop-api/src/v0/mod.rs
@@ -2,9 +2,8 @@ use crate::{
 	build_extension_method,
 	constants::{DISPATCH, READ_STATE},
 	primitives::Error,
-	StatusCode,
+	ChainExtensionMethodApi, StatusCode,
 };
-use ink::env::chain_extension::ChainExtensionMethod;
 
 /// APIs for fungible tokens.
 #[cfg(feature = "fungibles")]
@@ -23,7 +22,7 @@ impl From<StatusCode> for Error {
 // Parameters:
 // - 'module': The index of the runtime module.
 // - 'dispatchable': The index of the module dispatchable functions.
-fn build_dispatch(module: u8, dispatchable: u8) -> ChainExtensionMethod<(), (), (), false> {
+fn build_dispatch(module: u8, dispatchable: u8) -> ChainExtensionMethodApi {
 	build_extension_method(V0, DISPATCH, module, dispatchable)
 }
 
@@ -32,6 +31,6 @@ fn build_dispatch(module: u8, dispatchable: u8) -> ChainExtensionMethod<(), (), 
 // Parameters:
 // - 'module': The index of the runtime module.
 // - 'state_query': The index of the runtime state query.
-fn build_read_state(module: u8, state_query: u8) -> ChainExtensionMethod<(), (), (), false> {
+fn build_read_state(module: u8, state_query: u8) -> ChainExtensionMethodApi {
 	build_extension_method(V0, READ_STATE, module, state_query)
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -17,7 +17,7 @@ pub mod v0 {
 		use super::*;
 
 		/// Reason why a Pop API call failed.
-		#[derive(Encode, Decode, Debug, Eq, PartialEq)]
+		#[derive(Encode, Decode, Debug, Eq, PartialEq, Clone)]
 		#[cfg_attr(feature = "std", derive(TypeInfo))]
 		#[repr(u8)]
 		#[allow(clippy::unnecessary_cast)]
@@ -102,7 +102,7 @@ pub mod v0 {
 		}
 
 		/// Description of what went wrong when trying to complete an operation on a token.
-		#[derive(Encode, Decode, Debug, Eq, PartialEq)]
+		#[derive(Encode, Decode, Debug, Eq, PartialEq, Clone)]
 		#[cfg_attr(feature = "std", derive(TypeInfo))]
 		pub enum TokenError {
 			/// Funds are unavailable.
@@ -129,7 +129,7 @@ pub mod v0 {
 		}
 
 		/// Arithmetic errors.
-		#[derive(Encode, Decode, Debug, Eq, PartialEq)]
+		#[derive(Encode, Decode, Debug, Eq, PartialEq, Clone)]
 		#[cfg_attr(feature = "std", derive(TypeInfo))]
 		pub enum ArithmeticError {
 			/// Underflow.
@@ -141,7 +141,7 @@ pub mod v0 {
 		}
 
 		/// Errors related to transactional storage layers.
-		#[derive(Encode, Decode, Debug, Eq, PartialEq)]
+		#[derive(Encode, Decode, Debug, Eq, PartialEq, Clone)]
 		#[cfg_attr(feature = "std", derive(TypeInfo))]
 		pub enum TransactionalError {
 			/// Too many transactional layers have been spawned.

--- a/runtime/devnet/src/config/assets.rs
+++ b/runtime/devnet/src/config/assets.rs
@@ -96,7 +96,7 @@ impl pallet_nft_fractionalization::Config for Runtime {
 	type WeightInfo = pallet_nft_fractionalization::weights::SubstrateWeight<Self>;
 }
 
-pub type TrustBackedAssetsInstance = pallet_assets::Instance1;
+pub(crate) type TrustBackedAssetsInstance = pallet_assets::Instance1;
 pub type TrustBackedAssetsCall = pallet_assets::Call<Runtime, TrustBackedAssetsInstance>;
 impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type ApprovalDeposit = ApprovalDeposit;


### PR DESCRIPTION
Contains all changes coming from comments for `pop-api` in #132 . Please not that in the comments I used #279 (incorrect) and #280. They both count for this PR.

Changes include:
- Example refactor
- refactor (pop api): ChainExtensionMethodApi type + small doc changes.
- refactor (integration tests): 
1. remove clone
2. terminology to token & token_id
3. refactor env_logger
4. refactor helper functions from pallet assets
5. probably some more small ones.