### PR TITLE
feat: token name & symbol return `Option`

### DIFF
--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -91,10 +91,10 @@ pub mod pallet {
 		BalanceOf(BalanceOf<T>),
 		/// Allowance for a spender approved by an owner, for a specified token.
 		Allowance(BalanceOf<T>),
-		/// Name of the specified token.
-		TokenName(Vec<u8>),
-		/// Symbol for the specified token.
-		TokenSymbol(Vec<u8>),
+		/// Name of the specified token, if available.
+		TokenName(Option<Vec<u8>>),
+		/// Symbol for the specified token, if available.
+		TokenSymbol(Option<Vec<u8>>),
 		/// Decimals for the specified token.
 		TokenDecimals(u8),
 		/// Whether the specified token exists.
@@ -514,12 +514,14 @@ pub mod pallet {
 					ReadResult::BalanceOf(AssetsOf::<T>::balance(token, owner)),
 				Allowance { token, owner, spender } =>
 					ReadResult::Allowance(AssetsOf::<T>::allowance(token, &owner, &spender)),
-				TokenName(token) => ReadResult::TokenName(<AssetsOf<T> as MetadataInspect<
-					AccountIdOf<T>,
-				>>::name(token)),
-				TokenSymbol(token) => ReadResult::TokenSymbol(<AssetsOf<T> as MetadataInspect<
-					AccountIdOf<T>,
-				>>::symbol(token)),
+				TokenName(token) => ReadResult::TokenName(
+					Some(<AssetsOf<T> as MetadataInspect<AccountIdOf<T>>>::name(token))
+						.filter(|v| !v.is_empty()),
+				),
+				TokenSymbol(token) => ReadResult::TokenSymbol(
+					Some(<AssetsOf<T> as MetadataInspect<AccountIdOf<T>>>::symbol(token))
+						.filter(|v| !v.is_empty()),
+				),
 				TokenDecimals(token) => ReadResult::TokenDecimals(
 					<AssetsOf<T> as MetadataInspect<AccountIdOf<T>>>::decimals(token),
 				),

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -47,7 +47,7 @@ mod encoding_read_result {
 
 	#[test]
 	fn token_name() {
-		let mut name = Some(vec![42, 42, 42, 42, 42]);
+		let mut name = Some("some name".as_bytes().to_vec());
 		assert_eq!(ReadResult::TokenName::<Test>(name.clone()).encode(), name.encode());
 		name = None;
 		assert_eq!(ReadResult::TokenName::<Test>(name.clone()).encode(), name.encode());
@@ -55,7 +55,7 @@ mod encoding_read_result {
 
 	#[test]
 	fn token_symbol() {
-		let mut symbol = Some(vec![42, 42, 42, 42, 42]);
+		let mut symbol = Some("some symbol".as_bytes().to_vec());
 		assert_eq!(ReadResult::TokenSymbol::<Test>(symbol.clone()).encode(), symbol.encode());
 		symbol = None;
 		assert_eq!(ReadResult::TokenSymbol::<Test>(symbol.clone()).encode(), symbol.encode());
@@ -498,15 +498,9 @@ fn token_metadata_works() {
 		let name: Vec<u8> = vec![11, 12, 13];
 		let symbol: Vec<u8> = vec![21, 22, 23];
 		let decimals: u8 = 69;
-		assert_eq!(Fungibles::read(TokenName(TOKEN)), ReadResult::TokenName(Default::default()));
-		assert_eq!(
-			Fungibles::read(TokenSymbol(TOKEN)),
-			ReadResult::TokenSymbol(Default::default())
-		);
-		assert_eq!(
-			Fungibles::read(TokenDecimals(TOKEN)),
-			ReadResult::TokenDecimals(Default::default())
-		);
+		assert_eq!(Fungibles::read(TokenName(TOKEN)), ReadResult::TokenName(None));
+		assert_eq!(Fungibles::read(TokenSymbol(TOKEN)), ReadResult::TokenSymbol(None));
+		assert_eq!(Fungibles::read(TokenDecimals(TOKEN)), ReadResult::TokenDecimals(0));
 		assets::create_and_set_metadata(ALICE, TOKEN, name.clone(), symbol.clone(), decimals);
 		assert_eq!(Fungibles::read(TokenName(TOKEN)), ReadResult::TokenName(Some(name)));
 		assert_eq!(Fungibles::read(TokenSymbol(TOKEN)), ReadResult::TokenSymbol(Some(symbol)));

--- a/pallets/api/src/fungibles/tests.rs
+++ b/pallets/api/src/fungibles/tests.rs
@@ -47,13 +47,17 @@ mod encoding_read_result {
 
 	#[test]
 	fn token_name() {
-		let name = vec![42, 42, 42, 42, 42];
+		let mut name = Some(vec![42, 42, 42, 42, 42]);
+		assert_eq!(ReadResult::TokenName::<Test>(name.clone()).encode(), name.encode());
+		name = None;
 		assert_eq!(ReadResult::TokenName::<Test>(name.clone()).encode(), name.encode());
 	}
 
 	#[test]
 	fn token_symbol() {
-		let symbol = vec![42, 42, 42, 42, 42];
+		let mut symbol = Some(vec![42, 42, 42, 42, 42]);
+		assert_eq!(ReadResult::TokenSymbol::<Test>(symbol.clone()).encode(), symbol.encode());
+		symbol = None;
 		assert_eq!(ReadResult::TokenSymbol::<Test>(symbol.clone()).encode(), symbol.encode());
 	}
 
@@ -504,11 +508,14 @@ fn token_metadata_works() {
 			ReadResult::TokenDecimals(Default::default())
 		);
 		assets::create_and_set_metadata(ALICE, TOKEN, name.clone(), symbol.clone(), decimals);
-		assert_eq!(Fungibles::read(TokenName(TOKEN)), ReadResult::TokenName(name));
-		assert_eq!(Fungibles::read(TokenSymbol(TOKEN)), ReadResult::TokenSymbol(symbol));
+		assert_eq!(Fungibles::read(TokenName(TOKEN)), ReadResult::TokenName(Some(name)));
+		assert_eq!(Fungibles::read(TokenSymbol(TOKEN)), ReadResult::TokenSymbol(Some(symbol)));
 		assert_eq!(Fungibles::read(TokenDecimals(TOKEN)), ReadResult::TokenDecimals(decimals));
-		assert_eq!(Fungibles::read(TokenName(TOKEN)).encode(), Assets::name(TOKEN).encode());
-		assert_eq!(Fungibles::read(TokenSymbol(TOKEN)).encode(), Assets::symbol(TOKEN).encode());
+		assert_eq!(Fungibles::read(TokenName(TOKEN)).encode(), Some(Assets::name(TOKEN)).encode());
+		assert_eq!(
+			Fungibles::read(TokenSymbol(TOKEN)).encode(),
+			Some(Assets::symbol(TOKEN)).encode()
+		);
 		assert_eq!(
 			Fungibles::read(TokenDecimals(TOKEN)).encode(),
 			Assets::decimals(TOKEN).encode(),
@@ -677,8 +684,8 @@ mod read_weights {
 }
 
 mod ensure_codec_indexes {
-	use super::{Encode, RuntimeCall, *};
-	use crate::{fungibles, fungibles::Call::*, mock::RuntimeCall::Fungibles};
+	use super::{Encode, *};
+	use crate::{fungibles, mock::RuntimeCall::Fungibles};
 
 	#[test]
 	fn ensure_read_variant_indexes() {

--- a/pop-api/integration-tests/contracts/fungibles/lib.rs
+++ b/pop-api/integration-tests/contracts/fungibles/lib.rs
@@ -126,12 +126,12 @@ mod fungibles {
 		/// - token_decimals
 
 		#[ink(message)]
-		pub fn token_name(&self, token: TokenId) -> Result<Vec<u8>> {
+		pub fn token_name(&self, token: TokenId) -> Result<Option<Vec<u8>>> {
 			api::token_name(token)
 		}
 
 		#[ink(message)]
-		pub fn token_symbol(&self, token: TokenId) -> Result<Vec<u8>> {
+		pub fn token_symbol(&self, token: TokenId) -> Result<Option<Vec<u8>>> {
 			api::token_symbol(token)
 		}
 

--- a/pop-api/integration-tests/src/fungibles/mod.rs
+++ b/pop-api/integration-tests/src/fungibles/mod.rs
@@ -297,7 +297,6 @@ fn token_metadata_works() {
 		// Token does not exist.
 		assert_eq!(token_name(&addr, TOKEN_ID), Ok(None));
 		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(None));
-		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(Assets::decimals(TOKEN_ID)));
 		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(0));
 		// Create Token.
 		assets::create_and_set_metadata(&addr, TOKEN_ID, name.clone(), symbol.clone(), decimals);

--- a/pop-api/integration-tests/src/fungibles/mod.rs
+++ b/pop-api/integration-tests/src/fungibles/mod.rs
@@ -295,18 +295,16 @@ fn token_metadata_works() {
 		let decimals: u8 = 69;
 
 		// Token does not exist.
-		assert_eq!(token_name(&addr, TOKEN_ID), Ok(Assets::name(TOKEN_ID)));
-		assert_eq!(token_name(&addr, TOKEN_ID), Ok(Vec::<u8>::new()));
-		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(Assets::symbol(TOKEN_ID)));
-		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(Vec::<u8>::new()));
+		assert_eq!(token_name(&addr, TOKEN_ID), Ok(None));
+		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(None));
 		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(Assets::decimals(TOKEN_ID)));
 		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(0));
 		// Create Token.
 		assets::create_and_set_metadata(&addr, TOKEN_ID, name.clone(), symbol.clone(), decimals);
-		assert_eq!(token_name(&addr, TOKEN_ID), Ok(Assets::name(TOKEN_ID)));
-		assert_eq!(token_name(&addr, TOKEN_ID), Ok(name));
-		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(Assets::symbol(TOKEN_ID)));
-		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(symbol));
+		assert_eq!(token_name(&addr, TOKEN_ID), Ok(Some(Assets::name(TOKEN_ID))));
+		assert_eq!(token_name(&addr, TOKEN_ID), Ok(Some(name)));
+		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(Some(Assets::symbol(TOKEN_ID))));
+		assert_eq!(token_symbol(&addr, TOKEN_ID), Ok(Some(symbol)));
 		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(Assets::decimals(TOKEN_ID)));
 		assert_eq!(token_decimals(&addr, TOKEN_ID), Ok(decimals));
 	});

--- a/pop-api/integration-tests/src/fungibles/utils.rs
+++ b/pop-api/integration-tests/src/fungibles/utils.rs
@@ -40,15 +40,18 @@ pub(super) fn allowance(
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn token_name(addr: &AccountId32, token_id: TokenId) -> Result<Vec<u8>, Error> {
+pub(super) fn token_name(addr: &AccountId32, token_id: TokenId) -> Result<Option<Vec<u8>>, Error> {
 	let result = do_bare_call("token_name", addr, token_id.encode());
-	decoded::<Result<Vec<u8>, Error>>(result.clone())
+	decoded::<Result<Option<Vec<u8>>, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 
-pub(super) fn token_symbol(addr: &AccountId32, token_id: TokenId) -> Result<Vec<u8>, Error> {
+pub(super) fn token_symbol(
+	addr: &AccountId32,
+	token_id: TokenId,
+) -> Result<Option<Vec<u8>>, Error> {
 	let result = do_bare_call("token_symbol", addr, token_id.encode());
-	decoded::<Result<Vec<u8>, Error>>(result.clone())
+	decoded::<Result<Option<Vec<u8>>, Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
 }
 

--- a/pop-api/src/v0/fungibles/mod.rs
+++ b/pop-api/src/v0/fungibles/mod.rs
@@ -6,11 +6,6 @@
 //! 3. Management
 //! 4. PSP-22 Mintable & Burnable
 
-use crate::{
-	constants::{ASSETS, BALANCES, FUNGIBLES},
-	primitives::{AccountId, Balance, TokenId},
-	ChainExtensionMethodApi, Result, StatusCode,
-};
 use constants::*;
 pub use errors::*;
 pub use events::*;
@@ -18,6 +13,12 @@ use ink::prelude::vec::Vec;
 pub use management::*;
 pub use metadata::*;
 pub use traits::*;
+
+use crate::{
+	constants::{ASSETS, BALANCES, FUNGIBLES},
+	primitives::{AccountId, Balance, TokenId},
+	ChainExtensionMethodApi, Result, StatusCode,
+};
 
 pub mod errors;
 pub mod events;
@@ -177,28 +178,30 @@ pub fn burn(token: TokenId, account: AccountId, value: Balance) -> Result<()> {
 pub mod metadata {
 	use super::*;
 
-	/// Returns the name of the specified token.
+	/// Returns the name of the specified token, if available.
+	///
+	/// `None` if not existing.
 	///
 	/// # Parameters
 	/// - `token` - The token.
 	#[inline]
-	pub fn token_name(token: TokenId) -> Result<Vec<u8>> {
+	pub fn token_name(token: TokenId) -> Result<Option<Vec<u8>>> {
 		build_read_state(TOKEN_NAME)
 			.input::<TokenId>()
-			.output::<Result<Vec<u8>>, true>()
+			.output::<Result<Option<Vec<u8>>>, true>()
 			.handle_error_code::<StatusCode>()
 			.call(&(token))
 	}
 
-	/// Returns the symbol for the specified token.
+	/// Returns the symbol for the specified token, if available.
 	///
 	/// # Parameters
 	/// - `token` - The token.
 	#[inline]
-	pub fn token_symbol(token: TokenId) -> Result<Vec<u8>> {
+	pub fn token_symbol(token: TokenId) -> Result<Option<Vec<u8>>> {
 		build_read_state(TOKEN_SYMBOL)
 			.input::<TokenId>()
-			.output::<Result<Vec<u8>>, true>()
+			.output::<Result<Option<Vec<u8>>>, true>()
 			.handle_error_code::<StatusCode>()
 			.call(&(token))
 	}

--- a/pop-api/src/v0/fungibles/mod.rs
+++ b/pop-api/src/v0/fungibles/mod.rs
@@ -180,8 +180,6 @@ pub mod metadata {
 
 	/// Returns the name of the specified token, if available.
 	///
-	/// `None` if not existing.
-	///
 	/// # Parameters
 	/// - `token` - The token.
 	#[inline]


### PR DESCRIPTION
The psp22 standard returns an `Option<String>`. In stead of having the contract needing to add additional logic, we handle it in the pallet.