### PR TITLE
refactor: pop primitive conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10782,6 +10782,7 @@ dependencies = [
  "enum-iterator",
  "parity-scale-codec",
  "scale-info",
+ "sp-runtime",
 ]
 
 [[package]]

--- a/pop-api/examples/fungibles/tests.rs
+++ b/pop-api/examples/fungibles/tests.rs
@@ -1,7 +1,9 @@
 use drink::{
 	assert_ok, assert_runtime_err,
-	devnet::{account_id_from_slice, AccountId, ArithmeticError, Balance, Runtime, RuntimeError},
-	pallet_assets::Error::*,
+	devnet::{
+		account_id_from_slice, AccountId, ArithmeticError, AssetsError, Balance, Runtime,
+		RuntimeError,
+	},
 	session::Session,
 	utils::{call, last_contract_event},
 	AssetsAPI, TestExternalities, NO_SALT,
@@ -163,7 +165,10 @@ fn transfer_fails_with_no_account() {
 		deploy(&mut session, "new", vec![TOKEN.to_string(), MIN_BALANCE.to_string()]).unwrap();
 	session.set_actor(contract.clone());
 	// `pallet-assets` returns `NoAccount` error.
-	assert_runtime_err!(transfer(&mut session, ALICE, AMOUNT), RuntimeError::Assets(NoAccount));
+	assert_runtime_err!(
+		transfer(&mut session, ALICE, AMOUNT),
+		RuntimeError::Assets(AssetsError::NoAccount),
+	);
 }
 
 #[drink::test(sandbox = Pop)]
@@ -208,7 +213,7 @@ fn transfer_fails_with_token_not_live() {
 	// `pallet-assets` returns `AssetNotLive` error.
 	assert_runtime_err!(
 		transfer(&mut session, BOB, AMOUNT / 2),
-		RuntimeError::Assets(AssetNotLive)
+		RuntimeError::Assets(AssetsError::AssetNotLive),
 	);
 }
 
@@ -303,7 +308,7 @@ fn transfer_from_fails_with_token_not_live() {
 	// `pallet-assets` returns `AssetNotLive` error.
 	assert_runtime_err!(
 		transfer_from(&mut session, ALICE, BOB, AMOUNT / 2),
-		RuntimeError::Assets(AssetNotLive)
+		RuntimeError::Assets(AssetsError::AssetNotLive),
 	);
 }
 
@@ -359,7 +364,10 @@ fn approve_fails_with_token_not_live(mut session: Session) {
 	// Token is not live, i.e. frozen or being destroyed.
 	assert_ok!(session.sandbox().start_destroy(&TOKEN));
 	// `pallet-assets` returns `AssetNotLive` error.
-	assert_runtime_err!(approve(&mut session, ALICE, AMOUNT), RuntimeError::Assets(AssetNotLive));
+	assert_runtime_err!(
+		approve(&mut session, ALICE, AMOUNT),
+		RuntimeError::Assets(AssetsError::AssetNotLive),
+	);
 }
 
 #[drink::test(sandbox = Pop)]
@@ -430,7 +438,7 @@ fn increase_allowance_fails_with_token_not_live(mut session: Session) {
 	// `pallet-assets` returns `AssetNotLive` error.
 	assert_runtime_err!(
 		increase_allowance(&mut session, ALICE, AMOUNT),
-		RuntimeError::Assets(AssetNotLive),
+		RuntimeError::Assets(AssetsError::AssetNotLive),
 	);
 }
 
@@ -517,7 +525,7 @@ fn decrease_allowance_fails_with_token_not_live(mut session: Session) {
 	// `pallet-assets` returns `AssetNotLive` error.
 	assert_runtime_err!(
 		decrease_allowance(&mut session, ALICE, AMOUNT),
-		RuntimeError::Assets(AssetNotLive),
+		RuntimeError::Assets(AssetsError::AssetNotLive),
 	);
 }
 
@@ -606,7 +614,10 @@ fn mint_fails_with_no_permission(mut session: Session) {
 	assert_ok!(session.sandbox().create(&(TOKEN + 1), &BOB, MIN_BALANCE));
 	assert_ok!(deploy(&mut session, "existing", vec![(TOKEN + 1).to_string()]));
 	// `pallet-assets` returns `NoPermission` error.
-	assert_runtime_err!(mint(&mut session, BOB, AMOUNT), RuntimeError::Assets(NoPermission));
+	assert_runtime_err!(
+		mint(&mut session, BOB, AMOUNT),
+		RuntimeError::Assets(AssetsError::NoPermission),
+	);
 }
 
 #[drink::test(sandbox = Pop)]
@@ -632,7 +643,7 @@ fn mint_fails_with_arithmetic_overflow(mut session: Session) {
 	// Total supply increased by `value` exceeds maximal value of `u128` type.
 	assert_runtime_err!(
 		mint(&mut session, ALICE, u128::MAX),
-		RuntimeError::Raw(ArithmeticError::Overflow.into())
+		RuntimeError::Raw(ArithmeticError::Overflow.into()),
 	);
 }
 
@@ -646,7 +657,10 @@ fn mint_fails_with_token_not_live(mut session: Session) {
 	// Token is not live, i.e. frozen or being destroyed.
 	assert_ok!(session.sandbox().start_destroy(&TOKEN));
 	// `pallet-assets` returns `AssetNotLive` error.
-	assert_runtime_err!(mint(&mut session, ALICE, AMOUNT), RuntimeError::Assets(AssetNotLive));
+	assert_runtime_err!(
+		mint(&mut session, ALICE, AMOUNT),
+		RuntimeError::Assets(AssetsError::AssetNotLive),
+	);
 }
 
 #[drink::test(sandbox = Pop)]
@@ -682,7 +696,10 @@ fn burn_fails_with_no_permission(mut session: Session) {
 	assert_ok!(session.sandbox().mint_into(&(TOKEN + 1), &BOB, AMOUNT));
 	assert_ok!(deploy(&mut session, "existing", vec![(TOKEN + 1).to_string()]));
 	// `pallet-assets` returns `NoPermission` error.
-	assert_runtime_err!(burn(&mut session, BOB, AMOUNT), RuntimeError::Assets(NoPermission));
+	assert_runtime_err!(
+		burn(&mut session, BOB, AMOUNT),
+		RuntimeError::Assets(AssetsError::NoPermission),
+	);
 }
 
 #[drink::test(sandbox = Pop)]
@@ -719,7 +736,10 @@ fn burn_fails_with_token_not_live(mut session: Session) {
 	// Token is not live, i.e. frozen or being destroyed.
 	assert_ok!(session.sandbox().start_destroy(&TOKEN));
 	// `pallet-assets` returns `IncorrectStatus` error.
-	assert_runtime_err!(burn(&mut session, ALICE, AMOUNT), RuntimeError::Assets(IncorrectStatus));
+	assert_runtime_err!(
+		burn(&mut session, ALICE, AMOUNT),
+		RuntimeError::Assets(AssetsError::IncorrectStatus),
+	);
 }
 
 #[drink::test(sandbox = Pop)]

--- a/pop-api/examples/fungibles/tests.rs
+++ b/pop-api/examples/fungibles/tests.rs
@@ -1,9 +1,7 @@
 use drink::{
 	assert_ok, assert_runtime_err,
-	devnet::{
-		account_id_from_slice, AccountId, ArithmeticError, AssetsError, Balance, Runtime,
-		RuntimeError,
-	},
+	devnet::{account_id_from_slice, AccountId, ArithmeticError, Balance, Runtime, RuntimeError},
+	pallet_assets::Error::*,
 	session::Session,
 	utils::{call, last_contract_event},
 	AssetsAPI, TestExternalities, NO_SALT,
@@ -165,10 +163,7 @@ fn transfer_fails_with_no_account() {
 		deploy(&mut session, "new", vec![TOKEN.to_string(), MIN_BALANCE.to_string()]).unwrap();
 	session.set_actor(contract.clone());
 	// `pallet-assets` returns `NoAccount` error.
-	assert_runtime_err!(
-		transfer(&mut session, ALICE, AMOUNT),
-		RuntimeError::Assets(AssetsError::NoAccount),
-	);
+	assert_runtime_err!(transfer(&mut session, ALICE, AMOUNT), RuntimeError::Assets(NoAccount));
 }
 
 #[drink::test(sandbox = Pop)]
@@ -213,7 +208,7 @@ fn transfer_fails_with_token_not_live() {
 	// `pallet-assets` returns `AssetNotLive` error.
 	assert_runtime_err!(
 		transfer(&mut session, BOB, AMOUNT / 2),
-		RuntimeError::Assets(AssetsError::AssetNotLive),
+		RuntimeError::Assets(AssetNotLive)
 	);
 }
 
@@ -308,7 +303,7 @@ fn transfer_from_fails_with_token_not_live() {
 	// `pallet-assets` returns `AssetNotLive` error.
 	assert_runtime_err!(
 		transfer_from(&mut session, ALICE, BOB, AMOUNT / 2),
-		RuntimeError::Assets(AssetsError::AssetNotLive),
+		RuntimeError::Assets(AssetNotLive)
 	);
 }
 
@@ -364,10 +359,7 @@ fn approve_fails_with_token_not_live(mut session: Session) {
 	// Token is not live, i.e. frozen or being destroyed.
 	assert_ok!(session.sandbox().start_destroy(&TOKEN));
 	// `pallet-assets` returns `AssetNotLive` error.
-	assert_runtime_err!(
-		approve(&mut session, ALICE, AMOUNT),
-		RuntimeError::Assets(AssetsError::AssetNotLive),
-	);
+	assert_runtime_err!(approve(&mut session, ALICE, AMOUNT), RuntimeError::Assets(AssetNotLive));
 }
 
 #[drink::test(sandbox = Pop)]
@@ -438,7 +430,7 @@ fn increase_allowance_fails_with_token_not_live(mut session: Session) {
 	// `pallet-assets` returns `AssetNotLive` error.
 	assert_runtime_err!(
 		increase_allowance(&mut session, ALICE, AMOUNT),
-		RuntimeError::Assets(AssetsError::AssetNotLive),
+		RuntimeError::Assets(AssetNotLive),
 	);
 }
 
@@ -525,7 +517,7 @@ fn decrease_allowance_fails_with_token_not_live(mut session: Session) {
 	// `pallet-assets` returns `AssetNotLive` error.
 	assert_runtime_err!(
 		decrease_allowance(&mut session, ALICE, AMOUNT),
-		RuntimeError::Assets(AssetsError::AssetNotLive),
+		RuntimeError::Assets(AssetNotLive),
 	);
 }
 
@@ -614,10 +606,7 @@ fn mint_fails_with_no_permission(mut session: Session) {
 	assert_ok!(session.sandbox().create(&(TOKEN + 1), &BOB, MIN_BALANCE));
 	assert_ok!(deploy(&mut session, "existing", vec![(TOKEN + 1).to_string()]));
 	// `pallet-assets` returns `NoPermission` error.
-	assert_runtime_err!(
-		mint(&mut session, BOB, AMOUNT),
-		RuntimeError::Assets(AssetsError::NoPermission),
-	);
+	assert_runtime_err!(mint(&mut session, BOB, AMOUNT), RuntimeError::Assets(NoPermission));
 }
 
 #[drink::test(sandbox = Pop)]
@@ -643,7 +632,7 @@ fn mint_fails_with_arithmetic_overflow(mut session: Session) {
 	// Total supply increased by `value` exceeds maximal value of `u128` type.
 	assert_runtime_err!(
 		mint(&mut session, ALICE, u128::MAX),
-		RuntimeError::Raw(ArithmeticError::Overflow.into()),
+		RuntimeError::Raw(ArithmeticError::Overflow.into())
 	);
 }
 
@@ -657,10 +646,7 @@ fn mint_fails_with_token_not_live(mut session: Session) {
 	// Token is not live, i.e. frozen or being destroyed.
 	assert_ok!(session.sandbox().start_destroy(&TOKEN));
 	// `pallet-assets` returns `AssetNotLive` error.
-	assert_runtime_err!(
-		mint(&mut session, ALICE, AMOUNT),
-		RuntimeError::Assets(AssetsError::AssetNotLive),
-	);
+	assert_runtime_err!(mint(&mut session, ALICE, AMOUNT), RuntimeError::Assets(AssetNotLive));
 }
 
 #[drink::test(sandbox = Pop)]
@@ -696,10 +682,7 @@ fn burn_fails_with_no_permission(mut session: Session) {
 	assert_ok!(session.sandbox().mint_into(&(TOKEN + 1), &BOB, AMOUNT));
 	assert_ok!(deploy(&mut session, "existing", vec![(TOKEN + 1).to_string()]));
 	// `pallet-assets` returns `NoPermission` error.
-	assert_runtime_err!(
-		burn(&mut session, BOB, AMOUNT),
-		RuntimeError::Assets(AssetsError::NoPermission),
-	);
+	assert_runtime_err!(burn(&mut session, BOB, AMOUNT), RuntimeError::Assets(NoPermission));
 }
 
 #[drink::test(sandbox = Pop)]
@@ -736,10 +719,7 @@ fn burn_fails_with_token_not_live(mut session: Session) {
 	// Token is not live, i.e. frozen or being destroyed.
 	assert_ok!(session.sandbox().start_destroy(&TOKEN));
 	// `pallet-assets` returns `IncorrectStatus` error.
-	assert_runtime_err!(
-		burn(&mut session, ALICE, AMOUNT),
-		RuntimeError::Assets(AssetsError::IncorrectStatus),
-	);
+	assert_runtime_err!(burn(&mut session, ALICE, AMOUNT), RuntimeError::Assets(IncorrectStatus));
 }
 
 #[drink::test(sandbox = Pop)]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -8,10 +8,11 @@ version = "0.0.0"
 [dependencies]
 codec.workspace = true
 scale-info.workspace = true
+sp-runtime.workspace = true
 
 [dev-dependencies]
 enum-iterator = "2.1.0"
 
 [features]
 default = [ "std" ]
-std = [ "codec/std", "scale-info/std" ]
+std = [ "codec/std", "scale-info/std", "sp-runtime/std" ]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -7,6 +7,7 @@ use codec::{Decode, Encode};
 use enum_iterator::Sequence;
 #[cfg(feature = "std")]
 use scale_info::TypeInfo;
+use sp_runtime::{DispatchError, ModuleError};
 pub use v0::*;
 
 /// The identifier of a token.
@@ -107,6 +108,57 @@ pub mod v0 {
 			}
 		}
 
+		impl From<DispatchError> for Error {
+			fn from(error: DispatchError) -> Self {
+				use sp_runtime::{
+					ArithmeticError::*, DispatchError::*, TokenError::*, TransactionalError::*,
+				};
+				// Mappings exist here to avoid taking a dependency of sp_runtime on pop-primitives
+				match error {
+					Other(_message) => {
+						// Note: lossy conversion: message not used due to returned contract status
+						// code size limitation
+						Error::Other
+					},
+					CannotLookup => Error::CannotLookup,
+					BadOrigin => Error::BadOrigin,
+					Module(error) => {
+						// Note: message not used
+						let ModuleError { index, error, message: _message } = error;
+						Error::Module { index, error: [error[0], error[1]] }
+					},
+					ConsumerRemaining => Error::ConsumerRemaining,
+					NoProviders => Error::NoProviders,
+					TooManyConsumers => Error::TooManyConsumers,
+					Token(error) => Error::Token(match error {
+						FundsUnavailable => TokenError::FundsUnavailable,
+						OnlyProvider => TokenError::OnlyProvider,
+						BelowMinimum => TokenError::BelowMinimum,
+						CannotCreate => TokenError::CannotCreate,
+						UnknownAsset => TokenError::UnknownAsset,
+						Frozen => TokenError::Frozen,
+						Unsupported => TokenError::Unsupported,
+						CannotCreateHold => TokenError::CannotCreateHold,
+						NotExpendable => TokenError::NotExpendable,
+						Blocked => TokenError::Blocked,
+					}),
+					Arithmetic(error) => Error::Arithmetic(match error {
+						Underflow => ArithmeticError::Underflow,
+						Overflow => ArithmeticError::Overflow,
+						DivisionByZero => ArithmeticError::DivisionByZero,
+					}),
+					Transactional(error) => Error::Transactional(match error {
+						LimitReached => TransactionalError::LimitReached,
+						NoLayer => TransactionalError::NoLayer,
+					}),
+					Exhausted => Error::Exhausted,
+					Corruption => Error::Corruption,
+					Unavailable => Error::Unavailable,
+					RootNotAllowed => Error::RootNotAllowed,
+				}
+			}
+		}
+
 		/// Description of what went wrong when trying to complete an operation on a token.
 		#[derive(Encode, Decode, Debug)]
 		#[cfg_attr(test, derive(Sequence))]
@@ -194,6 +246,59 @@ pub mod v0 {
 				let error: Error = invalid_value.into();
 				assert_eq!(error, DecodingFailed,);
 			});
+		}
+
+		// Compare all the different `DispatchError` variants with the expected `Error`.
+		#[test]
+		fn from_dispatch_error_to_error_works() {
+			use sp_runtime::DispatchError::*;
+			let test_cases = vec![
+				(Other(""), (Error::Other)),
+				(Other("UnknownCall"), Error::Other),
+				(Other("DecodingFailed"), Error::Other),
+				(Other("Random"), (Error::Other)),
+				(CannotLookup, Error::CannotLookup),
+				(BadOrigin, Error::BadOrigin),
+				(
+					Module(ModuleError { index: 1, error: [2, 0, 0, 0], message: Some("hallo") }),
+					Error::Module { index: 1, error: [2, 0] },
+				),
+				(
+					Module(ModuleError { index: 1, error: [2, 2, 0, 0], message: Some("hallo") }),
+					Error::Module { index: 1, error: [2, 2] },
+				),
+				(
+					Module(ModuleError { index: 1, error: [2, 2, 2, 0], message: Some("hallo") }),
+					Error::Module { index: 1, error: [2, 2] },
+				),
+				(
+					Module(ModuleError { index: 1, error: [2, 2, 2, 4], message: Some("hallo") }),
+					Error::Module { index: 1, error: [2, 2] },
+				),
+				(ConsumerRemaining, Error::ConsumerRemaining),
+				(NoProviders, Error::NoProviders),
+				(TooManyConsumers, Error::TooManyConsumers),
+				(
+					Token(sp_runtime::TokenError::BelowMinimum),
+					Error::Token(TokenError::BelowMinimum),
+				),
+				(
+					Arithmetic(sp_runtime::ArithmeticError::Overflow),
+					Error::Arithmetic(ArithmeticError::Overflow),
+				),
+				(
+					Transactional(sp_runtime::TransactionalError::LimitReached),
+					Error::Transactional(TransactionalError::LimitReached),
+				),
+				(Exhausted, Error::Exhausted),
+				(Corruption, Error::Corruption),
+				(Unavailable, Error::Unavailable),
+				(RootNotAllowed, Error::RootNotAllowed),
+			];
+			for (dispatch_error, expected) in test_cases {
+				let error = Error::from(dispatch_error);
+				assert_eq!(error, expected);
+			}
 		}
 	}
 }

--- a/runtime/devnet/src/config/api/mod.rs
+++ b/runtime/devnet/src/config/api/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 	config::assets::TrustBackedAssetsInstance, fungibles, Runtime, RuntimeCall, RuntimeEvent,
 };
 
-pub mod versioning;
+mod versioning;
 
 type DecodingFailedError = DecodingFailed<Runtime>;
 type DecodesAs<Output, Logger = ()> = pallet_api::extension::DecodesAs<

--- a/runtime/devnet/src/config/api/versioning.rs
+++ b/runtime/devnet/src/config/api/versioning.rs
@@ -99,21 +99,13 @@ impl From<VersionedError> for u32 {
 
 // Type for conversion to a versioned `pop_primitives::Error` to avoid taking a dependency of
 // sp-runtime on pop-primitives.
-pub struct V0Error(pub pop_primitives::v0::Error);
+struct V0Error(pop_primitives::v0::Error);
 impl From<DispatchError> for V0Error {
 	fn from(error: DispatchError) -> Self {
 		use pop_primitives::v0::*;
-		use sp_runtime::{ArithmeticError::*, TokenError::*, TransactionalError::*};
 		use DispatchError::*;
 		// Mappings exist here to avoid taking a dependency of sp_runtime on pop-primitives
 		Self(match error {
-			Other(_message) => {
-				// Note: lossy conversion: message not used due to returned contract status code
-				// size limitation
-				Error::Other
-			},
-			CannotLookup => Error::CannotLookup,
-			BadOrigin => Error::BadOrigin,
 			Module(error) => {
 				// Note: message not used
 				let ModuleError { index, error, message: _message } = error;
@@ -129,34 +121,7 @@ impl From<DispatchError> for V0Error {
 					Error::Module { index, error: [error[0], error[1]] }
 				}
 			},
-			ConsumerRemaining => Error::ConsumerRemaining,
-			NoProviders => Error::NoProviders,
-			TooManyConsumers => Error::TooManyConsumers,
-			Token(error) => Error::Token(match error {
-				FundsUnavailable => TokenError::FundsUnavailable,
-				OnlyProvider => TokenError::OnlyProvider,
-				BelowMinimum => TokenError::BelowMinimum,
-				CannotCreate => TokenError::CannotCreate,
-				UnknownAsset => TokenError::UnknownAsset,
-				Frozen => TokenError::Frozen,
-				Unsupported => TokenError::Unsupported,
-				CannotCreateHold => TokenError::CannotCreateHold,
-				NotExpendable => TokenError::NotExpendable,
-				Blocked => TokenError::Blocked,
-			}),
-			Arithmetic(error) => Error::Arithmetic(match error {
-				Underflow => ArithmeticError::Underflow,
-				Overflow => ArithmeticError::Overflow,
-				DivisionByZero => ArithmeticError::DivisionByZero,
-			}),
-			Transactional(error) => Error::Transactional(match error {
-				LimitReached => TransactionalError::LimitReached,
-				NoLayer => TransactionalError::NoLayer,
-			}),
-			Exhausted => Error::Exhausted,
-			Corruption => Error::Corruption,
-			Unavailable => Error::Unavailable,
-			RootNotAllowed => Error::RootNotAllowed,
+			_ => error.into(),
 		})
 	}
 }

--- a/runtime/devnet/src/config/mod.rs
+++ b/runtime/devnet/src/config/mod.rs
@@ -1,5 +1,4 @@
-// Public due to pop drink crate.
-pub mod api;
+mod api;
 // Public due to pop api integration tests crate.
 pub mod assets;
 mod contracts;


### PR DESCRIPTION
Moving the conversion code `DispatchError -> V0Error` for `pop_primitives::Error` in `devnet/versioning.rs` to `pop_primitives` to handle `DispatchError -> pop_primitives::Error`.