### PR TITLE
chore(api): use git dep for fungible contract

### DIFF
--- a/pop-api/integration-tests/contracts/fungibles/Cargo.toml
+++ b/pop-api/integration-tests/contracts/fungibles/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [dependencies]
 ink = { version = "5.0.0", default-features = false }
-pop-api = { path = "../../../../pop-api", default-features = false, features = [ "fungibles" ] }
+pop-api = { git = "https://github.com/r0gue-io/pop-node.git", branch = "al3mart/testnet-v0.4.2", default-features = false, features = [ "fungibles" ] }
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
Updates the dependency for fungibles contract in integration tests. This way we can be sure contracts can depend on the crate.