### PR TITLE
feat(revive): add `to_account_id` host function for converting from a `h160` to `h256` account

### DIFF
--- a/pallets/revive/src/wasm/runtime.rs
+++ b/pallets/revive/src/wasm/runtime.rs
@@ -2041,4 +2041,25 @@ pub mod env {
 		*self.ext.last_frame_output_mut() = output;
 		Ok(result?)
 	}
+
+	#[api_version(0)]
+	pub fn to_account_id(
+		&mut self,
+		memory: &mut M,
+		addr_ptr: u32,
+		out_ptr: u32,
+	) -> Result<(), TrapReason> {
+		// TODO: add specific runtime cost
+		self.charge_gas(RuntimeCosts::Caller)?;
+		let mut address = H160::zero();
+		memory.read_into_buf(addr_ptr, address.as_bytes_mut())?;
+		let account = <E::T as Config>::AddressMapper::to_account_id(&address);
+		Ok(self.write_fixed_sandbox_output(
+			memory,
+			out_ptr,
+			account.encode().as_ref(),
+			false,
+			already_charged,
+		)?)
+	}
 }

--- a/pallets/revive/uapi/src/host.rs
+++ b/pallets/revive/uapi/src/host.rs
@@ -635,6 +635,9 @@ pub trait HostFn: private::Sealed {
 	/// - `output`: A reference to the output buffer to write the data.
 	/// - `offset`: Byte offset into the returned data
 	fn return_data_copy(output: &mut &mut [u8], offset: u32);
+
+	/// Convert an ethereum address to a native account id.
+	fn to_account_id(addr: &[u8; 20], output: &mut [u8; 32]);
 }
 
 mod private {

--- a/pallets/revive/uapi/src/host/riscv32.rs
+++ b/pallets/revive/uapi/src/host/riscv32.rs
@@ -133,6 +133,7 @@ mod sys {
 		) -> ReturnCode;
 		pub fn return_data_size(out_ptr: *mut u8);
 		pub fn return_data_copy(out_ptr: *mut u8, out_len_ptr: *mut u32, offset: u32);
+		pub fn to_account_id(addr_ptr: *const u8, out_ptr: *mut u8);
 	}
 }
 
@@ -564,5 +565,10 @@ impl HostFn for HostFnImpl {
 			unsafe { sys::return_data_copy(output.as_mut_ptr(), &mut output_len, offset) };
 		}
 		extract_from_slice(output, output_len as usize);
+	}
+
+	/// Convert an ethereum address to a native account id.
+	fn to_account_id(addr: &[u8; 20], output: &mut [u8; 32]) {
+		unsafe { sys::to_account_id(addr.as_ptr(), output.as_mut_ptr()) };
 	}
 }


### PR DESCRIPTION
Required for a compatible implementation of self.env().caller() for ink!