### PR TITLE
chore: timestamp settings for tests

### DIFF
--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -291,6 +291,9 @@ impl pallet_timestamp::Config for Runtime {
 	type MinimumPeriod = ConstU64<0>;
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
+	#[cfg(feature = "std")]
+	type OnTimestampSet = ();
+	#[cfg(not(feature = "std"))]
 	type OnTimestampSet = Aura;
 	type WeightInfo = ();
 }


### PR DESCRIPTION
Required change for drink test environment. This PR has to be merged to have the reviewers test #300 