### PR TITLE
feat: return `UnApproved` in `decrease_allowance` instead of `saturating_sub`

### DIFF
--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -514,12 +514,10 @@ pub mod pallet {
 			use Read::*;
 			match request {
 				TotalSupply(token) => ReadResult::TotalSupply(AssetsOf::<T>::total_supply(token)),
-				BalanceOf { token, owner } => {
-					ReadResult::BalanceOf(AssetsOf::<T>::balance(token, owner))
-				},
-				Allowance { token, owner, spender } => {
-					ReadResult::Allowance(AssetsOf::<T>::allowance(token, &owner, &spender))
-				},
+				BalanceOf { token, owner } =>
+					ReadResult::BalanceOf(AssetsOf::<T>::balance(token, owner)),
+				Allowance { token, owner, spender } =>
+					ReadResult::Allowance(AssetsOf::<T>::allowance(token, &owner, &spender)),
 				TokenName(token) => ReadResult::TokenName(<AssetsOf<T> as MetadataInspect<
 					AccountIdOf<T>,
 				>>::name(token)),

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -286,6 +286,11 @@ fn decrease_allowance_works() {
 			Ok(Some(WeightInfo::approve(0, 0)).into())
 		);
 		assert_eq!(Assets::allowance(token, &owner, &spender), value);
+		// `UnApproved` error returned if current allowance is decreased more than the owner balance.
+		assert_noop!(
+			Fungibles::decrease_allowance(signed(owner), token, spender, value * 2),
+			AssetsError::Unapproved
+		);
 		// Decrease allowance successfully.
 		assert_eq!(
 			Fungibles::decrease_allowance(signed(owner), token, spender, value / 2),
@@ -295,13 +300,6 @@ fn decrease_allowance_works() {
 		System::assert_last_event(
 			Event::Approval { token, owner, spender, value: value / 2 }.into(),
 		);
-		// Saturating if current allowance is decreased more than the owner balance.
-		assert_eq!(
-			Fungibles::decrease_allowance(signed(owner), token, spender, value),
-			Ok(Some(WeightInfo::approve(0, 1)).into())
-		);
-		assert_eq!(Assets::allowance(token, &owner, &spender), 0);
-		System::assert_last_event(Event::Approval { token, owner, spender, value: 0 }.into());
 	});
 }
 
@@ -677,8 +675,8 @@ mod read_weights {
 }
 
 mod ensure_codec_indexes {
-	use super::{Encode, RuntimeCall, *};
-	use crate::{fungibles, fungibles::Call::*, mock::RuntimeCall::Fungibles};
+	use super::{Encode, *};
+	use crate::{fungibles, mock::RuntimeCall::Fungibles};
 
 	#[test]
 	fn ensure_read_variant_indexes() {

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -286,7 +286,7 @@ fn decrease_allowance_works() {
 			Ok(Some(WeightInfo::approve(0, 0)).into())
 		);
 		assert_eq!(Assets::allowance(token, &owner, &spender), value);
-		// `UnApproved` error returned if current allowance is decreased more than the allowance.
+		// "Unapproved" error is returned if the current allowance is less than `value`.
 		assert_noop!(
 			Fungibles::decrease_allowance(signed(owner), token, spender, value * 2),
 			AssetsError::Unapproved

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -286,7 +286,8 @@ fn decrease_allowance_works() {
 			Ok(Some(WeightInfo::approve(0, 0)).into())
 		);
 		assert_eq!(Assets::allowance(token, &owner, &spender), value);
-		// `UnApproved` error returned if current allowance is decreased more than the owner balance.
+		// `UnApproved` error returned if current allowance is decreased more than the owner
+		// balance.
 		assert_noop!(
 			Fungibles::decrease_allowance(signed(owner), token, spender, value * 2),
 			AssetsError::Unapproved

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -286,8 +286,7 @@ fn decrease_allowance_works() {
 			Ok(Some(WeightInfo::approve(0, 0)).into())
 		);
 		assert_eq!(Assets::allowance(token, &owner, &spender), value);
-		// `UnApproved` error returned if current allowance is decreased more than the owner
-		// balance.
+		// `UnApproved` error returned if current allowance is decreased more than the allowance.
 		assert_noop!(
 			Fungibles::decrease_allowance(signed(owner), token, spender, value * 2),
 			AssetsError::Unapproved

--- a/pop-api/integration-tests/src/fungibles/mod.rs
+++ b/pop-api/integration-tests/src/fungibles/mod.rs
@@ -267,7 +267,7 @@ fn decrease_allowance_works() {
 			Err(Module { index: 52, error: [16, 0] }),
 		);
 		assets::thaw(&addr, token);
-		// Error returned if current allowance is decreased more than the owner balance.
+		// `UnApproved` error returned if current allowance is decreased more than the allowance.
 		assert_eq!(
 			decrease_allowance(&addr, token, &BOB, amount * 2),
 			Err(Module { index: 52, error: [10, 0] }),

--- a/pop-api/integration-tests/src/fungibles/mod.rs
+++ b/pop-api/integration-tests/src/fungibles/mod.rs
@@ -267,7 +267,7 @@ fn decrease_allowance_works() {
 			Err(Module { index: 52, error: [16, 0] }),
 		);
 		assets::thaw(&addr, token);
-		// `UnApproved` error returned if current allowance is decreased more than the allowance.
+		// "Unapproved" error is returned if the current allowance is less than `value`.
 		assert_eq!(
 			decrease_allowance(&addr, token, &BOB, amount * 2),
 			Err(Module { index: 52, error: [10, 0] }),

--- a/pop-api/integration-tests/src/fungibles/mod.rs
+++ b/pop-api/integration-tests/src/fungibles/mod.rs
@@ -267,9 +267,14 @@ fn decrease_allowance_works() {
 			Err(Module { index: 52, error: [16, 0] }),
 		);
 		assets::thaw(&addr, token);
+		// Error returned if current allowance is decreased more than the owner balance.
+		assert_eq!(
+			decrease_allowance(&addr, token, &BOB, amount * 2),
+			Err(Module { index: 52, error: [10, 0] }),
+		);
 		// Successfully decrease allowance.
 		let allowance_before = Assets::allowance(token, &addr, &BOB);
-		assert_ok!(decrease_allowance(&addr, 0, &BOB, amount / 2 - 1 * UNIT));
+		assert_ok!(decrease_allowance(&addr, token, &BOB, amount / 2 - 1 * UNIT));
 		let allowance_after = Assets::allowance(token, &addr, &BOB);
 		assert_eq!(allowance_before - allowance_after, amount / 2 - 1 * UNIT);
 		// Token is not live, i.e. frozen or being destroyed.


### PR DESCRIPTION
`Fungibles::decrease_allowance()` saturating_sub the value, it should `checked_sub` and throw an error instead. Hence, we don't have to handle `InsufficientAllowance` on the contract side.

Benefit of this approach is to make the implementation of PSP22 example contract cleaner. 