### PR TITLE
feat(drink test): assert last event

### DIFF
--- a/pop-api/examples/fungibles/tests.rs
+++ b/pop-api/examples/fungibles/tests.rs
@@ -1,5 +1,5 @@
 use drink::{
-	assert_err, assert_last_event, assert_ok, call,
+	assert_err, assert_last_contract_event, assert_ok, call,
 	devnet::{
 		account_id_from_slice,
 		error::{
@@ -69,7 +69,7 @@ fn new_constructor_works(mut session: Session) {
 	// Token exists after the deployment.
 	assert!(session.sandbox().asset_exists(&TOKEN));
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Created {
 			id: TOKEN,
@@ -225,7 +225,7 @@ fn transfer_works(mut session: Session) {
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &contract), AMOUNT - value);
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &BOB), value);
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Transfer {
 			from: Some(account_id_from_slice(&contract)),
@@ -315,7 +315,7 @@ fn transfer_from_works(mut session: Session) {
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &ALICE), value);
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &BOB), value);
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Approval {
 			owner: account_id_from_slice(&ALICE),
@@ -362,7 +362,7 @@ fn approve_works(mut session: Session) {
 	assert_ok!(approve(&mut session, BOB, value));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &BOB), value);
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
@@ -374,7 +374,7 @@ fn approve_works(mut session: Session) {
 	assert_ok!(approve(&mut session, ALICE, value - 1));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &ALICE), value - 1);
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
@@ -428,7 +428,7 @@ fn increase_allowance_works(mut session: Session) {
 	assert_ok!(increase_allowance(&mut session, ALICE, value));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &ALICE), AMOUNT + value);
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
@@ -440,7 +440,7 @@ fn increase_allowance_works(mut session: Session) {
 	assert_ok!(increase_allowance(&mut session, ALICE, value));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &ALICE), AMOUNT + value * 2);
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
@@ -507,7 +507,7 @@ fn decrease_allowance_works(mut session: Session) {
 	assert_ok!(decrease_allowance(&mut session, ALICE, value));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &ALICE), AMOUNT - value);
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
@@ -519,7 +519,7 @@ fn decrease_allowance_works(mut session: Session) {
 	assert_ok!(decrease_allowance(&mut session, ALICE, value));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &ALICE), AMOUNT - value * 2);
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
@@ -616,7 +616,7 @@ fn mint_works(mut session: Session) {
 	assert_eq!(session.sandbox().total_supply(&TOKEN), value);
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &ALICE), value);
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Transfer { from: None, to: Some(account_id_from_slice(&ALICE)), value }
 	);
@@ -681,7 +681,7 @@ fn burn_works(mut session: Session) {
 	assert_eq!(session.sandbox().total_supply(&TOKEN), AMOUNT - value);
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &ALICE), AMOUNT - value);
 	// Successfully emit event.
-	assert_last_event!(
+	assert_last_contract_event!(
 		&session,
 		Transfer { from: Some(account_id_from_slice(&ALICE)), to: None, value }
 	);

--- a/pop-api/examples/fungibles/tests.rs
+++ b/pop-api/examples/fungibles/tests.rs
@@ -1,5 +1,5 @@
 use drink::{
-	assert_err, assert_ok, call,
+	assert_err, assert_last_event, assert_ok, call,
 	devnet::{
 		account_id_from_slice,
 		error::{
@@ -69,15 +69,13 @@ fn new_constructor_works(mut session: Session) {
 	// Token exists after the deployment.
 	assert!(session.sandbox().asset_exists(&TOKEN));
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Created {
 			id: TOKEN,
 			creator: account_id_from_slice(&contract),
 			admin: account_id_from_slice(&contract),
 		}
-		.encode()
-		.as_slice()
 	);
 }
 
@@ -227,15 +225,13 @@ fn transfer_works(mut session: Session) {
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &contract), AMOUNT - value);
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &BOB), value);
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Transfer {
 			from: Some(account_id_from_slice(&contract)),
 			to: Some(account_id_from_slice(&BOB)),
 			value,
 		}
-		.encode()
-		.as_slice()
 	);
 }
 
@@ -319,15 +315,13 @@ fn transfer_from_works(mut session: Session) {
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &ALICE), value);
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &BOB), value);
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Approval {
 			owner: account_id_from_slice(&ALICE),
 			spender: account_id_from_slice(&contract),
 			value,
 		}
-		.encode()
-		.as_slice()
 	);
 }
 
@@ -368,29 +362,25 @@ fn approve_works(mut session: Session) {
 	assert_ok!(approve(&mut session, BOB, value));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &BOB), value);
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
 			spender: account_id_from_slice(&BOB),
 			value,
 		}
-		.encode()
-		.as_slice()
 	);
 	// Non-additive, sets new value.
 	assert_ok!(approve(&mut session, ALICE, value - 1));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &ALICE), value - 1);
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
 			spender: account_id_from_slice(&ALICE),
 			value: value - 1,
 		}
-		.encode()
-		.as_slice()
 	);
 }
 
@@ -438,29 +428,25 @@ fn increase_allowance_works(mut session: Session) {
 	assert_ok!(increase_allowance(&mut session, ALICE, value));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &ALICE), AMOUNT + value);
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
 			spender: account_id_from_slice(&ALICE),
 			value: AMOUNT + value,
 		}
-		.encode()
-		.as_slice()
 	);
 	// Additive.
 	assert_ok!(increase_allowance(&mut session, ALICE, value));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &ALICE), AMOUNT + value * 2);
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
 			spender: account_id_from_slice(&ALICE),
 			value: AMOUNT + value * 2,
 		}
-		.encode()
-		.as_slice()
 	);
 }
 
@@ -521,29 +507,25 @@ fn decrease_allowance_works(mut session: Session) {
 	assert_ok!(decrease_allowance(&mut session, ALICE, value));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &ALICE), AMOUNT - value);
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
 			spender: account_id_from_slice(&ALICE),
 			value: AMOUNT - value,
 		}
-		.encode()
-		.as_slice()
 	);
 	// Additive.
 	assert_ok!(decrease_allowance(&mut session, ALICE, value));
 	assert_eq!(session.sandbox().allowance(&TOKEN, &contract, &ALICE), AMOUNT - value * 2);
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Approval {
 			owner: account_id_from_slice(&contract),
 			spender: account_id_from_slice(&ALICE),
 			value: AMOUNT - value * 2,
 		}
-		.encode()
-		.as_slice()
 	);
 }
 
@@ -634,11 +616,9 @@ fn mint_works(mut session: Session) {
 	assert_eq!(session.sandbox().total_supply(&TOKEN), value);
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &ALICE), value);
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Transfer { from: None, to: Some(account_id_from_slice(&ALICE)), value }
-			.encode()
-			.as_slice()
 	);
 }
 
@@ -701,11 +681,9 @@ fn burn_works(mut session: Session) {
 	assert_eq!(session.sandbox().total_supply(&TOKEN), AMOUNT - value);
 	assert_eq!(session.sandbox().balance_of(&TOKEN, &ALICE), AMOUNT - value);
 	// Successfully emit event.
-	assert_eq!(
-		last_contract_event(&session).unwrap(),
+	assert_last_event!(
+		&session,
 		Transfer { from: Some(account_id_from_slice(&ALICE)), to: None, value }
-			.encode()
-			.as_slice()
 	);
 }
 

--- a/pop-api/src/v0/fungibles/events.rs
+++ b/pop-api/src/v0/fungibles/events.rs
@@ -13,7 +13,7 @@ use super::*;
 /// Event emitted when allowance by `owner` to `spender` changes.
 // Differing style: event name abides by the PSP22 standard.
 #[ink::event]
-#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub struct Approval {
 	/// The owner providing the allowance.
 	#[ink(topic)]
@@ -28,7 +28,7 @@ pub struct Approval {
 /// Event emitted when transfer of tokens occurs.
 // Differing style: event name abides by the PSP22 standard.
 #[ink::event]
-#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub struct Transfer {
 	/// The source of the transfer. `None` when minting.
 	#[ink(topic)]
@@ -42,7 +42,7 @@ pub struct Transfer {
 
 /// Event emitted when a token is created.
 #[ink::event]
-#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub struct Created {
 	/// The token identifier.
 	#[ink(topic)]
@@ -57,7 +57,7 @@ pub struct Created {
 
 /// Event emitted when a token is in the process of being destroyed.
 #[ink::event]
-#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub struct DestroyStarted {
 	/// The token.
 	#[ink(topic)]
@@ -66,7 +66,7 @@ pub struct DestroyStarted {
 
 /// Event emitted when new metadata is set for a token.
 #[ink::event]
-#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub struct MetadataSet {
 	/// The token.
 	#[ink(topic)]
@@ -83,7 +83,7 @@ pub struct MetadataSet {
 
 /// Event emitted when metadata is cleared for a token.
 #[ink::event]
-#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub struct MetadataCleared {
 	/// The token.
 	#[ink(topic)]

--- a/pop-api/src/v0/fungibles/events.rs
+++ b/pop-api/src/v0/fungibles/events.rs
@@ -13,6 +13,7 @@ use super::*;
 /// Event emitted when allowance by `owner` to `spender` changes.
 // Differing style: event name abides by the PSP22 standard.
 #[ink::event]
+#[derive(Debug)]
 pub struct Approval {
 	/// The owner providing the allowance.
 	#[ink(topic)]
@@ -27,6 +28,7 @@ pub struct Approval {
 /// Event emitted when transfer of tokens occurs.
 // Differing style: event name abides by the PSP22 standard.
 #[ink::event]
+#[derive(Debug)]
 pub struct Transfer {
 	/// The source of the transfer. `None` when minting.
 	#[ink(topic)]
@@ -40,6 +42,7 @@ pub struct Transfer {
 
 /// Event emitted when a token is created.
 #[ink::event]
+#[derive(Debug)]
 pub struct Created {
 	/// The token identifier.
 	#[ink(topic)]
@@ -54,6 +57,7 @@ pub struct Created {
 
 /// Event emitted when a token is in the process of being destroyed.
 #[ink::event]
+#[derive(Debug)]
 pub struct DestroyStarted {
 	/// The token.
 	#[ink(topic)]
@@ -62,6 +66,7 @@ pub struct DestroyStarted {
 
 /// Event emitted when new metadata is set for a token.
 #[ink::event]
+#[derive(Debug)]
 pub struct MetadataSet {
 	/// The token.
 	#[ink(topic)]
@@ -78,6 +83,7 @@ pub struct MetadataSet {
 
 /// Event emitted when metadata is cleared for a token.
 #[ink::event]
+#[derive(Debug)]
 pub struct MetadataCleared {
 	/// The token.
 	#[ink(topic)]


### PR DESCRIPTION
Changes made to the pop-api crate for the `assert_last_event!` macro in pop-drink

Require this PR to be merged to `pop-drink/main`: https://github.com/r0gue-io/pop-drink/pull/25

## Outcome

```rs
---- tests::transfer_works stdout ----
thread 'tests::transfer_works' panicked at tests.rs:228:5:
assertion `left == right` failed
left: Transfer { from: Some(AccountId([173, 100, 34, 109, 10, 153, 156, 207, 68, 34, 52, 155, 110, 41, 181, 130, 49, 109, 253, 15, 182, 64, 22, 194, 42, 213, 101, 242, 31, 229, 155, 97])), to: Some(AccountId([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])), value: 10000 }
right: Transfer { from: Some(AccountId([173, 100, 34, 109, 10, 153, 156, 207, 68, 34, 52, 155, 110, 41, 181, 130, 49, 109, 253, 15, 182, 64, 22, 194, 42, 213, 101, 242, 31, 229, 155, 97])), to: Some(AccountId([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])), value: 10001 }
```