### PR TITLE
feat: messaging api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7375,9 +7375,11 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "ismp",
  "log",
  "pallet-assets",
  "pallet-balances",
+ "pallet-ismp",
  "parity-scale-codec",
  "pop-chain-extension",
  "scale-info",
@@ -7385,6 +7387,8 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "staging-xcm",
+ "staging-xcm-executor",
 ]
 
 [[package]]

--- a/networks/devnet.toml
+++ b/networks/devnet.toml
@@ -3,12 +3,6 @@
 [relaychain]
 chain = "paseo-local"
 
-[relaychain.runtime_genesis_patch.balances]
-balances = [
-    # Pop sovereign account
-    ["5Ec4AhPKXY9B4ayGshkz2wFMh7N8gP7XKfAvtt1cigpG9FkJ", 60000000000000000],
-]
-
 [[relaychain.nodes]]
 name = "alice"
 rpc_port = 8833
@@ -18,6 +12,7 @@ validator = true
 name = "bob"
 validator = true
 
+# Pop
 [[parachains]]
 id = 4001
 default_command = "./target/release/pop-node"
@@ -41,14 +36,35 @@ args = [
     "-lruntime::contracts=debug",
     "-lruntime::revive=trace",
     "-lruntime::revive::strace=trace",
+    "-lxcm=trace",
     "--enable-offchain-indexing=true"
 ]
 
+# Asset Hub
 [[parachains]]
 id = 1000
-chain = "asset-hub-rococo-local"
+chain = "asset-hub-paseo-local"
+
+[parachains.genesis_overrides.balances]
+balances = [
+    # Pop sovereign account
+    ["5Eg2fnt8cGL5CBhRRhi59abAwb3SPoAdPJpN9qY7bQqpzpf6", 60000000000000000],
+]
 
 [[parachains.collators]]
 name = "asset-hub"
 args = ["-lxcm=trace"]
 rpc_port = 9977
+
+# Channels
+[[hrmp_channels]]
+sender = 1000
+recipient = 4001
+max_capacity = 1000
+max_message_size = 1024
+
+[[hrmp_channels]]
+sender = 4001
+recipient = 1000
+max_capacity = 1000
+max_message_size = 1024

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -92,6 +92,7 @@ substrate-build-script-utils.workspace = true
 pallet-multisig.workspace = true
 
 [features]
+default = [ "ismp" ]
 runtime-benchmarks = [
 	"cumulus-primitives-core/runtime-benchmarks",
 	"frame-benchmarking-cli/runtime-benchmarks",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -315,7 +315,7 @@ fn devnet_genesis(
 	id: ParaId,
 ) -> serde_json::Value {
 	use pop_runtime_devnet::EXISTENTIAL_DEPOSIT;
-	let asset_hub = ismp_parachain::ParachainData { id: 1000, slot_duration: 6000 };
+	let asset_hub = ismp_parachain::ParachainData { id: 1000, slot_duration: 12_000 };
 
 	serde_json::json!({
 		"balances": {

--- a/pallets/api/Cargo.toml
+++ b/pallets/api/Cargo.toml
@@ -22,12 +22,18 @@ frame-benchmarking.workspace = true
 frame-support.workspace = true
 frame-system.workspace = true
 pallet-assets.workspace = true
+sp-core.workspace = true
 sp-runtime.workspace = true
 sp-std.workspace = true
 
+# Cross chain
+ismp.workspace = true
+pallet-ismp.workspace = true
+xcm.workspace = true
+xcm-executor.workspace = true
+
 [dev-dependencies]
 pallet-balances.workspace = true
-sp-core.workspace = true
 sp-io.workspace = true
 
 [features]
@@ -45,8 +51,10 @@ std = [
 	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
+	"ismp/std",
 	"pallet-assets/std",
 	"pallet-balances/std",
+	"pallet-ismp/std",
 	"pop-chain-extension/std",
 	"scale-info/std",
 	"sp-core/std",

--- a/pallets/api/src/lib.rs
+++ b/pallets/api/src/lib.rs
@@ -5,6 +5,7 @@ use frame_support::pallet_prelude::Weight;
 
 pub mod extension;
 pub mod fungibles;
+pub mod messaging;
 #[cfg(test)]
 mod mock;
 

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -1,0 +1,407 @@
+//! TODO: pallet docs.
+
+use codec::{Decode, Encode};
+use frame_support::{
+	pallet_prelude::MaxEncodedLen,
+	traits::{fungible::Inspect, Get, OriginTrait},
+};
+use frame_system::pallet_prelude::*;
+pub use pallet::*;
+use scale_info::TypeInfo;
+use sp_core::H256;
+use sp_runtime::{traits::Saturating, BoundedVec, SaturatedConversion};
+use sp_std::vec::Vec;
+use transports::{
+	ismp::{self as ismp, FeeMetadata, IsmpDispatcher},
+	xcm::{self as xcm, Location, QueryHandler, QueryId, VersionedLocation},
+};
+use xcm::VersionedResponse;
+
+use super::Weight;
+
+/// Messaging transports.
+pub mod transports;
+
+type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+type BlockNumberOf<T> = BlockNumberFor<T>;
+type BalanceOf<T> = <<T as Config>::Deposit as Inspect<AccountIdOf<T>>>::Balance;
+type MessageId = u64;
+
+#[frame_support::pallet]
+pub mod pallet {
+
+	use frame_support::{
+		dispatch::DispatchResult,
+		pallet_prelude::*,
+		traits::tokens::{fungible::hold::Mutate, Precision::Exact},
+	};
+	use sp_core::H256;
+	use sp_runtime::traits::TryConvert;
+
+	use super::*;
+
+	/// Configuration of the pallet by specifying the parameters and types on which it depends.
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// Because this pallet emits events, it depends on the runtime's definition of an event.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		type OriginConverter: TryConvert<Self::RuntimeOrigin, Location>;
+
+		#[pallet::constant]
+		type ByteFee: Get<BalanceOf<Self>>;
+
+		/// The deposit mechanism.
+		type Deposit: Mutate<Self::AccountId, Reason = Self::RuntimeHoldReason>
+			+ Inspect<Self::AccountId>;
+
+		#[pallet::constant]
+		type IsmpByteFee: Get<BalanceOf<Self>>;
+
+		/// The ISMP message dispatcher.
+		type IsmpDispatcher: IsmpDispatcher<Account = Self::AccountId, Balance = BalanceOf<Self>>;
+
+		/// The maximum length of any additional application-specific metadata relating to a
+		/// request.
+		#[pallet::constant]
+		type MaxContextLen: Get<u32>;
+		/// The maximum length of outbound (posted) data.
+		#[pallet::constant]
+		type MaxDataLen: Get<u32>;
+		#[pallet::constant]
+		type MaxKeys: Get<u32>;
+		#[pallet::constant]
+		type MaxKeyLen: Get<u32>;
+
+		#[pallet::constant]
+		type MaxResponseLen: Get<u32>;
+		#[pallet::constant]
+		type MaxRemovals: Get<u32>;
+
+		/// Overarching hold reason.
+		type RuntimeHoldReason: From<HoldReason>;
+
+		type Xcm: QueryHandler<BlockNumber = BlockNumberOf<Self>>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::storage]
+	pub(super) type Messages<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		T::AccountId,
+		Blake2_128Concat,
+		MessageId,
+		Message<T>,
+		OptionQuery,
+	>;
+
+	#[pallet::storage]
+	pub(super) type IsmpRequests<T: Config> =
+		StorageMap<_, Identity, H256, (T::AccountId, MessageId), OptionQuery>;
+
+	#[pallet::storage]
+	pub(super) type XcmQueries<T: Config> =
+		StorageMap<_, Identity, QueryId, (T::AccountId, MessageId), OptionQuery>;
+
+	/// The events that can be emitted.
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		IsmpGetDispatched { origin: T::AccountId, id: MessageId },
+		IsmpGetResponseReceived { dest: T::AccountId, id: MessageId },
+		IsmpPostDispatched { origin: T::AccountId, id: MessageId },
+		IsmpPostResponseReceived { dest: T::AccountId, id: MessageId },
+		XcmQueryCreated { origin: T::AccountId, id: MessageId },
+		XcmResponseReceived { dest: T::AccountId, id: MessageId },
+		Removed { origin: T::AccountId, messages: Vec<MessageId> },
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		DispatchFailed,
+		InvalidMessage,
+		OriginConversionFailed,
+		MessageExists,
+		RequestPending,
+	}
+
+	/// A reason for the pallet placing a hold on funds.
+	#[pallet::composite_enum]
+	pub enum HoldReason {
+		/// Held for the duration of a message's lifespan.
+		#[codec(index = 0)]
+		Messaging,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight(Weight::zero())] // todo: benchmarking after consolidating storage
+		pub fn send(_origin: OriginFor<T>, _id: MessageId) -> DispatchResult {
+			// e.g. Message::StateQuery { dest: Parachain(1000), storage_keys: vec![] }
+			// e.g. Message::Transact { dest: Parachain(1000), call: vec![] }
+			todo!("Reserved for messaging abstractions")
+		}
+
+		// TODO: does ismp allow querying to ensure that specified para id is supported?
+		#[pallet::call_index(1)]
+		#[pallet::weight(Weight::zero())] // todo: benchmarking after consolidating storage
+		pub fn ismp_get(
+			origin: OriginFor<T>,
+			id: MessageId,
+			message: ismp::Get<T>,
+			fee: BalanceOf<T>,
+		) -> DispatchResult {
+			let origin = ensure_signed(origin)?;
+
+			// Calculate deposit and place on hold.
+			let deposit = Self::calculate_deposit(message.calculate_deposit());
+			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
+
+			// Process message by dispatching request via ISMP.
+			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
+			let commitment = T::IsmpDispatcher::default()
+				.dispatch_request(message.into(), FeeMetadata { payer: origin.clone(), fee })
+				.map_err(|_| Error::<T>::DispatchFailed)?;
+
+			// Store commitment for lookup on response, message for querying, response/timeout
+			// handling.
+			IsmpRequests::<T>::insert(&commitment, (&origin, id));
+			Messages::<T>::insert(&origin, id, Message::Ismp { deposit, commitment });
+			Pallet::<T>::deposit_event(Event::<T>::IsmpGetDispatched { origin, id });
+			Ok(())
+		}
+
+		// TODO: does ismp allow querying to ensure that specified para id is supported?
+		#[pallet::call_index(2)]
+		#[pallet::weight(Weight::zero())] // todo: benchmarking after consolidating storage
+		pub fn ismp_post(
+			origin: OriginFor<T>,
+			id: MessageId,
+			message: ismp::Post<T>,
+			fee: BalanceOf<T>,
+		) -> DispatchResult {
+			let origin = ensure_signed(origin)?;
+
+			// Calculate deposit and place on hold.
+			let deposit = Self::calculate_deposit(message.calculate_deposit());
+			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
+
+			// Process message by dispatching request via ISMP.
+			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
+			let commitment = T::IsmpDispatcher::default()
+				.dispatch_request(message.into(), FeeMetadata { payer: origin.clone(), fee })
+				.map_err(|_| Error::<T>::DispatchFailed)?;
+
+			// Store commitment for lookup on response, message for querying, response/timeout
+			// handling.
+			IsmpRequests::<T>::insert(&commitment, (&origin, id));
+			Messages::<T>::insert(&origin, id, Message::Ismp { deposit, commitment });
+			Pallet::<T>::deposit_event(Event::<T>::IsmpPostDispatched { origin, id });
+			Ok(())
+		}
+
+		#[pallet::call_index(3)]
+		#[pallet::weight(Weight::zero())] // todo: benchmarking after consolidating storage
+		pub fn xcm_new_query(
+			origin: OriginFor<T>,
+			id: u64,
+			responder: VersionedLocation,
+			timeout: BlockNumberOf<T>,
+		) -> DispatchResult {
+			let origin = ensure_signed(origin)?;
+
+			// Calculate deposit and place on hold.
+			let deposit = Self::calculate_deposit(Default::default());
+			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
+
+			// Process message by creating new query via XCM.
+			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
+			let responder =
+				Location::try_from(responder).map_err(|_| Error::<T>::OriginConversionFailed)?;
+			// TODO: neater way of doing this
+			let querier = T::OriginConverter::try_convert(T::RuntimeOrigin::signed(origin.clone()))
+				.map_err(|_| Error::<T>::OriginConversionFailed)?;
+			let query_id = T::Xcm::new_query(responder, timeout, querier);
+
+			// Store query id for later lookup on response, message for querying, response/timeout
+			// handling.
+			XcmQueries::<T>::insert(&query_id, (&origin, id));
+			Messages::<T>::insert(&origin, id, Message::XcmQuery { deposit, query_id });
+			Pallet::<T>::deposit_event(Event::<T>::XcmQueryCreated { origin, id });
+			Ok(())
+		}
+
+		// Remove a request/response, returning any deposit previously taken.
+		#[pallet::call_index(4)]
+		#[pallet::weight(Weight::zero())] // todo: benchmarking after consolidating storage
+		pub fn remove(
+			origin: OriginFor<T>,
+			messages: BoundedVec<MessageId, T::MaxRemovals>,
+		) -> DispatchResult {
+			let origin = ensure_signed(origin)?;
+			for id in &messages {
+				// Ensure request exists and is not pending.
+				let deposit = match Messages::<T>::take(&origin, id) {
+					Some(message) => match message {
+						Message::Ismp { .. } | Message::XcmQuery { .. } => {
+							return Err(Error::<T>::RequestPending.into());
+						},
+						Message::IsmpResponse { commitment, deposit, .. } => {
+							IsmpRequests::<T>::remove(commitment);
+							deposit
+						},
+						Message::XcmResponse { query_id, deposit, .. } => {
+							XcmQueries::<T>::remove(query_id);
+							deposit
+						},
+						Message::IsmpTimedOut { .. } => {
+							todo!()
+						},
+					},
+					None => {
+						return Err(Error::<T>::InvalidMessage.into());
+					},
+				};
+				// Return deposit.
+				T::Deposit::release(&HoldReason::Messaging.into(), &origin, deposit, Exact)?;
+			}
+			Pallet::<T>::deposit_event(Event::<T>::Removed {
+				origin,
+				messages: messages.into_inner(),
+			});
+			Ok(())
+		}
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	// Calculate the deposit required for a particular request.
+	fn calculate_deposit(mut deposit: BalanceOf<T>) -> BalanceOf<T> {
+		// Add amount for `Requests` key.
+		let request_key_len: BalanceOf<T> =
+			(T::AccountId::max_encoded_len() + MessageId::max_encoded_len()).saturated_into();
+		deposit.saturating_accrue(T::ByteFee::get() * request_key_len);
+
+		// Add amount for `Requests` value.
+		let request_value_len = Status::max_encoded_len() +
+			BalanceOf::<T>::max_encoded_len() +
+			// todo: could be optimised away
+			Option::<H256>::max_encoded_len();
+		deposit.saturating_accrue(T::ByteFee::get() * request_value_len.saturated_into());
+
+		// Add amount for storing response.
+		deposit.saturating_accrue(T::ByteFee::get() * request_key_len);
+		deposit.saturating_accrue(T::ByteFee::get() * T::MaxResponseLen::get().saturated_into());
+
+		deposit
+	}
+}
+
+#[derive(Clone, Decode, Debug, Encode, MaxEncodedLen, PartialEq, TypeInfo)]
+pub enum Status {
+	Pending,
+	TimedOut,
+	Complete,
+}
+
+#[derive(Encode, Decode, Debug, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(PartialEq, Clone))]
+#[repr(u8)]
+#[allow(clippy::unnecessary_cast)]
+pub enum Read<T: Config> {
+	#[codec(index = 0)]
+	Poll((T::AccountId, MessageId)),
+	#[codec(index = 1)]
+	Get((T::AccountId, MessageId)),
+	#[codec(index = 2)]
+	QueryId((T::AccountId, MessageId)),
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(PartialEq, Clone))]
+pub enum ReadResult<T: Config> {
+	Poll(Option<Status>),
+	Get(Option<BoundedVec<u8, T::MaxResponseLen>>),
+	QueryId(Option<QueryId>),
+}
+
+impl<T: Config> ReadResult<T> {
+	pub fn encode(&self) -> Vec<u8> {
+		use ReadResult::*;
+		match self {
+			Poll(status) => status.encode(),
+			Get(response) => response.encode(),
+			QueryId(query_id) => query_id.encode(),
+		}
+	}
+}
+
+impl<T: Config> crate::Read for Pallet<T> {
+	type Read = Read<T>;
+	type Result = ReadResult<T>;
+
+	fn weight(_read: &Self::Read) -> Weight {
+		// TODO: implement benchmarks
+		Weight::zero()
+	}
+
+	fn read(request: Self::Read) -> Self::Result {
+		match request {
+			Read::Poll(request) =>
+				ReadResult::Poll(Messages::<T>::get(request.0, request.1).map(|m| match m {
+					Message::Ismp { .. } | Message::XcmQuery { .. } => Status::Pending,
+					Message::IsmpTimedOut { .. } => Status::TimedOut,
+					Message::IsmpResponse { .. } | Message::XcmResponse { .. } => Status::Complete,
+				})),
+			Read::Get(request) =>
+				ReadResult::Get(Messages::<T>::get(request.0, request.1).and_then(|m| match m {
+					Message::IsmpResponse { response, .. } => Some(response),
+					Message::XcmResponse { response, .. } =>
+						Some(response.encode().try_into().unwrap()), // todo: handle error
+					_ => None,
+				})),
+			Read::QueryId(request) => ReadResult::QueryId(
+				Messages::<T>::get(request.0, request.1).and_then(|m| match m {
+					Message::XcmQuery { query_id, .. } | Message::XcmResponse { query_id, .. } =>
+						Some(query_id),
+					_ => None,
+				}),
+			),
+		}
+	}
+}
+
+trait CalculateDeposit<Deposit> {
+	fn calculate_deposit(&self) -> Deposit;
+}
+
+#[derive(Clone, Debug, Encode, Eq, Decode, MaxEncodedLen, PartialEq, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+enum Message<T: Config> {
+	Ismp {
+		commitment: H256,
+		deposit: BalanceOf<T>,
+	},
+	IsmpTimedOut {
+		commitment: H256,
+		deposit: BalanceOf<T>,
+	},
+	IsmpResponse {
+		commitment: H256,
+		deposit: BalanceOf<T>,
+		response: BoundedVec<u8, T::MaxResponseLen>,
+	},
+	XcmQuery {
+		query_id: QueryId,
+		deposit: BalanceOf<T>,
+	},
+	XcmResponse {
+		query_id: QueryId,
+		deposit: BalanceOf<T>,
+		response: VersionedResponse,
+	},
+}

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -1,0 +1,235 @@
+use core::marker::PhantomData;
+
+pub(crate) use ::ismp::dispatcher::{FeeMetadata, IsmpDispatcher};
+use ::ismp::{
+	dispatcher::{
+		DispatchGet,
+		DispatchRequest::{self},
+	},
+	host::StateMachine,
+};
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::{
+	pallet_prelude::Weight, traits::Get as _, CloneNoBound, DebugNoBound, EqNoBound,
+	PartialEqNoBound,
+};
+use ismp::{
+	dispatcher::DispatchPost,
+	module::IsmpModule,
+	router::{GetResponse, PostRequest, PostResponse, Request::*, Response, Timeout},
+	Error,
+};
+use pallet_ismp::weights::IsmpModuleWeight;
+use scale_info::TypeInfo;
+use sp_core::{keccak_256, H256};
+use sp_runtime::{BoundedVec, SaturatedConversion, Saturating};
+
+use crate::messaging::{
+	pallet::{Config, Event, IsmpRequests, Messages, Pallet},
+	BalanceOf, CalculateDeposit, MessageId,
+};
+
+pub const ID: [u8; 3] = *b"pop";
+
+type DbWeightOf<T> = <T as frame_system::Config>::DbWeight;
+
+#[derive(Encode, EqNoBound, CloneNoBound, DebugNoBound, Decode, PartialEqNoBound, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+pub enum Message<T: Config> {
+	Get(Get<T>),
+	Post(Post<T>),
+}
+
+impl<T: Config> From<Message<T>> for DispatchRequest {
+	fn from(value: Message<T>) -> Self {
+		match value {
+			Message::Get(get) => get.into(),
+			Message::Post(post) => post.into(),
+		}
+	}
+}
+
+#[derive(Encode, EqNoBound, CloneNoBound, DebugNoBound, Decode, PartialEqNoBound, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+pub struct Get<T: Config> {
+	// TODO: Option<u32> to support relay?
+	pub(crate) dest: u32,
+	pub(crate) height: u32,
+	pub(crate) timeout: u64,
+	pub(crate) context: BoundedVec<u8, T::MaxContextLen>,
+	pub(crate) keys: BoundedVec<BoundedVec<u8, T::MaxKeyLen>, T::MaxKeys>,
+}
+
+impl<T: Config> From<Get<T>> for DispatchGet {
+	fn from(value: Get<T>) -> Self {
+		DispatchGet {
+			dest: StateMachine::Polkadot(value.dest),
+			from: ID.into(),
+			keys: value.keys.into_iter().map(|key| key.into_inner()).collect(),
+			height: value.height.into(),
+			context: value.context.into_inner(),
+			timeout: value.timeout,
+		}
+	}
+}
+
+impl<T: Config> From<Get<T>> for DispatchRequest {
+	fn from(value: Get<T>) -> Self {
+		DispatchRequest::Get(value.into())
+	}
+}
+
+impl<T: Config> CalculateDeposit<BalanceOf<T>> for Get<T> {
+	fn calculate_deposit(&self) -> BalanceOf<T> {
+		let len = self.dest.encoded_size() +
+			self.height.encoded_size() +
+			self.timeout.encoded_size() +
+			self.context.len() +
+			self.keys.iter().map(|k| k.len()).sum::<usize>();
+		calculate_deposit::<T>(T::IsmpByteFee::get() * len.saturated_into())
+	}
+}
+
+#[derive(Encode, EqNoBound, CloneNoBound, DebugNoBound, Decode, PartialEqNoBound, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+pub struct Post<T: Config> {
+	// TODO: Option<u32> to support relay?
+	pub(crate) dest: u32,
+	pub(crate) timeout: u64,
+	pub(crate) data: BoundedVec<u8, T::MaxDataLen>,
+}
+
+impl<T: Config> From<Post<T>> for DispatchPost {
+	fn from(value: Post<T>) -> Self {
+		DispatchPost {
+			dest: StateMachine::Polkadot(value.dest),
+			from: ID.into(),
+			to: ID.into(),
+			timeout: value.timeout,
+			body: value.data.into_inner(),
+		}
+	}
+}
+
+impl<T: Config> From<Post<T>> for DispatchRequest {
+	fn from(value: Post<T>) -> Self {
+		DispatchRequest::Post(value.into())
+	}
+}
+
+impl<T: Config> CalculateDeposit<BalanceOf<T>> for Post<T> {
+	fn calculate_deposit(&self) -> BalanceOf<T> {
+		let len = self.dest.encoded_size() + self.timeout.encoded_size() + self.data.len();
+		calculate_deposit::<T>(T::IsmpByteFee::get() * len.saturated_into())
+	}
+}
+
+pub struct Handler<T>(PhantomData<T>);
+impl<T> Handler<T> {
+	pub fn new() -> Self {
+		Self(PhantomData)
+	}
+}
+
+impl<T: Config> IsmpModule for Handler<T> {
+	fn on_accept(&self, _request: PostRequest) -> Result<(), Error> {
+		todo!()
+	}
+
+	fn on_response(&self, response: Response) -> Result<(), Error> {
+		let ((origin, id), response) = match response {
+			Response::Get(GetResponse { get, values }) => {
+				// hash request to determine key for original message id lookup
+				let id = IsmpRequests::<T>::get(H256::from(keccak_256(
+					&ismp::router::Request::Get(get).encode(),
+				)))
+				.ok_or(Error::Custom("request not found".into()))?;
+				Pallet::<T>::deposit_event(Event::<T>::IsmpGetResponseReceived {
+					dest: id.0.clone(),
+					id: id.1,
+				});
+				(id, values.encode())
+			},
+			Response::Post(PostResponse { post, response, .. }) => {
+				// hash request to determine key for original message id lookup
+				let id = IsmpRequests::<T>::get(H256::from(keccak_256(&Post(post).encode())))
+					.ok_or(Error::Custom("request not found".into()))?;
+				Pallet::<T>::deposit_event(Event::<T>::IsmpPostResponseReceived {
+					dest: id.0.clone(),
+					id: id.1,
+				});
+				(id, response)
+			},
+		};
+
+		// Store values for later retrieval
+		let response: BoundedVec<u8, T::MaxResponseLen> =
+			response.try_into().map_err(|_| Error::Custom("response exceeds max".into()))?;
+		Messages::<T>::try_mutate(&origin, &id, |message| {
+			let Some(super::super::Message::Ismp { deposit, commitment }) = message else {
+				return Err(Error::Custom("message not found".into()))
+			};
+			*message = Some(super::super::Message::IsmpResponse {
+				deposit: *deposit,
+				commitment: *commitment,
+				response,
+			});
+			Ok(())
+		})?;
+		Ok(())
+	}
+
+	fn on_timeout(&self, timeout: Timeout) -> Result<(), Error> {
+		match timeout {
+			Timeout::Request(request) => {
+				// hash request to determine key for original request id lookup
+				let id = match request {
+					Get(get) => H256::from(keccak_256(&get.encode())),
+					Post(post) => H256::from(keccak_256(&post.encode())),
+				};
+				let key =
+					IsmpRequests::<T>::get(id).ok_or(Error::Custom("request not found".into()))?;
+				Messages::<T>::try_mutate(key.0, key.1, |message| {
+					let Some(super::super::Message::Ismp { deposit, commitment }) = message else {
+						return Err(Error::Custom("message not found".into()))
+					};
+					*message = Some(super::super::Message::IsmpTimedOut {
+						deposit: *deposit,
+						commitment: *commitment,
+					});
+					Ok(())
+				})?;
+				Ok(())
+			},
+			Timeout::Response(_response) => {
+				todo!()
+			},
+		}
+	}
+}
+
+// TODO: replace with benchmarked weight functions
+impl<T: Config> IsmpModuleWeight for Pallet<T> {
+	fn on_accept(&self, _request: &PostRequest) -> Weight {
+		todo!()
+	}
+
+	fn on_timeout(&self, _timeout: &Timeout) -> Weight {
+		DbWeightOf::<T>::get().reads_writes(2, 1)
+	}
+
+	fn on_response(&self, _response: &Response) -> Weight {
+		DbWeightOf::<T>::get().reads_writes(2, 2)
+	}
+}
+
+fn calculate_deposit<T: Config>(mut deposit: BalanceOf<T>) -> BalanceOf<T> {
+	// Add amount for `IsmpRequests` lookup.
+	let key_len: BalanceOf<T> =
+		(T::AccountId::max_encoded_len() + MessageId::max_encoded_len()).saturated_into();
+	deposit.saturating_accrue(
+		T::ByteFee::get() * (H256::max_encoded_len().saturated_into::<BalanceOf<T>>() + key_len),
+	);
+
+	deposit
+}

--- a/pallets/api/src/messaging/transports/mod.rs
+++ b/pallets/api/src/messaging/transports/mod.rs
@@ -1,0 +1,4 @@
+/// Messaging using the Interoperable State Machine Protocol (ISMP).
+pub mod ismp;
+/// Messaging using Polkadot's Cross-Consensus Messaging (XCM).
+pub(crate) mod xcm;

--- a/pallets/api/src/messaging/transports/xcm.rs
+++ b/pallets/api/src/messaging/transports/xcm.rs
@@ -1,0 +1,49 @@
+use frame_support::pallet_prelude::Weight;
+use xcm::latest::{Response, XcmContext};
+pub(crate) use xcm::{
+	latest::{Location, QueryId},
+	VersionedLocation, VersionedResponse,
+};
+use xcm_executor::traits::OnResponse;
+pub(crate) use xcm_executor::traits::QueryHandler;
+
+use crate::messaging::{
+	pallet::{Messages, XcmQueries},
+	Config, Event, Pallet,
+};
+
+impl<T: Config> OnResponse for Pallet<T> {
+	// todo: check origin and querier
+	fn expecting_response(_origin: &Location, query_id: u64, _querier: Option<&Location>) -> bool {
+		// todo: weight?
+		XcmQueries::<T>::contains_key(query_id)
+	}
+
+	// todo: check origin and querier
+	fn on_response(
+		_origin: &Location,
+		query_id: u64,
+		_querier: Option<&Location>,
+		response: Response,
+		_max_weight: Weight,
+		_context: &XcmContext,
+	) -> Weight {
+		let (origin, id) = XcmQueries::<T>::get(query_id).unwrap(); // TODO: handle error
+
+		Messages::<T>::mutate(&origin, &id, |message| {
+			let Some(super::super::Message::XcmQuery { query_id, deposit }) = message else {
+				panic!() // TODO: handle error
+			};
+			*message = Some(super::super::Message::XcmResponse {
+				deposit: *deposit,
+				query_id: *query_id,
+				// TODO: remove this in favour of using the data stored in the xcm-pallet until
+				// taken.
+				response: VersionedResponse::from(response),
+			});
+		});
+		Pallet::<T>::deposit_event(Event::<T>::XcmResponseReceived { dest: origin, id });
+		// todo: weight
+		Weight::zero()
+	}
+}

--- a/pop-api/Cargo.toml
+++ b/pop-api/Cargo.toml
@@ -23,4 +23,5 @@ path = "src/lib.rs"
 [features]
 default = [ "std" ]
 fungibles = [  ]
+messaging = [  ]
 std = [ "ink/std", "pop-primitives/std" ]

--- a/pop-api/examples/messaging/Cargo.toml
+++ b/pop-api/examples/messaging/Cargo.toml
@@ -5,7 +5,8 @@ name = "messaging"
 version = "0.1.0"
 
 [dependencies]
-ink = { git = "https://github.com/use-ink/ink", branch = "xcm", default-features = false }
+ink = { git = "https://github.com/r0gue-io/ink", branch = "sub0", default-features = false }
+polkavm-derive = "0.11.0"
 pop-api = { path = "../../../pop-api", default-features = false, features = [ "messaging" ] }
 
 [lib]

--- a/pop-api/examples/messaging/Cargo.toml
+++ b/pop-api/examples/messaging/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+authors = [ "R0GUE <go@r0gue.io>" ]
+edition = "2021"
+name = "messaging"
+version = "0.1.0"
+
+[dependencies]
+ink = { git = "https://github.com/use-ink/ink", branch = "xcm", default-features = false }
+pop-api = { path = "../../../pop-api", default-features = false, features = [ "messaging" ] }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = [ "std" ]
+e2e-tests = [  ]
+ink-as-dependency = [  ]
+std = [
+	"ink/std",
+	"pop-api/std",
+]

--- a/pop-api/examples/messaging/lib.rs
+++ b/pop-api/examples/messaging/lib.rs
@@ -1,0 +1,226 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+use ink::{
+	env::hash::{Blake2x256, CryptoHash},
+	prelude::vec::Vec,
+	scale::{Compact, Encode},
+	xcm::{
+		prelude::{All, Asset, Junction::Parachain, Location, Weight, WeightLimit, Xcm},
+		VersionedXcm,
+	},
+};
+use pop_api::{
+	messaging::{self as api, ismp, RequestId, Status},
+	StatusCode,
+};
+
+pub type Result<T> = core::result::Result<T, StatusCode>;
+
+#[ink::contract]
+mod messaging {
+	use ink::xcm::{
+		prelude::{AccountId32, OriginKind, QueryId, QueryResponseInfo, XcmHash},
+		DoubleEncoded,
+	};
+	use pop_api::messaging::ismp::Get;
+
+	use super::*;
+
+	#[ink(storage)]
+	#[derive(Default)]
+	pub struct Messaging {
+		para: u32,
+		id: RequestId,
+	}
+
+	impl Messaging {
+		#[ink(constructor, payable)]
+		pub fn new(para: u32) -> Self {
+			Self { para, id: 0 }
+		}
+
+		#[ink(message)]
+		pub fn get(&mut self, key: Vec<u8>, height: u32) -> Result<()> {
+			self.id = self.id.saturating_add(1);
+			ismp::get(
+				self.id,
+				Get::new(self.para, height, 0, Vec::default(), Vec::from([key.clone()])),
+				0,
+			)?;
+			self.env().emit_event(IsmpRequested { id: self.id, key, height });
+			Ok(())
+		}
+
+		#[ink(message, payable)]
+		pub fn fund(&mut self) -> Result<()> {
+			let dest = Location::new(1, Parachain(self.para));
+
+			// Reserve transfer specified assets to contract account on destination.
+			let asset: Asset = (Location::parent(), self.env().transferred_value()).into();
+			let beneficiary = hashed_account(4_001, self.env().account_id()); // todo: para id getter
+			let message: Xcm<()> = Xcm::builder_unsafe()
+				.withdraw_asset(asset.clone().into())
+				.initiate_reserve_withdraw(
+					asset.clone().into(),
+					dest.clone(),
+					Xcm::builder_unsafe()
+						.buy_execution(asset.clone(), WeightLimit::Unlimited)
+						.deposit_asset(
+							All.into(),
+							Location::new(0, AccountId32 { network: None, id: beneficiary.0 }),
+						)
+						.build(),
+				)
+				.build();
+			api::xcm::execute(&VersionedXcm::V4(message)).unwrap(); // todo: handle error
+
+			self.env().emit_event(Funded {
+				account_id: beneficiary,
+				value: self.env().transferred_value(),
+			});
+			Ok(())
+		}
+
+		#[ink(message, payable)]
+		pub fn transact(&mut self, call: DoubleEncoded<()>, weight: Weight) -> Result<()> {
+			let dest = Location::new(1, Parachain(self.para));
+
+			// Register a new query for receiving a response, used to report transact status.
+			self.id = self.id.saturating_add(1);
+			let query_id = api::xcm::new_query(
+				self.id,
+				dest.clone().into_versioned(),
+				self.env().block_number().saturating_add(100),
+			)?
+			.unwrap(); // TODO: handle error
+
+			// TODO: provide an api function for determining the local para id and max weight value
+			// for processing the reported transact status on the local chain.
+			let response = QueryResponseInfo {
+				// Route back to this parachain.
+				destination: Location::new(1, Parachain(4_001)),
+				query_id,
+				max_weight: Weight::from_parts(1_000_000, 5_000),
+			};
+
+			// Send transact message.
+			let fees: Asset = (Location::parent(), self.env().transferred_value()).into();
+			let message: Xcm<()> = self._transact(call, weight, fees, response);
+			let hash = api::xcm::send(&dest.into_versioned(), &VersionedXcm::V4(message)).unwrap(); // todo: handle error
+
+			self.env().emit_event(XcmRequested { id: self.id, query_id, hash });
+			Ok(())
+		}
+
+		#[ink(message)]
+		pub fn complete(&mut self, request: RequestId) -> Result<()> {
+			if let Ok(Some(status)) = api::poll((self.env().account_id(), request)) {
+				if status == Status::Complete {
+					let result = api::get((self.env().account_id(), request))?;
+					api::remove([request].to_vec())?;
+					self.env().emit_event(Completed { id: request, result });
+				}
+			}
+			Ok(())
+		}
+
+		fn _transact(
+			&self,
+			call: DoubleEncoded<()>,
+			weight: Weight,
+			fees: Asset,
+			response: QueryResponseInfo,
+		) -> Xcm<()> {
+			let beneficiary = hashed_account(4_001, self.env().account_id()); // todo: para id getter
+			Xcm::builder_unsafe()
+				.withdraw_asset(fees.clone().into())
+				.buy_execution(fees, WeightLimit::Unlimited)
+				.set_appendix(
+					Xcm::builder_unsafe()
+						.refund_surplus()
+						.deposit_asset(
+							All.into(),
+							Location::new(0, AccountId32 { network: None, id: beneficiary.0 }),
+						)
+						.build(),
+				)
+				.set_error_handler(Xcm::builder_unsafe().report_error(response.clone()).build())
+				.transact(OriginKind::SovereignAccount, weight, call)
+				.report_transact_status(response)
+				.build()
+		}
+	}
+
+	#[ink::event]
+	pub struct IsmpRequested {
+		#[ink(topic)]
+		pub id: RequestId,
+		pub key: Vec<u8>,
+		pub height: BlockNumber,
+	}
+
+	#[ink::event]
+	pub struct Funded {
+		#[ink(topic)]
+		pub account_id: AccountId,
+		pub value: Balance,
+	}
+
+	#[ink::event]
+	pub struct XcmRequested {
+		#[ink(topic)]
+		pub id: RequestId,
+		#[ink(topic)]
+		pub query_id: QueryId,
+		#[ink(topic)]
+		pub hash: XcmHash,
+	}
+
+	#[ink::event]
+	pub struct Completed {
+		#[ink(topic)]
+		pub id: RequestId,
+		pub result: Option<Vec<u8>>,
+	}
+
+	// todo: make hasher generic and move to pop-api
+	fn hashed_account(para_id: u32, account_id: AccountId) -> AccountId {
+		let location = (
+			b"SiblingChain",
+			Compact::<u32>::from(para_id),
+			(b"AccountId32", account_id.0).encode(),
+		)
+			.encode();
+		let mut output = [0u8; 32];
+		Blake2x256::hash(&location, &mut output);
+		AccountId::from(output)
+	}
+
+	#[cfg(test)]
+	mod tests {
+
+		use super::*;
+
+		#[ink::test]
+		fn default_works() {
+			Messaging::new(1_000);
+		}
+
+		#[test]
+		fn it_works() {
+			let account_id: [u8; 32] = [
+				27, 2, 24, 17, 104, 5, 173, 98, 25, 32, 36, 0, 82, 159, 11, 212, 178, 11, 39, 219,
+				14, 178, 226, 179, 216, 62, 19, 85, 226, 17, 80, 179,
+			];
+			let location = (
+				b"SiblingChain",
+				Compact::<u32>::from(4001),
+				(b"AccountId32", account_id).encode(),
+			)
+				.encode();
+			let mut output = [0u8; 32];
+			Blake2x256::hash(&location, &mut output);
+			println!("{output:?}")
+		}
+	}
+}

--- a/pop-api/integration-tests/Cargo.toml
+++ b/pop-api/integration-tests/Cargo.toml
@@ -12,13 +12,16 @@ env_logger = "0.11.2"
 frame-support = { version = "36.0.0", default-features = false }
 frame-support-procedural = { version = "=30.0.1", default-features = false }
 frame-system = { version = "36.1.0", default-features = false }
+ismp = { git = "https://github.com/r0gue-io/ismp", branch = "polkadot-v1.14.0", default-features = false }
 log = "0.4.22"
 pallet-assets = { version = "37.0.0", default-features = false }
 pallet-balances = { version = "37.0.0", default-features = false }
+pallet-ismp = { git = "https://github.com/r0gue-io/ismp", branch = "polkadot-v1.14.0", default-features = false }
 pallet-revive = { path = "../../pallets/revive", default-features = false }
 pallet-timestamp = { version = "35.0.0", default-features = false }
 pop-api = { path = "../../pop-api", default-features = false, features = [
 	"fungibles",
+	"messaging",
 ] }
 pop-primitives = { path = "../../primitives", default-features = false }
 pop-runtime-devnet = { path = "../../runtime/devnet", default-features = false }
@@ -29,6 +32,7 @@ sp-io = { version = "37.0.0", default-features = false }
 sp-runtime = { version = "=38.0.0", default-features = false }
 # TODO: Requires to resolve a dependency version issue. See more at: https://github.com/r0gue-io/pop-node/issues/313.
 staging-xcm = { version = "=14.1.0", default-features = false }
+xcm-executor = { version = "15.0.0", package = "staging-xcm-executor", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.toml
+++ b/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = [ "r0gue <go@r0gue.io>" ]
+authors = [ "R0GUE <go@r0gue.io>" ]
 edition = "2021"
 name = "create_token_in_constructor"
 version = "0.1.0"

--- a/pop-api/integration-tests/contracts/fungibles/lib.rs
+++ b/pop-api/integration-tests/contracts/fungibles/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
+use ink::env::{DefaultEnvironment, Environment};
 /// 1. PSP-22
 /// 2. PSP-22 Metadata
 /// 3. Management

--- a/pop-api/integration-tests/contracts/fungibles/lib.rs
+++ b/pop-api/integration-tests/contracts/fungibles/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-use ink::env::{DefaultEnvironment, Environment};
 /// 1. PSP-22
 /// 2. PSP-22 Metadata
 /// 3. Management

--- a/pop-api/integration-tests/contracts/messaging/Cargo.toml
+++ b/pop-api/integration-tests/contracts/messaging/Cargo.toml
@@ -5,7 +5,8 @@ name = "messaging"
 version = "0.1.0"
 
 [dependencies]
-ink = { git = "https://github.com/use-ink/ink", branch = "xcm", default-features = false }
+ink = { git = "https://github.com/r0gue-io/ink", branch = "sub0", default-features = false }
+polkavm-derive = "0.11.0"
 pop-api = { path = "../../../../pop-api", default-features = false, features = [ "messaging" ] }
 
 [lib]

--- a/pop-api/integration-tests/contracts/messaging/Cargo.toml
+++ b/pop-api/integration-tests/contracts/messaging/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+authors = [ "R0GUE <go@r0gue.io>" ]
+edition = "2021"
+name = "messaging"
+version = "0.1.0"
+
+[dependencies]
+ink = { git = "https://github.com/use-ink/ink", branch = "xcm", default-features = false }
+pop-api = { path = "../../../../pop-api", default-features = false, features = [ "messaging" ] }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = [ "std" ]
+e2e-tests = [  ]
+ink-as-dependency = [  ]
+std = [
+	"ink/std",
+	"pop-api/std",
+]

--- a/pop-api/integration-tests/contracts/messaging/lib.rs
+++ b/pop-api/integration-tests/contracts/messaging/lib.rs
@@ -8,10 +8,20 @@ use pop_api::{
 		xcm::{QueryId, VersionedLocation},
 		RequestId, Status,
 	},
+	primitives::AccountId,
 	StatusCode,
 };
 
 pub type Result<T> = core::result::Result<T, StatusCode>;
+
+// Converts a H160 read as a H256 to a H256 expected by revive
+// TODO: remove once ink! updated
+fn to_account_id(address: &AccountId) -> AccountId {
+	let mut account_id = AccountId::from([0xEE; 32]);
+	<AccountId as AsMut<[u8; 32]>>::as_mut(&mut account_id)[..20]
+		.copy_from_slice(&<AccountId as AsRef<[u8; 32]>>::as_ref(&address)[..20]);
+	account_id
+}
 
 #[ink::contract]
 mod messaging {
@@ -51,12 +61,12 @@ mod messaging {
 
 		#[ink(message)]
 		pub fn poll(&self, request: RequestId) -> Result<Option<Status>> {
-			api::poll((self.env().account_id(), request))
+			api::poll((to_account_id(&self.env().account_id()), request))
 		}
 
 		#[ink(message)]
 		pub fn get(&self, request: RequestId) -> Result<Option<Vec<u8>>> {
-			api::get((self.env().account_id(), request))
+			api::get((to_account_id(&self.env().account_id()), request))
 		}
 
 		#[ink(message)]

--- a/pop-api/integration-tests/contracts/messaging/lib.rs
+++ b/pop-api/integration-tests/contracts/messaging/lib.rs
@@ -8,7 +8,6 @@ use pop_api::{
 		xcm::{Junction, Location, QueryId, VersionedLocation},
 		RequestId, Status,
 	},
-	primitives::to_account_id,
 	StatusCode,
 };
 
@@ -60,12 +59,12 @@ mod messaging {
 
 		#[ink(message)]
 		pub fn poll(&self, request: RequestId) -> Result<Option<Status>> {
-			api::poll((to_account_id(&self.env().account_id()), request))
+			api::poll((self.env().account_id(), request))
 		}
 
 		#[ink(message)]
 		pub fn get(&self, request: RequestId) -> Result<Option<Vec<u8>>> {
-			api::get((to_account_id(&self.env().account_id()), request))
+			api::get((self.env().account_id(), request))
 		}
 
 		#[ink(message)]

--- a/pop-api/integration-tests/contracts/messaging/lib.rs
+++ b/pop-api/integration-tests/contracts/messaging/lib.rs
@@ -1,0 +1,78 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+use ink::prelude::vec::Vec;
+use pop_api::{
+	messaging::{
+		self as api,
+		ismp::{Get, Post},
+		xcm::{QueryId, VersionedLocation},
+		RequestId, Status,
+	},
+	StatusCode,
+};
+
+pub type Result<T> = core::result::Result<T, StatusCode>;
+
+#[ink::contract]
+mod messaging {
+	use super::*;
+
+	#[ink(storage)]
+	#[derive(Default)]
+	pub struct Contract;
+
+	impl Contract {
+		#[ink(constructor, payable)]
+		pub fn new() -> Self {
+			Default::default()
+		}
+
+		#[ink(message)]
+		pub fn ismp_get(&mut self, id: RequestId, request: Get, fee: Balance) -> Result<()> {
+			api::ismp::get(id, request, fee)?;
+			Ok(())
+		}
+
+		#[ink(message)]
+		pub fn ismp_post(&mut self, id: RequestId, request: Post, fee: Balance) -> Result<()> {
+			api::ismp::post(id, request, fee)?;
+			Ok(())
+		}
+
+		#[ink(message)]
+		pub fn xcm_new_query(
+			&mut self,
+			id: RequestId,
+			responder: VersionedLocation,
+			timeout: BlockNumber,
+		) -> Result<Option<QueryId>> {
+			api::xcm::new_query(id, responder, timeout)
+		}
+
+		#[ink(message)]
+		pub fn poll(&self, request: RequestId) -> Result<Option<Status>> {
+			api::poll((self.env().account_id(), request))
+		}
+
+		#[ink(message)]
+		pub fn get(&self, request: RequestId) -> Result<Option<Vec<u8>>> {
+			api::get((self.env().account_id(), request))
+		}
+
+		#[ink(message)]
+		pub fn remove(&mut self, request: RequestId) -> Result<()> {
+			api::remove([request].to_vec())?;
+			Ok(())
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+
+		#[ink::test]
+		fn default_works() {
+			Contract::new();
+		}
+	}
+}

--- a/pop-api/integration-tests/src/lib.rs
+++ b/pop-api/integration-tests/src/lib.rs
@@ -80,7 +80,7 @@ fn bare_call(
 }
 
 // Deploy, instantiate and return contract address.
-fn instantiate(contract: &str, init_value: u128, salt: Vec<u8>) -> (sp_core::H160, AccountId32) {
+fn instantiate(contract: &str, init_value: u128, _salt: Vec<u8>) -> (sp_core::H160, AccountId32) {
 	let wasm_binary = std::fs::read(contract).expect("could not read .wasm file");
 
 	let result = Revive::bare_instantiate(

--- a/pop-api/integration-tests/src/lib.rs
+++ b/pop-api/integration-tests/src/lib.rs
@@ -80,11 +80,7 @@ fn bare_call(
 }
 
 // Deploy, instantiate and return contract address.
-fn instantiate(
-	contract: &str,
-	init_value: u128,
-	salt: Vec<u8>,
-) -> (crate::sp_core::H160, AccountId32) {
+fn instantiate(contract: &str, init_value: u128, salt: Vec<u8>) -> (sp_core::H160, AccountId32) {
 	let wasm_binary = std::fs::read(contract).expect("could not read .wasm file");
 
 	let result = Revive::bare_instantiate(

--- a/pop-api/integration-tests/src/lib.rs
+++ b/pop-api/integration-tests/src/lib.rs
@@ -8,12 +8,15 @@ use frame_support::{
 	weights::Weight,
 };
 use pallet_revive::{AddressMapper, Code, CollectEvents, ExecReturnValue};
-use pop_runtime_devnet::{Assets, Revive, Runtime, RuntimeOrigin, System, UNIT};
+use pop_runtime_devnet::{config::ismp::Router, Assets, Messaging, Revive, Runtime, RuntimeOrigin, System, UNIT};
 use scale::{Decode, Encode};
-use sp_runtime::{app_crypto::sp_core, AccountId32, BuildStorage, DispatchError};
+use sp_runtime::{app_crypto::sp_core,
+                 offchain::{testing::TestOffchainExt, OffchainDbExt},
+                 AccountId32, BuildStorage, DispatchError};
 
 mod environment;
 mod fungibles;
+mod messaging;
 
 type Balance = u128;
 
@@ -40,6 +43,8 @@ fn new_test_ext() -> sp_io::TestExternalities {
 	.expect("Pallet balances storage can be assimilated");
 
 	let mut ext = sp_io::TestExternalities::new(t);
+	let (offchain, _state) = TestOffchainExt::new();
+	ext.register_extension(OffchainDbExt::new(offchain));
 	ext.execute_with(|| System::set_block_number(1));
 	// register account mappings
 	ext.execute_with(|| {

--- a/pop-api/integration-tests/src/messaging.rs
+++ b/pop-api/integration-tests/src/messaging.rs
@@ -12,12 +12,12 @@ use pop_api::{
 	primitives::{BlockNumber, Error},
 };
 use sp_io::{hashing::keccak_256, TestExternalities};
-use sp_runtime::offchain::OffchainOverlayedChange;
+use sp_runtime::{app_crypto::sp_core::H160, offchain::OffchainOverlayedChange};
 use xcm_executor::traits::OnResponse;
 
 use super::*;
 
-const CONTRACT: &str = "contracts/messaging/target/ink/messaging.wasm";
+const CONTRACT: &str = "contracts/messaging/target/ink/messaging.riscv";
 const ASSET_HUB: u32 = 1_000;
 const HYPERBRIDGE: u32 = 4_009;
 const ISMP_MODULE_ID: [u8; 3] = *b"pop";
@@ -122,7 +122,7 @@ fn xcm_request_works() {
 			0,
 			[staging_xcm::prelude::Junction::AccountId32 {
 				network: None,
-				id: contract.0.clone().into(),
+				id: contract.0 .1.clone().into(),
 			}],
 		);
 		let origin = staging_xcm::prelude::Location::decode(&mut &origin.encode()[..]).unwrap();
@@ -187,7 +187,7 @@ fn get_ismp_request(ext: &mut TestExternalities) -> ::ismp::router::Request {
 }
 
 // A simple, strongly typed wrapper for the contract.
-struct Contract(AccountId32);
+struct Contract((H160, AccountId32));
 impl Contract {
 	fn new() -> Self {
 		Self(instantiate(CONTRACT, INIT_VALUE, vec![]))
@@ -237,6 +237,6 @@ impl Contract {
 	fn call(&self, function: &str, params: Vec<u8>, value: u128) -> ExecReturnValue {
 		let function = function_selector(function);
 		let params = [function, params].concat();
-		bare_call(self.0.clone(), params, value).expect("should work")
+		bare_call(self.0.clone().0, params, value).expect("should work")
 	}
 }

--- a/pop-api/integration-tests/src/messaging.rs
+++ b/pop-api/integration-tests/src/messaging.rs
@@ -1,0 +1,242 @@
+use ::ismp::router::{GetResponse, IsmpRouter, PostResponse, Response, StorageValue};
+use pallet_ismp::mmr::Leaf;
+use pop_api::{
+	messaging::{
+		ismp::{Get, Post},
+		xcm::{
+			Junction, Location, MaybeErrorCode, QueryId, VersionedLocation, VersionedResponse,
+			XcmHash,
+		},
+		RequestId, Status,
+	},
+	primitives::{BlockNumber, Error},
+};
+use sp_io::{hashing::keccak_256, TestExternalities};
+use sp_runtime::offchain::OffchainOverlayedChange;
+use xcm_executor::traits::OnResponse;
+
+use super::*;
+
+const CONTRACT: &str = "contracts/messaging/target/ink/messaging.wasm";
+const ASSET_HUB: u32 = 1_000;
+const HYPERBRIDGE: u32 = 4_009;
+const ISMP_MODULE_ID: [u8; 3] = *b"pop";
+
+#[test]
+fn ismp_get_request_works() {
+	let id = 42;
+	let key = "some_key".as_bytes().to_vec();
+	let request = Get::new(ASSET_HUB, 0, 0, "some_context".as_bytes().to_vec(), vec![key.clone()]);
+	let response = vec![StorageValue { key, value: Some("some_value".as_bytes().to_vec()) }];
+
+	// Create a get request.
+	let mut ext = new_test_ext();
+	let contract = ext.execute_with(|| {
+		let contract = Contract::new();
+		assert_ok!(contract.ismp_get(id, request, 0));
+		assert_eq!(contract.poll(id).unwrap(), Some(Status::Pending));
+
+		// TODO: assert events from messaging and ismp pallets emitted
+		println!("{:#?}", System::events());
+
+		contract
+	});
+
+	// Look up the request within offchain state in order to provide a response.
+	let ::ismp::router::Request::Get(get) = get_ismp_request(&mut ext) else { panic!() };
+
+	// Provide a response.
+	ext.execute_with(|| {
+		let module = Router::default().module_for_id(ISMP_MODULE_ID.to_vec()).unwrap();
+		module
+			.on_response(Response::Get(GetResponse { get, values: response.clone() }))
+			.unwrap();
+
+		assert_eq!(contract.poll(id).unwrap(), Some(Status::Complete));
+		assert_eq!(contract.get(id).unwrap(), Some(response.encode()));
+		assert_ok!(contract.remove(id));
+	});
+}
+
+#[test]
+fn ismp_post_request_works() {
+	let id = 42;
+	let request = Post::new(HYPERBRIDGE, 0, "some_data".as_bytes().to_vec());
+	let response = "some_value".as_bytes().to_vec();
+
+	// Create a post request.
+	let mut ext = new_test_ext();
+	let contract = ext.execute_with(|| {
+		let contract = Contract::new();
+		assert_ok!(contract.ismp_post(id, request, 0));
+		assert_eq!(contract.poll(id).unwrap(), Some(Status::Pending));
+
+		// TODO: assert events from messaging and ismp pallets emitted
+		println!("{:#?}", System::events());
+		contract
+	});
+
+	// Look up the request within offchain state in order to provide a response.
+	let ::ismp::router::Request::Post(post) = get_ismp_request(&mut ext) else { panic!() };
+
+	// Provide a response.
+	ext.execute_with(|| {
+		let module = Router::default().module_for_id(ISMP_MODULE_ID.to_vec()).unwrap();
+		module
+			.on_response(Response::Post(PostResponse {
+				post,
+				response: response.clone(),
+				timeout_timestamp: 0,
+			}))
+			.unwrap();
+
+		assert_eq!(contract.poll(id).unwrap(), Some(Status::Complete));
+		assert_eq!(contract.get(id).unwrap(), Some(response));
+		assert_ok!(contract.remove(id));
+	});
+}
+
+#[test]
+fn xcm_request_works() {
+	let id = 42u64;
+	let origin = Location::new(1, [Junction::Parachain(ASSET_HUB)]);
+	let responder = origin.clone().into_versioned();
+	let timeout = 100;
+	let response = pop_api::messaging::xcm::Response::DispatchResult(MaybeErrorCode::Success);
+	let context = staging_xcm::prelude::XcmContext {
+		origin: None,
+		message_id: XcmHash::default(),
+		topic: None,
+	};
+	new_test_ext().execute_with(|| {
+		let contract = Contract::new();
+		let query_id = contract.xcm_new_query(id, responder, timeout).unwrap().unwrap();
+		assert_eq!(query_id, 0);
+		assert_eq!(contract.poll(id).unwrap(), Some(Status::Pending));
+
+		// TODO: assert events from messaging pallet emitted
+		println!("{:#?}", System::events());
+
+		// Provide a response.
+		let querier = staging_xcm::prelude::Location::new(
+			0,
+			[staging_xcm::prelude::Junction::AccountId32 {
+				network: None,
+				id: contract.0.clone().into(),
+			}],
+		);
+		let origin = staging_xcm::prelude::Location::decode(&mut &origin.encode()[..]).unwrap();
+		assert!(Messaging::expecting_response(&origin, query_id, Some(&querier)));
+		// TODO: update weight
+		assert_eq!(
+			Messaging::on_response(
+				&origin,
+				query_id,
+				Some(&querier),
+				staging_xcm::prelude::Response::decode(&mut &response.encode()[..]).unwrap(),
+				Weight::MAX,
+				&context
+			),
+			Weight::zero()
+		);
+
+		assert_eq!(contract.poll(id).unwrap(), Some(Status::Complete));
+		assert_eq!(contract.get(id).unwrap(), Some(VersionedResponse::from(response).encode()));
+		assert_ok!(contract.remove(id));
+	});
+}
+
+// Get the last ismp request.
+fn get_ismp_request(ext: &mut TestExternalities) -> ::ismp::router::Request {
+	// Get commitment from last ismp request event.
+	let commitment = ext.execute_with(|| {
+		System::read_events_for_pallet::<pallet_ismp::Event<Runtime>>()
+			.iter()
+			.filter_map(|e| match e {
+				pallet_ismp::Event::<Runtime>::Request { commitment, .. } =>
+					Some(commitment.clone()),
+				_ => None,
+			})
+			.last()
+			.unwrap()
+	});
+	// Read value from offchain storage overlay, stored via `NoOpMmrTree`.
+	let key = ("storage".as_bytes().to_vec(), (b"no_op", commitment).encode());
+	let request = ext
+		.overlayed_changes()
+		.offchain()
+		.overlay()
+		.changes()
+		.filter_map(|c| {
+			(c.0 == &key).then(|| match c.1.value_ref() {
+				OffchainOverlayedChange::SetValue(value) => {
+					match Leaf::decode(&mut &value[..]).unwrap() {
+						Leaf::Request(req) => Some(req),
+						Leaf::Response(_) => None,
+					}
+				},
+				_ => None,
+			})
+		})
+		.last()
+		.flatten()
+		.unwrap();
+	// Ensure the request matches the commitment.
+	assert_eq!(commitment.0, keccak_256(&request.encode()));
+	request
+}
+
+// A simple, strongly typed wrapper for the contract.
+struct Contract(AccountId32);
+impl Contract {
+	fn new() -> Self {
+		Self(instantiate(CONTRACT, INIT_VALUE, vec![]))
+	}
+
+	fn ismp_get(&self, id: RequestId, request: Get, fee: Balance) -> Result<(), Error> {
+		let result = self.call("ismp_get", (id, request, fee).encode(), 0);
+		<Result<(), Error>>::decode(&mut &result.data[1..])
+			.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+	}
+
+	fn ismp_post(&self, id: RequestId, request: Post, fee: Balance) -> Result<(), Error> {
+		let result = self.call("ismp_post", (id, request, fee).encode(), 0);
+		<Result<(), Error>>::decode(&mut &result.data[1..])
+			.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+	}
+
+	fn xcm_new_query(
+		&self,
+		id: RequestId,
+		responder: VersionedLocation,
+		timeout: BlockNumber,
+	) -> Result<Option<QueryId>, Error> {
+		let result = self.call("xcm_new_query", (id, responder, timeout).encode(), 0);
+		<Result<Option<QueryId>, Error>>::decode(&mut &result.data[1..])
+			.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+	}
+
+	fn poll(&self, request: RequestId) -> Result<Option<Status>, Error> {
+		let result = self.call("poll", request.encode(), 0);
+		Result::<Option<Status>, Error>::decode(&mut &result.data[1..])
+			.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+	}
+
+	fn get(&self, request: RequestId) -> Result<Option<Vec<u8>>, Error> {
+		let result = self.call("get", request.encode(), 0);
+		Result::<Option<Vec<u8>>, Error>::decode(&mut &result.data[1..])
+			.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+	}
+
+	fn remove(&self, request: RequestId) -> Result<(), Error> {
+		let result = self.call("remove", request.encode(), 0);
+		<Result<(), Error>>::decode(&mut &result.data[1..])
+			.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))
+	}
+
+	fn call(&self, function: &str, params: Vec<u8>, value: u128) -> ExecReturnValue {
+		let function = function_selector(function);
+		let params = [function, params].concat();
+		bare_call(self.0.clone(), params, value).expect("should work")
+	}
+}

--- a/pop-api/src/primitives.rs
+++ b/pop-api/src/primitives.rs
@@ -4,5 +4,6 @@ pub use pop_primitives::*;
 // Public due to integration tests crate.
 pub type AccountId = <DefaultEnvironment as Environment>::AccountId;
 pub type Balance = <DefaultEnvironment as Environment>::Balance;
+pub type BlockNumber = <DefaultEnvironment as Environment>::BlockNumber;
 pub type Hash = <DefaultEnvironment as Environment>::Hash;
 pub type Timestamp = <DefaultEnvironment as Environment>::Timestamp;

--- a/pop-api/src/v0/messaging/ismp.rs
+++ b/pop-api/src/v0/messaging/ismp.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+#[ink::scale_derive(Encode, Decode, TypeInfo)]
+pub struct Get {
+	dest: u32,
+	height: u32,
+	timeout: u64,
+	// TODO: Option
+	context: Vec<u8>,
+	keys: Vec<Vec<u8>>,
+}
+
+impl Get {
+	pub fn new(dest: u32, height: u32, timeout: u64, context: Vec<u8>, keys: Vec<Vec<u8>>) -> Self {
+		// TODO: validate: dest para id, ensure at least one key
+		Self { dest, height, timeout, context, keys }
+	}
+}
+
+#[ink::scale_derive(Encode, Decode, TypeInfo)]
+pub struct Post {
+	dest: u32,
+	timeout: u64,
+	data: Vec<u8>,
+}
+
+impl Post {
+	pub fn new(dest: u32, timeout: u64, data: Vec<u8>) -> Self {
+		// TODO: validate: dest para id, ensure data not empty
+		Self { dest, timeout, data }
+	}
+}
+
+#[inline]
+pub fn get(id: RequestId, request: Get, fee: Balance) -> Result<()> {
+	build_dispatch(ISMP_GET)
+		.input::<(RequestId, Get, Balance)>()
+		.output::<Result<()>, true>()
+		.handle_error_code::<StatusCode>()
+		.call(&(id, request, fee))
+}
+
+#[inline]
+pub fn post(id: RequestId, request: Post, fee: Balance) -> Result<()> {
+	build_dispatch(ISMP_POST)
+		.input::<(RequestId, Post, Balance)>()
+		.output::<Result<()>, true>()
+		.handle_error_code::<StatusCode>()
+		.call(&(id, request, fee))
+}

--- a/pop-api/src/v0/messaging/mod.rs
+++ b/pop-api/src/v0/messaging/mod.rs
@@ -1,0 +1,69 @@
+use ink::prelude::vec::Vec;
+
+use crate::{
+	primitives::{AccountId, Balance, BlockNumber},
+	ChainExtensionMethodApi, Result, StatusCode,
+};
+
+/// APIs for messaging using the Interoperable State Machine Protocol (ISMP).
+pub mod ismp;
+/// APIs for messaging using Polkadot's Cross-Consensus Messaging (XCM).
+pub mod xcm;
+
+pub(crate) const API: u8 = 151;
+// Dispatchables
+pub(super) const REQUEST: u8 = 0;
+pub(super) const ISMP_GET: u8 = 1;
+pub(super) const ISMP_POST: u8 = 2;
+pub(super) const XCM_NEW_QUERY: u8 = 3;
+pub(super) const REMOVE: u8 = 4;
+// Reads
+pub(super) const POLL: u8 = 0;
+pub(super) const GET: u8 = 1;
+pub(super) const QUERY_ID: u8 = 2;
+
+pub type RequestId = u64;
+
+fn build_dispatch(dispatchable: u8) -> ChainExtensionMethodApi {
+	crate::v0::build_dispatch(API, dispatchable)
+}
+
+fn build_read_state(state_query: u8) -> ChainExtensionMethodApi {
+	crate::v0::build_read_state(API, state_query)
+}
+
+#[inline]
+pub fn poll(id: (AccountId, RequestId)) -> Result<Option<Status>> {
+	build_read_state(POLL)
+		.input::<(AccountId, RequestId)>()
+		.output::<Result<Option<Status>>, true>()
+		.handle_error_code::<StatusCode>()
+		.call(&id)
+}
+
+#[inline]
+pub fn get(id: (AccountId, RequestId)) -> Result<Option<Vec<u8>>> {
+	build_read_state(GET)
+		.input::<(AccountId, RequestId)>()
+		.output::<Result<Option<Vec<u8>>>, true>()
+		.handle_error_code::<StatusCode>()
+		.call(&id)
+}
+
+#[inline]
+pub fn remove(requests: Vec<RequestId>) -> Result<()> {
+	build_dispatch(REMOVE)
+		.input::<Vec<RequestId>>()
+		.output::<Result<()>, true>()
+		.handle_error_code::<StatusCode>()
+		.call(&requests)
+}
+
+#[derive(PartialEq)]
+#[ink::scale_derive(Decode, Encode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub enum Status {
+	Pending,
+	TimedOut,
+	Complete,
+}

--- a/pop-api/src/v0/messaging/mod.rs
+++ b/pop-api/src/v0/messaging/mod.rs
@@ -12,7 +12,7 @@ pub mod xcm;
 
 pub(crate) const API: u8 = 151;
 // Dispatchables
-pub(super) const REQUEST: u8 = 0;
+pub(super) const _REQUEST: u8 = 0;
 pub(super) const ISMP_GET: u8 = 1;
 pub(super) const ISMP_POST: u8 = 2;
 pub(super) const XCM_NEW_QUERY: u8 = 3;

--- a/pop-api/src/v0/messaging/xcm.rs
+++ b/pop-api/src/v0/messaging/xcm.rs
@@ -8,7 +8,6 @@ use ink::{
 };
 
 use super::*;
-use crate::primitives::to_account_id;
 
 #[inline]
 pub fn new_query(
@@ -26,7 +25,7 @@ pub fn new_query(
 		.input::<(AccountId, RequestId)>()
 		.output::<Result<Option<QueryId>>, true>()
 		.handle_error_code::<StatusCode>()
-		.call(&(to_account_id(&account_id::<DefaultEnvironment>()), id))
+		.call(&(account_id::<DefaultEnvironment>(), id))
 }
 
 /// Execute an XCM message locally, using the contract's address as the origin.

--- a/pop-api/src/v0/messaging/xcm.rs
+++ b/pop-api/src/v0/messaging/xcm.rs
@@ -8,6 +8,7 @@ use ink::{
 };
 
 use super::*;
+use crate::primitives::to_account_id;
 
 #[inline]
 pub fn new_query(
@@ -25,7 +26,7 @@ pub fn new_query(
 		.input::<(AccountId, RequestId)>()
 		.output::<Result<Option<QueryId>>, true>()
 		.handle_error_code::<StatusCode>()
-		.call(&(account_id::<DefaultEnvironment>(), id))
+		.call(&(to_account_id(&account_id::<DefaultEnvironment>()), id))
 }
 
 /// Execute an XCM message locally, using the contract's address as the origin.

--- a/pop-api/src/v0/messaging/xcm.rs
+++ b/pop-api/src/v0/messaging/xcm.rs
@@ -1,0 +1,42 @@
+pub use ink::xcm::prelude::{
+	Junction, Junctions, Location, MaybeErrorCode, QueryId, Response, VersionedLocation,
+	VersionedResponse, VersionedXcm, XcmContext, XcmHash,
+};
+use ink::{
+	env::{account_id, xcm_execute, xcm_send, DefaultEnvironment},
+	scale::Encode,
+};
+
+use super::*;
+
+#[inline]
+pub fn new_query(
+	id: RequestId,
+	responder: VersionedLocation,
+	timeout: BlockNumber,
+) -> Result<Option<QueryId>> {
+	build_dispatch(XCM_NEW_QUERY)
+		.input::<(RequestId, VersionedLocation, BlockNumber)>()
+		.output::<Result<()>, true>()
+		.handle_error_code::<StatusCode>()
+		.call(&(id, responder, timeout))?;
+
+	build_read_state(QUERY_ID)
+		.input::<(AccountId, RequestId)>()
+		.output::<Result<Option<QueryId>>, true>()
+		.handle_error_code::<StatusCode>()
+		.call(&(account_id::<DefaultEnvironment>(), id))
+}
+
+/// Execute an XCM message locally, using the contract's address as the origin.
+pub fn execute<Call: Encode>(msg: &VersionedXcm<Call>) -> ink::env::Result<()> {
+	xcm_execute::<DefaultEnvironment, _>(msg)
+}
+
+/// Send an XCM message, using the contract's address as the origin.
+pub fn send<Call: Encode>(
+	dest: &VersionedLocation,
+	msg: &VersionedXcm<Call>,
+) -> ink::env::Result<XcmHash> {
+	xcm_send::<DefaultEnvironment, _>(dest, msg)
+}

--- a/pop-api/src/v0/mod.rs
+++ b/pop-api/src/v0/mod.rs
@@ -8,6 +8,9 @@ use crate::{
 /// APIs for fungible tokens.
 #[cfg(feature = "fungibles")]
 pub mod fungibles;
+/// APIs for messaging.
+#[cfg(feature = "messaging")]
+pub mod messaging;
 
 pub(crate) const V0: u8 = 0;
 

--- a/runtime/devnet/src/config/ismp.rs
+++ b/runtime/devnet/src/config/ismp.rs
@@ -16,6 +16,7 @@ impl pallet_ismp::Config for Runtime {
 	type Coprocessor = Coprocessor;
 	type Currency = Balances;
 	type HostStateMachine = HostStateMachine;
+	// State is stored in offchain database
 	type Mmr = pallet_ismp::NoOpMmrTree<Self>;
 	type Router = Router;
 	type RuntimeEvent = RuntimeEvent;
@@ -46,6 +47,10 @@ impl Get<StateMachine> for HostStateMachine {
 pub struct Router;
 impl IsmpRouter for Router {
 	fn module_for_id(&self, id: Vec<u8>) -> Result<Box<dyn IsmpModule>, Error> {
+		use pallet_api::messaging::transports::ismp::*;
+		if id == ID {
+			return Ok(Box::new(Handler::<Runtime>::new()));
+		}
 		Err(Error::ModuleNotFound(id))
 	}
 }

--- a/runtime/devnet/src/config/mod.rs
+++ b/runtime/devnet/src/config/mod.rs
@@ -1,7 +1,7 @@
 mod api;
 // Public due to pop api integration tests crate.
 pub mod assets;
-mod ismp;
+pub mod ismp;
 mod proxy;
 // Public due to integration tests crate.
 pub mod xcm;

--- a/runtime/devnet/src/config/revive.rs
+++ b/runtime/devnet/src/config/revive.rs
@@ -3,15 +3,6 @@ use frame_support::{
 	traits::{ConstBool, ConstU32, ConstU64, Nothing},
 };
 use frame_system::EnsureSigned;
-use pallet_api::Extension;
-use pallet_revive::{
-	chain_extension::{
-		ChainExtension, Environment, Ext, RegisteredChainExtension, Result as ExtensionResult,
-		RetVal, ReturnFlags,
-	},
-	wasm::Memory,
-};
-use sp_std::vec;
 
 use super::api::{self, Config};
 use crate::{

--- a/runtime/devnet/src/config/revive.rs
+++ b/runtime/devnet/src/config/revive.rs
@@ -38,5 +38,5 @@ impl pallet_revive::Config for Runtime {
 	type UploadOrigin = EnsureSigned<Self::AccountId>;
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
-	type Xcm = ();
+	type Xcm = pallet_xcm::Pallet<Self>;
 }

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -39,7 +39,7 @@ use frame_system::{
 	limits::{BlockLength, BlockWeights},
 	EnsureRoot,
 };
-use pallet_api::fungibles;
+use pallet_api::{fungibles, messaging};
 use pallet_balances::Call as BalancesCall;
 use pallet_ismp::mmr::{Leaf, Proof, ProofKeys};
 use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
@@ -194,11 +194,9 @@ type EventRecord = frame_system::EventRecord<
 >;
 
 // Prints debug output of the `contracts` pallet to stdout if the node is
-// started with `-lruntime::contracts=debug`.
-const CONTRACTS_DEBUG_OUTPUT: pallet_contracts::DebugInfo =
-	pallet_contracts::DebugInfo::UnsafeDebug;
-const CONTRACTS_EVENTS: pallet_contracts::CollectEvents =
-	pallet_contracts::CollectEvents::UnsafeCollect;
+// started with `-lruntime::revive=trace`.
+const CONTRACTS_DEBUG_OUTPUT: pallet_revive::DebugInfo = pallet_revive::DebugInfo::UnsafeDebug;
+const CONTRACTS_EVENTS: pallet_revive::CollectEvents = pallet_revive::CollectEvents::UnsafeCollect;
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
@@ -634,6 +632,8 @@ mod runtime {
 	// Pop API
 	#[runtime::pallet_index(150)]
 	pub type Fungibles = fungibles::Pallet<Runtime>;
+	#[runtime::pallet_index(151)]
+	pub type Messaging = messaging::Pallet<Runtime>;
 
 	// Revive
 	#[runtime::pallet_index(255)]
@@ -813,8 +813,8 @@ impl_runtime_apis! {
 				gas_limit.unwrap_or(RuntimeBlockWeights::get().max_block),
 				storage_deposit_limit.unwrap_or(u128::MAX),
 				input_data,
-				pallet_revive::DebugInfo::UnsafeDebug,
-				pallet_revive::CollectEvents::UnsafeCollect,
+				CONTRACTS_DEBUG_OUTPUT,
+				CONTRACTS_EVENTS,
 			)
 		}
 
@@ -836,8 +836,8 @@ impl_runtime_apis! {
 				code,
 				data,
 				salt,
-				pallet_revive::DebugInfo::UnsafeDebug,
-				pallet_revive::CollectEvents::UnsafeCollect,
+				CONTRACTS_DEBUG_OUTPUT,
+				CONTRACTS_EVENTS,
 			)
 		}
 


### PR DESCRIPTION
### NOTE:
- Requires `pop-cli` installed from https://github.com/r0gue-io/pop-cli/tree/sub0
- revive requires a call to `revive::map_account` from whatever account you are testing with.

### Steps:
- Install `pop-cli` from above branch
- Launch network via `pop up parachain -f ./networks/devnet.toml`
  - You will need https://github.com/r0gue-io/paseo-network-runtimes/releases/tag/v1.2.5, named as `paseo-chain-spec-generator-v1.2.5` within your pop cache. All other binaries can be the latest sourced by pop.
  - Ensure both chains are building blocks
- Build your contract via `pop build` or `cargo contract build --target=riscv` - e.g. `pop-api/examples/messaging`
- Deploy your contract via `pop up contract`, noting the address. If using the example contract, use `pop up contract --args 1000 --value 100000000000` to specify AH as the chain to interact with and to fund the contract.
- XCM:
  - Call the contract via `pop call contract`:
    - Using the example contract, select the `fund` message first and enter a value to fund the smart contract's account on AH (e.g. 10 PAS). Check that the xcm send is successful and the contract account on AH is funded.
    - Using the example contract, select the `transact` message and enter `0x000734706f70206f6e20726576697665` as the value for the `call parameter` and `{ ref_time:65000000, proof_size:0 }` for the `weight` parameter. Enter a value to transfer to the contract with the call for the execution - e.g. 0.5 PAS. Check that the xcm send is successful and that a response is received a few blocks later.
- ISMP:
  - Call the contract via `pop call contract`:
    - Using the example contract, select the `get` message and enter a value for the `key` parameter. See https://www.shawntabrizi.com/substrate-known-keys/ for examples. Enter a **recent** block number on AH for the `height` parameter. Once submitted, find the `commitment` for `Ismp -> Request` event, which will be required to relay the storage value(s) from AH.
    - Use pop to relay: 
      - Query commitments for relay: `pop relay query --rpc ws://localhost:9944 --commitment 0x9fc3f62ba18df61f859981711b12174d7a1f087e539daf0388a459679da257e9`
      - Relay a get request: `pop relay get --source ws://127.0.0.1:9944 --dest ws://127.0.0.1:9977 --commitment 0x9fc3f62ba18df61f859981711b12174d7a1f087e539daf0388a459679da257e9`