### PR TITLE
refactor(devnet): remove pallet-contracts remnants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11005,7 +11005,6 @@ dependencies = [
  "pallet-authorship",
  "pallet-balances",
  "pallet-collator-selection",
- "pallet-contracts",
  "pallet-ismp",
  "pallet-ismp-runtime-api",
  "pallet-message-queue",

--- a/runtime/devnet/Cargo.toml
+++ b/runtime/devnet/Cargo.toml
@@ -40,7 +40,6 @@ pallet-assets.workspace = true
 pallet-aura.workspace = true
 pallet-authorship.workspace = true
 pallet-balances.workspace = true
-pallet-contracts.workspace = true
 pallet-message-queue.workspace = true
 pallet-multisig.workspace = true
 pallet-nft-fractionalization.workspace = true
@@ -138,7 +137,6 @@ std = [
 	"pallet-authorship/std",
 	"pallet-balances/std",
 	"pallet-collator-selection/std",
-	"pallet-contracts/std",
 	"pallet-ismp-runtime-api/std",
 	"pallet-ismp/std",
 	"pallet-message-queue/std",
@@ -197,7 +195,6 @@ runtime-benchmarks = [
 	"pallet-assets/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-collator-selection/runtime-benchmarks",
-	"pallet-contracts/runtime-benchmarks",
 	"pallet-message-queue/runtime-benchmarks",
 	"pallet-multisig/runtime-benchmarks",
 	"pallet-nft-fractionalization/runtime-benchmarks",
@@ -236,7 +233,6 @@ try-runtime = [
 	"pallet-authorship/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-collator-selection/try-runtime",
-	"pallet-contracts/try-runtime",
 	"pallet-ismp/try-runtime",
 	"pallet-message-queue/try-runtime",
 	"pallet-multisig/try-runtime",

--- a/runtime/devnet/src/config/api/versioning.rs
+++ b/runtime/devnet/src/config/api/versioning.rs
@@ -117,7 +117,7 @@ impl From<DispatchError> for V0Error {
 			Module(error) => {
 				// Note: message not used
 				let ModuleError { index, error, message: _message } = error;
-				// Map `pallet-contracts::Error::DecodingFailed` to `Error::DecodingFailed`
+				// Map `pallet-revive::Error::DecodingFailed` to `Error::DecodingFailed`
 				if index as usize ==
 					<crate::Revive as frame_support::traits::PalletInfoAccess>::index() &&
 					error == DECODING_FAILED_ERROR

--- a/runtime/devnet/src/config/api/versioning.rs
+++ b/runtime/devnet/src/config/api/versioning.rs
@@ -119,7 +119,7 @@ impl From<DispatchError> for V0Error {
 				let ModuleError { index, error, message: _message } = error;
 				// Map `pallet-revive::Error::DecodingFailed` to `Error::DecodingFailed`
 				if index as usize ==
-					<crate::Revive as frame_support::traits::PalletInfoAccess>::index() &&
+					<crate::Contracts as frame_support::traits::PalletInfoAccess>::index() &&
 					error == DECODING_FAILED_ERROR
 				{
 					Error::DecodingFailed

--- a/runtime/devnet/src/config/revive.rs
+++ b/runtime/devnet/src/config/revive.rs
@@ -3,15 +3,6 @@ use frame_support::{
 	traits::{ConstBool, ConstU32, ConstU64, Nothing},
 };
 use frame_system::EnsureSigned;
-use pallet_api::Extension;
-use pallet_revive::{
-	chain_extension::{
-		ChainExtension, Environment, Ext, RegisteredChainExtension, Result as ExtensionResult,
-		RetVal, ReturnFlags,
-	},
-	wasm::Memory,
-};
-use sp_std::vec;
 
 use super::api::{self, Config};
 use crate::{

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -609,7 +609,7 @@ mod runtime {
 
 	// Contracts via Revive
 	#[runtime::pallet_index(40)]
-	pub type Revive = pallet_revive::Pallet<Runtime>;
+	pub type Contracts = pallet_revive::Pallet<Runtime>;
 
 	// Proxy
 	#[runtime::pallet_index(41)]
@@ -800,15 +800,15 @@ impl_runtime_apis! {
 			storage_deposit_limit: Option<Balance>,
 			input_data: Vec<u8>,
 		) -> pallet_revive::ContractExecResult<Balance, EventRecord> {
-			Revive::bare_call(
+			Contracts::bare_call(
 				RuntimeOrigin::signed(origin),
 				dest,
 				value,
 				gas_limit.unwrap_or(RuntimeBlockWeights::get().max_block),
 				storage_deposit_limit.unwrap_or(u128::MAX),
 				input_data,
-				pallet_revive::DebugInfo::UnsafeDebug,
-				pallet_revive::CollectEvents::UnsafeCollect,
+				CONTRACTS_DEBUG_OUTPUT,
+				CONTRACTS_EVENTS,
 			)
 		}
 
@@ -822,7 +822,7 @@ impl_runtime_apis! {
 			salt: Option<[u8; 32]>,
 		) -> pallet_revive::ContractInstantiateResult<Balance, EventRecord>
 		{
-			Revive::bare_instantiate(
+			Contracts::bare_instantiate(
 				RuntimeOrigin::signed(origin),
 				value,
 				gas_limit.unwrap_or(RuntimeBlockWeights::get().max_block),
@@ -841,7 +841,7 @@ impl_runtime_apis! {
 			storage_deposit_limit: Option<Balance>,
 		) -> pallet_revive::CodeUploadResult<Balance>
 		{
-			Revive::bare_upload_code(
+			Contracts::bare_upload_code(
 				RuntimeOrigin::signed(origin),
 				code,
 				storage_deposit_limit.unwrap_or(u128::MAX),
@@ -852,7 +852,7 @@ impl_runtime_apis! {
 			address: H160,
 			key: [u8; 32],
 		) -> pallet_revive::GetStorageResult {
-			Revive::get_storage(
+			Contracts::get_storage(
 				address,
 				key
 			)

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -193,12 +193,10 @@ type EventRecord = frame_system::EventRecord<
 	<Runtime as frame_system::Config>::Hash,
 >;
 
-// Prints debug output of the `contracts` pallet to stdout if the node is
-// started with `-lruntime::contracts=debug`.
-const CONTRACTS_DEBUG_OUTPUT: pallet_contracts::DebugInfo =
-	pallet_contracts::DebugInfo::UnsafeDebug;
-const CONTRACTS_EVENTS: pallet_contracts::CollectEvents =
-	pallet_contracts::CollectEvents::UnsafeCollect;
+// Prints debug output of the `revive` pallet to stdout if the node is
+// started with `-lruntime::revive=debug`.
+const CONTRACTS_DEBUG_OUTPUT: pallet_revive::DebugInfo = pallet_revive::DebugInfo::UnsafeDebug;
+const CONTRACTS_EVENTS: pallet_revive::CollectEvents = pallet_revive::CollectEvents::UnsafeCollect;
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
@@ -609,9 +607,9 @@ mod runtime {
 	#[runtime::pallet_index(39)]
 	pub type IsmpParachain = ismp_parachain::Pallet<Runtime>;
 
-	// Contracts
-	// #[runtime::pallet_index(40)]
-	// pub type Contracts = pallet_contracts::Pallet<Runtime>;
+	// Contracts via Revive
+	#[runtime::pallet_index(40)]
+	pub type Revive = pallet_revive::Pallet<Runtime>;
 
 	// Proxy
 	#[runtime::pallet_index(41)]
@@ -634,10 +632,6 @@ mod runtime {
 	// Pop API
 	#[runtime::pallet_index(150)]
 	pub type Fungibles = fungibles::Pallet<Runtime>;
-
-	// Revive
-	#[runtime::pallet_index(255)]
-	pub type Revive = pallet_revive::Pallet<Runtime>;
 }
 
 #[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
Just removes a few pallet-contracts remnants from the devnet runtime.

Note: the second commit restores the name of the pallet in the runtime, which restores the Contracts UI within PJS. Whether it works is another story...