### PR TITLE
refactor: primitive error conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10782,6 +10782,7 @@ dependencies = [
  "enum-iterator",
  "parity-scale-codec",
  "scale-info",
+ "sp-runtime",
 ]
 
 [[package]]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -8,10 +8,14 @@ version = "0.0.0"
 [dependencies]
 codec.workspace = true
 scale-info.workspace = true
+sp-runtime.workspace = true
 
 [dev-dependencies]
 enum-iterator = "2.1.0"
 
 [features]
 default = [ "std" ]
-std = [ "codec/std", "scale-info/std" ]
+
+std = [ "codec/std", "scale-info/std", "sp-runtime/std" ]
+
+runtime = []

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -15,5 +15,5 @@ enum-iterator = "2.1.0"
 
 [features]
 default = [ "std" ]
-runtime = []
+runtime = [  ]
 std = [ "codec/std", "scale-info/std", "sp-runtime/std" ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -15,7 +15,5 @@ enum-iterator = "2.1.0"
 
 [features]
 default = [ "std" ]
-
-std = [ "codec/std", "scale-info/std", "sp-runtime/std" ]
-
 runtime = []
+std = [ "codec/std", "scale-info/std", "sp-runtime/std" ]

--- a/runtime/devnet/Cargo.toml
+++ b/runtime/devnet/Cargo.toml
@@ -24,7 +24,7 @@ smallvec.workspace = true
 # Local
 pallet-api.workspace = true
 pop-chain-extension.workspace = true
-pop-primitives.workspace = true
+pop-primitives = { workspace = true, features = [ "runtime" ] }
 pop-runtime-common.workspace = true
 
 # Substrate

--- a/runtime/devnet/src/config/api/versioning.rs
+++ b/runtime/devnet/src/config/api/versioning.rs
@@ -103,17 +103,9 @@ struct V0Error(pop_primitives::v0::Error);
 impl From<DispatchError> for V0Error {
 	fn from(error: DispatchError) -> Self {
 		use pop_primitives::v0::*;
-		use sp_runtime::{ArithmeticError::*, TokenError::*, TransactionalError::*};
 		use DispatchError::*;
 		// Mappings exist here to avoid taking a dependency of sp_runtime on pop-primitives
 		Self(match error {
-			Other(_message) => {
-				// Note: lossy conversion: message not used due to returned contract status code
-				// size limitation
-				Error::Other
-			},
-			CannotLookup => Error::CannotLookup,
-			BadOrigin => Error::BadOrigin,
 			Module(error) => {
 				// Note: message not used
 				let ModuleError { index, error, message: _message } = error;
@@ -129,34 +121,7 @@ impl From<DispatchError> for V0Error {
 					Error::Module { index, error: [error[0], error[1]] }
 				}
 			},
-			ConsumerRemaining => Error::ConsumerRemaining,
-			NoProviders => Error::NoProviders,
-			TooManyConsumers => Error::TooManyConsumers,
-			Token(error) => Error::Token(match error {
-				FundsUnavailable => TokenError::FundsUnavailable,
-				OnlyProvider => TokenError::OnlyProvider,
-				BelowMinimum => TokenError::BelowMinimum,
-				CannotCreate => TokenError::CannotCreate,
-				UnknownAsset => TokenError::UnknownAsset,
-				Frozen => TokenError::Frozen,
-				Unsupported => TokenError::Unsupported,
-				CannotCreateHold => TokenError::CannotCreateHold,
-				NotExpendable => TokenError::NotExpendable,
-				Blocked => TokenError::Blocked,
-			}),
-			Arithmetic(error) => Error::Arithmetic(match error {
-				Underflow => ArithmeticError::Underflow,
-				Overflow => ArithmeticError::Overflow,
-				DivisionByZero => ArithmeticError::DivisionByZero,
-			}),
-			Transactional(error) => Error::Transactional(match error {
-				LimitReached => TransactionalError::LimitReached,
-				NoLayer => TransactionalError::NoLayer,
-			}),
-			Exhausted => Error::Exhausted,
-			Corruption => Error::Corruption,
-			Unavailable => Error::Unavailable,
-			RootNotAllowed => Error::RootNotAllowed,
+			_ => error.into(),
 		})
 	}
 }


### PR DESCRIPTION
Moving the conversion code `DispatchError -> V0Error` for `pop_primitives::Error` in `devnet/versioning.rs` to `pop_primitives` to handle `DispatchError -> pop_primitives::Error`.

We need this refactor for for the pop-api refactor in example contract to work. For more context, please take a look at: 
- refactor pop-api error in example contract: https://github.com/r0gue-io/pop-node/pull/324#:~:text=feat%3A%20show%20reviewers,in%20contract%20size.
- pop-drink error type conversion: https://github.com/r0gue-io/pop-drink/pull/14