### PR TITLE
refactor(nfts): mapping with `ApprovalsOf` in the `Allowances` storage item

### DIFF
--- a/pallets/nfts/src/benchmarking.rs
+++ b/pallets/nfts/src/benchmarking.rs
@@ -62,6 +62,27 @@ fn add_collection_metadata<T: Config<I>, I: 'static>() -> (T::AccountId, Account
 	(caller, caller_lookup)
 }
 
+fn approve_collection<T: Config<I>, I: 'static>(
+	index: u32,
+) -> (T::AccountId, AccountIdLookupOf<T>) {
+	let caller = Collection::<T, I>::get(T::Helper::collection(0)).unwrap().owner;
+	if caller != whitelisted_caller() {
+		whitelist_account!(caller);
+	}
+	let caller_lookup = T::Lookup::unlookup(caller.clone());
+	let delegate: T::AccountId = account("delegate", index, SEED);
+	let delegate_lookup = T::Lookup::unlookup(delegate.clone());
+	let deadline = BlockNumberFor::<T>::max_value();
+	assert_ok!(Nfts::<T, I>::approve_transfer(
+		SystemOrigin::Signed(caller.clone()).into(),
+		T::Helper::collection(0),
+		None,
+		delegate_lookup.clone(),
+		Some(deadline),
+	));
+	(caller, caller_lookup)
+}
+
 fn mint_item<T: Config<I>, I: 'static>(
 	index: u16,
 ) -> (T::ItemId, T::AccountId, AccountIdLookupOf<T>) {
@@ -571,7 +592,7 @@ benchmarks_instance_pallet! {
 	}
 
 	approve_transfer {
-		let i in 0..1;
+		let i in 0 .. 1;
 
 		let (collection, caller, _) = create_collection::<T, I>();
 		let (item, ..) = mint_item::<T, I>(0);
@@ -589,7 +610,7 @@ benchmarks_instance_pallet! {
 	}
 
 	cancel_approval {
-		let i in 0..1;
+		let i in 0 .. 1;
 
 		let (collection, caller, _) = create_collection::<T, I>();
 		let (item, ..) = mint_item::<T, I>(0);
@@ -598,9 +619,9 @@ benchmarks_instance_pallet! {
 		let origin = SystemOrigin::Signed(caller.clone()).into();
 		let deadline = BlockNumberFor::<T>::max_value();
 		let maybe_item = if i == 0 {
-		  None
+			None
 		} else {
-		  Some(item)
+			Some(item)
 		};
 		Nfts::<T, I>::approve_transfer(origin, collection, maybe_item, delegate_lookup.clone(), Some(deadline))?;
 	}: _(SystemOrigin::Signed(caller.clone()), collection, maybe_item, delegate_lookup)
@@ -609,16 +630,28 @@ benchmarks_instance_pallet! {
 	}
 
 	clear_all_transfer_approvals {
+		let i in 0 .. 1;
+		let n in 0 .. T::ApprovalsLimit::get();
+
 		let (collection, caller, _) = create_collection::<T, I>();
 		let (item, ..) = mint_item::<T, I>(0);
-		let delegate: T::AccountId = account("delegate", 0, SEED);
-		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
-		let origin = SystemOrigin::Signed(caller.clone()).into();
-		let deadline = BlockNumberFor::<T>::max_value();
-		Nfts::<T, I>::approve_transfer(origin, collection, Some(item), delegate_lookup.clone(), Some(deadline))?;
-	}: _(SystemOrigin::Signed(caller.clone()), collection, item)
+		let maybe_item = if i == 0 {
+			for i in 0 .. n {
+				approve_collection::<T, I>(i);
+			}
+			None
+		} else {
+			let delegate: T::AccountId = account("delegate", 0, SEED);
+			let delegate_lookup = T::Lookup::unlookup(delegate.clone());
+			let origin = SystemOrigin::Signed(caller.clone()).into();
+			let deadline = BlockNumberFor::<T>::max_value();
+			Nfts::<T, I>::approve_transfer(origin, collection, Some(item), delegate_lookup.clone(), Some(deadline))?;
+			Some(item)
+		};
+		let witness = ClearAllApprovalsWitness { allowances: n };
+	}: _(SystemOrigin::Signed(caller.clone()), collection, maybe_item, witness)
 	verify {
-		assert_last_event::<T, I>(Event::AllApprovalsCancelled {collection, item, owner: caller}.into());
+		assert_last_event::<T, I>(Event::AllApprovalsCancelled {collection, item: maybe_item, owner: caller}.into());
 	}
 
 	set_accept_ownership {

--- a/pallets/nfts/src/common_functions.rs
+++ b/pallets/nfts/src/common_functions.rs
@@ -39,11 +39,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Collection::<T, I>::get(collection).map(|i| i.items)
 	}
 
-	/// Get the allowances to spend items within the collection.
-	pub fn collection_allowances(collection: T::CollectionId) -> Option<u32> {
-		Collection::<T, I>::get(collection).map(|i| i.allowances)
-	}
-
 	/// Get the metadata of the collection item.
 	pub fn item_metadata(
 		collection: T::CollectionId,

--- a/pallets/nfts/src/features/approvals.rs
+++ b/pallets/nfts/src/features/approvals.rs
@@ -282,9 +282,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				}
 
 				Allowances::<T, I>::remove((&collection, &owner, &delegate));
-				if let Some(check_origin) = maybe_check_origin {
-					ensure!(check_origin == owner, Error::<T, I>::NoPermission);
-				}
 				collection_details.allowances.saturating_dec();
 				Ok(owner)
 			},

--- a/pallets/nfts/src/features/approvals.rs
+++ b/pallets/nfts/src/features/approvals.rs
@@ -393,9 +393,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		delegate: &T::AccountId,
 	) -> Result<(), DispatchError> {
 		// Check if a `delegate` has a permission to spend the collection.
-		if Self::check_collection_allowance(collection, owner, delegate).is_ok() {
-			return Ok(());
-		}
+		let check_collection_allowance_error =
+			match Self::check_collection_allowance(collection, owner, delegate) {
+				Ok(()) => return Ok(()),
+				Err(error) => error,
+			};
 		// Check if a `delegate` has a permission to spend the collection item.
 		if let Some(item) = item {
 			let details = Item::<T, I>::get(collection, item).ok_or(Error::<T, I>::UnknownItem)?;
@@ -408,6 +410,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			}
 			return Ok(());
 		};
-		Err(Error::<T, I>::NoPermission.into())
+		Err(check_collection_allowance_error)
 	}
 }

--- a/pallets/nfts/src/features/approvals.rs
+++ b/pallets/nfts/src/features/approvals.rs
@@ -229,7 +229,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				let now = frame_system::Pallet::<T>::block_number();
 				let deadline = maybe_deadline.map(|d| d.saturating_add(now));
 
-				AccountAllowances::<T,I>::try_mutate(&collection, &owner, |allowances| -> Result<(), DispatchError> {
+				AccountAllowances::<T,I>::try_mutate(collection, &owner, |allowances| -> Result<(), DispatchError> {
     				ensure!(*allowances < T::ApprovalsLimit::get(), Error::<T, I>::ReachedApprovalLimit);
     				Allowances::<T, I>::mutate(
     					(&collection, &owner, &delegate),
@@ -297,7 +297,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				}
 
 				Allowances::<T, I>::remove((&collection, &owner, &delegate));
-				AccountAllowances::<T, I>::mutate(&collection, &owner, |allowances| {
+				AccountAllowances::<T, I>::mutate(collection, &owner, |allowances| {
 					allowances.saturating_dec();
 				});
 				Ok(owner)
@@ -323,7 +323,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	pub(crate) fn do_clear_all_collection_approvals(
 		maybe_check_origin: Option<T::AccountId>,
 		collection: T::CollectionId,
-		witness: ClearAllApprovalsWitness,
+		witness_allowances: u32,
 	) -> DispatchResult {
 		let owner = Collection::<T, I>::try_mutate(
 			collection,
@@ -337,10 +337,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				}
 
 				AccountAllowances::<T, I>::try_mutate(
-					&collection,
+					collection,
 					&owner,
 					|allowances| -> Result<(), DispatchError> {
-						ensure!(*allowances == witness.allowances, Error::<T, I>::BadWitness);
+						ensure!(*allowances == witness_allowances, Error::<T, I>::BadWitness);
 						let _ = Allowances::<T, I>::clear_prefix(
 							(collection, owner.clone()),
 							*allowances,

--- a/pallets/nfts/src/features/approvals.rs
+++ b/pallets/nfts/src/features/approvals.rs
@@ -303,7 +303,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		delegate: &T::AccountId,
 	) -> Result<(), DispatchError> {
 		let allowances = Allowances::<T, I>::get((&collection, &owner));
-		let maybe_deadline = allowances.get(&delegate).ok_or(Error::<T, I>::NoPermission)?;
+		let maybe_deadline = allowances.get(delegate).ok_or(Error::<T, I>::NoPermission)?;
 		if let Some(deadline) = maybe_deadline {
 			let block_number = frame_system::Pallet::<T>::block_number();
 			ensure!(block_number <= *deadline, Error::<T, I>::ApprovalExpired);
@@ -337,7 +337,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			let details = Item::<T, I>::get(collection, item).ok_or(Error::<T, I>::UnknownItem)?;
 
 			let maybe_deadline =
-				details.approvals.get(&delegate).ok_or(Error::<T, I>::NoPermission)?;
+				details.approvals.get(delegate).ok_or(Error::<T, I>::NoPermission)?;
 			if let Some(deadline) = maybe_deadline {
 				let block_number = frame_system::Pallet::<T>::block_number();
 				ensure!(block_number <= *deadline, Error::<T, I>::ApprovalExpired);

--- a/pallets/nfts/src/features/approvals.rs
+++ b/pallets/nfts/src/features/approvals.rs
@@ -332,6 +332,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		if Self::check_collection_allowance(collection, owner, delegate).is_ok() {
 			return Ok(());
 		}
+
 		// Check if a `delegate` has a permission to spend the collection item.
 		if let Some(item) = item {
 			let details = Item::<T, I>::get(collection, item).ok_or(Error::<T, I>::UnknownItem)?;

--- a/pallets/nfts/src/features/approvals.rs
+++ b/pallets/nfts/src/features/approvals.rs
@@ -332,7 +332,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		if Self::check_collection_allowance(collection, owner, delegate).is_ok() {
 			return Ok(());
 		}
-
 		// Check if a `delegate` has a permission to spend the collection item.
 		if let Some(item) = item {
 			let details = Item::<T, I>::get(collection, item).ok_or(Error::<T, I>::UnknownItem)?;

--- a/pallets/nfts/src/features/create_delete_collection.rs
+++ b/pallets/nfts/src/features/create_delete_collection.rs
@@ -55,7 +55,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				item_metadatas: 0,
 				item_configs: 0,
 				attributes: 0,
-				allowances: 0,
 			},
 		);
 		CollectionRoleOf::<T, I>::insert(
@@ -97,6 +96,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///   ([`NoPermission`](crate::Error::NoPermission)).
 	/// - If the collection is not empty (contains items)
 	///   ([`CollectionNotEmpty`](crate::Error::CollectionNotEmpty)).
+	/// - If the collection approvals is not empty (contains permissions to transfer all items
+	///   within the collection)
+	///   ([`CollectionApprovalsNotEmpty`](crate::Error::CollectionApprovalsNotEmpty)).
 	/// - If the `witness` does not match the actual collection details
 	///   ([`BadWitness`](crate::Error::BadWitness)).
 	pub fn do_destroy_collection(
@@ -110,8 +112,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			if let Some(check_owner) = maybe_check_owner {
 				ensure!(collection_details.owner == check_owner, Error::<T, I>::NoPermission);
 			}
+			let allowances = AccountAllowances::<T, I>::get(collection, &collection_details.owner);
 			ensure!(collection_details.items == 0, Error::<T, I>::CollectionNotEmpty);
-			ensure!(collection_details.allowances == 0, Error::<T, I>::AllowancesNotEmpty);
+			ensure!(allowances == 0, Error::<T, I>::CollectionApprovalsNotEmpty);
 			ensure!(collection_details.attributes == witness.attributes, Error::<T, I>::BadWitness);
 			ensure!(
 				collection_details.item_metadatas == witness.item_metadatas,

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -1417,15 +1417,17 @@ pub mod pallet {
 		///
 		/// Weight: `O(1)`
 		#[pallet::call_index(17)]
-		#[pallet::weight(T::WeightInfo::clear_all_transfer_approvals(
-		    maybe_item.is_some() as u32,
-			witness.allowances
-		))]
+		#[pallet::weight(
+		    T::WeightInfo::clear_all_transfer_approvals(
+				maybe_item.is_some() as u32,
+				witness_allowances.unwrap_or_default()
+			)
+		)]
 		pub fn clear_all_transfer_approvals(
 			origin: OriginFor<T>,
 			collection: T::CollectionId,
 			maybe_item: Option<T::ItemId>,
-			witness: ClearAllApprovalsWitness,
+			witness_allowances: Option<u32>,
 		) -> DispatchResult {
 			let maybe_check_origin = T::ForceOrigin::try_origin(origin)
 				.map(|_| None)
@@ -1434,8 +1436,11 @@ pub mod pallet {
 			match maybe_item {
 				Some(item) =>
 					Self::do_clear_all_transfer_approvals(maybe_check_origin, collection, item),
-				None =>
-					Self::do_clear_all_collection_approvals(maybe_check_origin, collection, witness),
+				None => Self::do_clear_all_collection_approvals(
+					maybe_check_origin,
+					collection,
+					witness_allowances.unwrap_or_default(),
+				),
 			}
 		}
 

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -425,10 +425,8 @@ pub mod pallet {
 			NMapKey<Twox64Concat, T::CollectionId>,
 			// Collection Owner Id.
 			NMapKey<Blake2_128Concat, T::AccountId>,
-			// Delegate Id.
-			NMapKey<Blake2_128Concat, T::AccountId>,
 		),
-		bool,
+		ApprovalsOf<T, I>,
 		ValueQuery,
 	>;
 
@@ -681,7 +679,7 @@ pub mod pallet {
 		NotForSale,
 		/// The provided bid is too low.
 		BidTooLow,
-		/// The item has reached its approval limit.
+		/// The collection or item has reached its approval limit.
 		ReachedApprovalLimit,
 		/// The deadline has already expired.
 		DeadlineExpired,
@@ -1339,7 +1337,12 @@ pub mod pallet {
 					delegate,
 					maybe_deadline,
 				),
-				None => Self::do_approve_collection(maybe_check_origin, collection, delegate),
+				None => Self::do_approve_collection(
+					maybe_check_origin,
+					collection,
+					delegate,
+					maybe_deadline,
+				),
 			}
 		}
 

--- a/pallets/nfts/src/tests.rs
+++ b/pallets/nfts/src/tests.rs
@@ -3369,9 +3369,9 @@ fn collection_locking_should_work() {
 
 		let stored_config = CollectionConfigOf::<Test>::get(collection_id).unwrap();
 		let full_lock_config = collection_config_from_disabled_settings(
-			CollectionSetting::TransferableItems
-				| CollectionSetting::UnlockedMetadata
-				| CollectionSetting::UnlockedAttributes,
+			CollectionSetting::TransferableItems |
+				CollectionSetting::UnlockedMetadata |
+				CollectionSetting::UnlockedAttributes,
 		);
 		assert_eq!(stored_config, full_lock_config);
 	});

--- a/pallets/nfts/src/tests.rs
+++ b/pallets/nfts/src/tests.rs
@@ -3369,9 +3369,9 @@ fn collection_locking_should_work() {
 
 		let stored_config = CollectionConfigOf::<Test>::get(collection_id).unwrap();
 		let full_lock_config = collection_config_from_disabled_settings(
-			CollectionSetting::TransferableItems |
-				CollectionSetting::UnlockedMetadata |
-				CollectionSetting::UnlockedAttributes,
+			CollectionSetting::TransferableItems
+				| CollectionSetting::UnlockedMetadata
+				| CollectionSetting::UnlockedAttributes,
 		);
 		assert_eq!(stored_config, full_lock_config);
 	});

--- a/pallets/nfts/src/tests.rs
+++ b/pallets/nfts/src/tests.rs
@@ -661,6 +661,19 @@ fn transfer_owner_should_work() {
 		assert_ok!(Nfts::set_accept_ownership(RuntimeOrigin::signed(account(2)), Some(0)));
 		assert_eq!(System::consumers(&account(2)), 1);
 
+		assert_ok!(Nfts::approve_transfer(
+			RuntimeOrigin::signed(account(1)),
+			0,
+			None,
+			account(3),
+			None
+		));
+		assert_noop!(
+			Nfts::transfer_ownership(RuntimeOrigin::signed(account(1)), 0, account(2)),
+			Error::<Test>::CollectionApprovalsNotEmpty
+		);
+		assert_ok!(Nfts::cancel_approval(RuntimeOrigin::signed(account(1)), 0, None, account(3),));
+
 		assert_ok!(Nfts::transfer_ownership(RuntimeOrigin::signed(account(1)), 0, account(2)));
 		assert_eq!(System::consumers(&account(2)), 1); // one consumer is added due to deposit repatriation
 

--- a/pallets/nfts/src/tests.rs
+++ b/pallets/nfts/src/tests.rs
@@ -2387,7 +2387,7 @@ fn clear_all_transfer_approvals_works() {
 				RuntimeOrigin::signed(account(3)),
 				0,
 				Some(42),
-				ClearAllApprovalsWitness { allowances: 0 }
+				None
 			),
 			Error::<Test>::NoPermission
 		);
@@ -2396,7 +2396,7 @@ fn clear_all_transfer_approvals_works() {
 			RuntimeOrigin::signed(account(2)),
 			0,
 			Some(42),
-			ClearAllApprovalsWitness { allowances: 0 }
+			None
 		));
 
 		assert!(events().contains(&Event::<Test>::AllApprovalsCancelled {
@@ -2449,22 +2449,12 @@ fn clear_all_collection_approvals_works() {
 		));
 
 		assert_noop!(
-			Nfts::clear_all_transfer_approvals(
-				RuntimeOrigin::signed(account(2)),
-				0,
-				None,
-				ClearAllApprovalsWitness { allowances: 2 }
-			),
+			Nfts::clear_all_transfer_approvals(RuntimeOrigin::signed(account(2)), 0, None, Some(2)),
 			Error::<Test>::NoPermission
 		);
 
 		assert_noop!(
-			Nfts::clear_all_transfer_approvals(
-				RuntimeOrigin::signed(account(1)),
-				0,
-				None,
-				ClearAllApprovalsWitness { allowances: 1 }
-			),
+			Nfts::clear_all_transfer_approvals(RuntimeOrigin::signed(account(1)), 0, None, Some(1)),
 			Error::<Test>::BadWitness
 		);
 
@@ -2472,7 +2462,7 @@ fn clear_all_collection_approvals_works() {
 			RuntimeOrigin::signed(account(1)),
 			0,
 			None,
-			ClearAllApprovalsWitness { allowances: 2 }
+			Some(2)
 		));
 		assert!(events().contains(&Event::<Test>::AllApprovalsCancelled {
 			collection: 0,

--- a/pallets/nfts/src/tests.rs
+++ b/pallets/nfts/src/tests.rs
@@ -2043,7 +2043,7 @@ fn cancel_approval_collection_works_with_admin() {
 			owner: account(1),
 			delegate: account(3)
 		}));
-		assert_eq!(Allowances::<Test>::get((0, account(2), account(3))), false);
+		assert_eq!(Allowances::<Test>::get((0, account(2))).contains_key(&account(3)), false);
 		assert_eq!(Nfts::collection_allowances(0).unwrap(), 0);
 
 		assert_noop!(
@@ -2200,7 +2200,7 @@ fn approval_collection_works_with_admin() {
 			delegate: account(3),
 			deadline: None
 		}));
-		assert_eq!(Allowances::<Test>::get((0, account(1), account(3))), true);
+		assert!(Allowances::<Test>::get((0, account(1))).contains_key(&account(3)));
 		assert_eq!(Nfts::collection_allowances(0).unwrap(), 1);
 		assert_ok!(Nfts::transfer(RuntimeOrigin::signed(account(3)), 0, 42, account(4)));
 	});

--- a/pallets/nfts/src/tests.rs
+++ b/pallets/nfts/src/tests.rs
@@ -2383,14 +2383,20 @@ fn clear_all_transfer_approvals_works() {
 		));
 
 		assert_noop!(
-			Nfts::clear_all_transfer_approvals(RuntimeOrigin::signed(account(3)), 0, Some(42)),
+			Nfts::clear_all_transfer_approvals(
+				RuntimeOrigin::signed(account(3)),
+				0,
+				Some(42),
+				ClearAllApprovalsWitness { allowances: 0 }
+			),
 			Error::<Test>::NoPermission
 		);
 
 		assert_ok!(Nfts::clear_all_transfer_approvals(
 			RuntimeOrigin::signed(account(2)),
 			0,
-			Some(42)
+			Some(42),
+			ClearAllApprovalsWitness { allowances: 0 }
 		));
 
 		assert!(events().contains(&Event::<Test>::AllApprovalsCancelled {
@@ -2443,17 +2449,38 @@ fn clear_all_collection_approvals_works() {
 		));
 
 		assert_noop!(
-			Nfts::clear_all_transfer_approvals(RuntimeOrigin::signed(account(2)), 0, None),
+			Nfts::clear_all_transfer_approvals(
+				RuntimeOrigin::signed(account(2)),
+				0,
+				None,
+				ClearAllApprovalsWitness { allowances: 2 }
+			),
 			Error::<Test>::NoPermission
 		);
 
-		assert_ok!(Nfts::clear_all_transfer_approvals(RuntimeOrigin::signed(account(1)), 0, None));
+		assert_noop!(
+			Nfts::clear_all_transfer_approvals(
+				RuntimeOrigin::signed(account(1)),
+				0,
+				None,
+				ClearAllApprovalsWitness { allowances: 1 }
+			),
+			Error::<Test>::BadWitness
+		);
+
+		assert_ok!(Nfts::clear_all_transfer_approvals(
+			RuntimeOrigin::signed(account(1)),
+			0,
+			None,
+			ClearAllApprovalsWitness { allowances: 2 }
+		));
 		assert!(events().contains(&Event::<Test>::AllApprovalsCancelled {
 			collection: 0,
 			item: None,
 			owner: account(1),
 		}));
 		assert_eq!(Allowances::<Test>::iter_prefix((0, account(1))).count(), 0);
+		assert_eq!(AccountAllowances::<Test>::get(0, account(1)), 0);
 
 		assert_noop!(
 			Nfts::transfer(RuntimeOrigin::signed(account(3)), 0, 42, account(5)),

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -122,14 +122,6 @@ pub struct DestroyWitness {
 	pub attributes: u32,
 }
 
-/// Witness data for the destroy transactions.
-#[derive(Copy, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-pub struct ClearAllApprovalsWitness {
-	/// The total number of collection approvals in the collection.
-	#[codec(compact)]
-	pub allowances: u32,
-}
-
 impl<AccountId, DepositBalance> CollectionDetails<AccountId, DepositBalance> {
 	pub fn destroy_witness(&self) -> DestroyWitness {
 		DestroyWitness {

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -106,8 +106,6 @@ pub struct CollectionDetails<AccountId, DepositBalance> {
 	pub item_configs: u32,
 	/// The total number of attributes for this collection.
 	pub attributes: u32,
-	/// The total number of allowances to spend all items within collections.
-	pub allowances: u32,
 }
 
 /// Witness data for the destroy transactions.
@@ -122,6 +120,14 @@ pub struct DestroyWitness {
 	/// The total number of attributes for this collection.
 	#[codec(compact)]
 	pub attributes: u32,
+}
+
+/// Witness data for the destroy transactions.
+#[derive(Copy, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub struct ClearAllApprovalsWitness {
+	/// The total number of collection approvals in the collection.
+	#[codec(compact)]
+	pub allowances: u32,
 }
 
 impl<AccountId, DepositBalance> CollectionDetails<AccountId, DepositBalance> {

--- a/pallets/nfts/src/weights.rs
+++ b/pallets/nfts/src/weights.rs
@@ -588,14 +588,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(113), added: 2588, mode: `MaxEncodedLen`)
 	/// The range of component `i` is `[0, 1]`.
 	/// The range of component `n` is `[0, 20]`.
-	fn clear_all_transfer_approvals(i: u32, n: u32, ) -> Weight {
+	fn clear_all_transfer_approvals(i: u32, _n: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1614`
 		//  Estimated: `52750 + i * (4325 ±496_172_781_796_926)`
 		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(34_351_559, 52750)
-			// Standard Error: 3_279
-			.saturating_add(Weight::from_parts(46_401, 0).saturating_mul(n.into()))
+		Weight::from_parts(35_525_221, 52750)
 			.saturating_add(T::DbWeight::get().reads(22_u64))
 			.saturating_add(T::DbWeight::get().writes(22_u64))
 			.saturating_add(Weight::from_parts(0, 4325).saturating_mul(i.into()))
@@ -1320,14 +1318,12 @@ impl WeightInfo for () {
 	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(113), added: 2588, mode: `MaxEncodedLen`)
 	/// The range of component `i` is `[0, 1]`.
 	/// The range of component `n` is `[0, 20]`.
-	fn clear_all_transfer_approvals(i: u32, n: u32, ) -> Weight {
+	fn clear_all_transfer_approvals(i: u32, _n: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1614`
 		//  Estimated: `52750 + i * (4325 ±496_172_781_796_926)`
 		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(34_351_559, 52750)
-			// Standard Error: 3_279
-			.saturating_add(Weight::from_parts(46_401, 0).saturating_mul(n.into()))
+		Weight::from_parts(35_525_221, 52750)
 			.saturating_add(RocksDbWeight::get().reads(22_u64))
 			.saturating_add(RocksDbWeight::get().writes(22_u64))
 			.saturating_add(Weight::from_parts(0, 4325).saturating_mul(i.into()))

--- a/pallets/nfts/src/weights.rs
+++ b/pallets/nfts/src/weights.rs
@@ -61,7 +61,7 @@ pub trait WeightInfo {
 	fn clear_collection_metadata() -> Weight;
 	fn approve_transfer(i: u32, ) -> Weight;
 	fn cancel_approval(i: u32, ) -> Weight;
-	fn clear_all_transfer_approvals() -> Weight;
+	fn clear_all_transfer_approvals(i: u32, n: u32, ) -> Weight;
 	fn set_accept_ownership() -> Weight;
 	fn set_collection_max_supply() -> Weight;
 	fn update_mint_settings() -> Weight;
@@ -117,7 +117,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
 	/// Storage: `Nfts::Collection` (r:1 w:1)
-	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
+	/// Storage: `Nfts::AccountAllowances` (r:1 w:0)
+	/// Proof: `Nfts::AccountAllowances` (`max_values`: None, `max_size`: Some(64), added: 2539, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::ItemMetadataOf` (r:1 w:0)
 	/// Proof: `Nfts::ItemMetadataOf` (`max_values`: None, `max_size`: Some(347), added: 2822, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::CollectionRoleOf` (r:1 w:1)
@@ -135,19 +137,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `m` is `[0, 1000]`.
 	/// The range of component `c` is `[0, 1000]`.
 	/// The range of component `a` is `[0, 1000]`.
-	fn destroy(m: u32, c: u32, a: u32, ) -> Weight {
+	fn destroy(_m: u32, c: u32, a: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `32169 + a * (366 ±0)`
+		//  Measured:  `32165 + a * (366 ±0)`
 		//  Estimated: `2523990 + a * (2954 ±0)`
-		// Minimum execution time: 976_000_000 picoseconds.
-		Weight::from_parts(489_392_768, 2523990)
-			// Standard Error: 29_146
-			.saturating_add(Weight::from_parts(2_634, 0).saturating_mul(m.into()))
-			// Standard Error: 29_146
-			.saturating_add(Weight::from_parts(406_042, 0).saturating_mul(c.into()))
-			// Standard Error: 29_146
-			.saturating_add(Weight::from_parts(5_358_742, 0).saturating_mul(a.into()))
-			.saturating_add(T::DbWeight::get().reads(1004_u64))
+		// Minimum execution time: 986_000_000 picoseconds.
+		Weight::from_parts(985_849_637, 2523990)
+			// Standard Error: 13_005
+			.saturating_add(Weight::from_parts(6_541, 0).saturating_mul(c.into()))
+			// Standard Error: 13_005
+			.saturating_add(Weight::from_parts(5_088_456, 0).saturating_mul(a.into()))
+			.saturating_add(T::DbWeight::get().reads(1005_u64))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(a.into())))
 			.saturating_add(T::DbWeight::get().writes(1005_u64))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(a.into())))
@@ -228,8 +228,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(8_u64))
 	}
-	/// Storage: `Nfts::Collection` (r:1 w:1)
-	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+	//// Storage: `Nfts::Collection` (r:1 w:1)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Attribute` (r:1 w:0)
 	/// Proof: `Nfts::Attribute` (`max_values`: None, `max_size`: Some(479), added: 2954, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::CollectionConfigOf` (r:1 w:0)
@@ -248,10 +248,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `Nfts::PendingSwapOf` (`max_values`: None, `max_size`: Some(71), added: 2546, mode: `MaxEncodedLen`)
 	fn transfer() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `609`
+		//  Measured:  `605`
 		//  Estimated: `6068`
-		// Minimum execution time: 39_000_000 picoseconds.
-		Weight::from_parts(41_000_000, 6068)
+		// Minimum execution time: 38_000_000 picoseconds.
+		Weight::from_parts(39_000_000, 6068)
 			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(8_u64))
 	}
@@ -317,16 +317,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `Nfts::OwnershipAcceptance` (r:1 w:1)
 	/// Proof: `Nfts::OwnershipAcceptance` (`max_values`: None, `max_size`: Some(52), added: 2527, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Collection` (r:1 w:1)
-	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
 	/// Storage: `System::Account` (r:1 w:1)
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::CollectionAccount` (r:0 w:2)
 	/// Proof: `Nfts::CollectionAccount` (`max_values`: None, `max_size`: Some(68), added: 2543, mode: `MaxEncodedLen`)
 	fn transfer_ownership() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `421`
+		//  Measured:  `417`
 		//  Estimated: `3593`
-		// Minimum execution time: 19_000_000 picoseconds.
+		// Minimum execution time: 18_000_000 picoseconds.
 		Weight::from_parts(19_000_000, 3593)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
@@ -543,47 +543,62 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `Nfts::CollectionConfigOf` (r:1 w:0)
 	/// Proof: `Nfts::CollectionConfigOf` (`max_values`: None, `max_size`: Some(73), added: 2548, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Collection` (r:1 w:1)
-	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
+	/// Storage: `Nfts::AccountAllowances` (r:1 w:1)
+	/// Proof: `Nfts::AccountAllowances` (`max_values`: None, `max_size`: Some(64), added: 2539, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Allowances` (r:1 w:1)
-	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(801), added: 3276, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(113), added: 2588, mode: `MaxEncodedLen`)
 	/// The range of component `i` is `[0, 1]`.
 	fn approve_transfer(i: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `304 + i * (33 ±0)`
-		//  Estimated: `4266 + i * (2163 ±0)`
+		//  Measured:  `360`
+		//  Estimated: `3578 + i * (2163 ±0)`
 		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(15_371_428, 4266)
-			.saturating_add(T::DbWeight::get().reads(3_u64))
-			.saturating_add(T::DbWeight::get().writes(2_u64))
+		Weight::from_parts(18_575_510, 3578)
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
 			.saturating_add(Weight::from_parts(0, 2163).saturating_mul(i.into()))
 	}
 	/// Storage: `Nfts::Item` (r:1 w:1)
 	/// Proof: `Nfts::Item` (`max_values`: None, `max_size`: Some(861), added: 3336, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Collection` (r:1 w:1)
-	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Allowances` (r:1 w:1)
-	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(801), added: 3276, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(113), added: 2588, mode: `MaxEncodedLen`)
+	/// Storage: `Nfts::AccountAllowances` (r:1 w:1)
+	/// Proof: `Nfts::AccountAllowances` (`max_values`: None, `max_size`: Some(64), added: 2539, mode: `MaxEncodedLen`)
 	/// The range of component `i` is `[0, 1]`.
 	fn cancel_approval(i: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `397`
-		//  Estimated: `4266 + i * (2163 ±0)`
+		//  Measured:  `496`
+		//  Estimated: `3578 + i * (2163 ±0)`
 		// Minimum execution time: 11_000_000 picoseconds.
-		Weight::from_parts(17_800_000, 4266)
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(2_u64))
+		Weight::from_parts(21_048_979, 3578)
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
 			.saturating_add(Weight::from_parts(0, 2163).saturating_mul(i.into()))
 	}
+	/// Storage: `Nfts::Collection` (r:1 w:0)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
+	/// Storage: `Nfts::AccountAllowances` (r:1 w:0)
+	/// Proof: `Nfts::AccountAllowances` (`max_values`: None, `max_size`: Some(64), added: 2539, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Item` (r:1 w:1)
 	/// Proof: `Nfts::Item` (`max_values`: None, `max_size`: Some(861), added: 3336, mode: `MaxEncodedLen`)
-	fn clear_all_transfer_approvals() -> Weight {
+	/// Storage: `Nfts::Allowances` (r:20 w:20)
+	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(113), added: 2588, mode: `MaxEncodedLen`)
+	/// The range of component `i` is `[0, 1]`.
+	/// The range of component `n` is `[0, 20]`.
+	fn clear_all_transfer_approvals(i: u32, n: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `345`
-		//  Estimated: `4326`
-		// Minimum execution time: 11_000_000 picoseconds.
-		Weight::from_parts(11_000_000, 4326)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		//  Measured:  `1614`
+		//  Estimated: `52750 + i * (4325 ±496_172_781_796_926)`
+		// Minimum execution time: 14_000_000 picoseconds.
+		Weight::from_parts(34_351_559, 52750)
+			// Standard Error: 3_279
+			.saturating_add(Weight::from_parts(46_401, 0).saturating_mul(n.into()))
+			.saturating_add(T::DbWeight::get().reads(22_u64))
+			.saturating_add(T::DbWeight::get().writes(22_u64))
+			.saturating_add(Weight::from_parts(0, 4325).saturating_mul(i.into()))
 	}
 	/// Storage: `Nfts::OwnershipAcceptance` (r:1 w:1)
 	/// Proof: `Nfts::OwnershipAcceptance` (`max_values`: None, `max_size`: Some(52), added: 2527, mode: `MaxEncodedLen`)
@@ -834,7 +849,9 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(5_u64))
 	}
 	/// Storage: `Nfts::Collection` (r:1 w:1)
-	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
+	/// Storage: `Nfts::AccountAllowances` (r:1 w:0)
+	/// Proof: `Nfts::AccountAllowances` (`max_values`: None, `max_size`: Some(64), added: 2539, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::ItemMetadataOf` (r:1 w:0)
 	/// Proof: `Nfts::ItemMetadataOf` (`max_values`: None, `max_size`: Some(347), added: 2822, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::CollectionRoleOf` (r:1 w:1)
@@ -852,19 +869,17 @@ impl WeightInfo for () {
 	/// The range of component `m` is `[0, 1000]`.
 	/// The range of component `c` is `[0, 1000]`.
 	/// The range of component `a` is `[0, 1000]`.
-	fn destroy(m: u32, c: u32, a: u32, ) -> Weight {
+	fn destroy(_m: u32, c: u32, a: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `32169 + a * (366 ±0)`
+		//  Measured:  `32165 + a * (366 ±0)`
 		//  Estimated: `2523990 + a * (2954 ±0)`
-		// Minimum execution time: 976_000_000 picoseconds.
-		Weight::from_parts(489_392_768, 2523990)
-			// Standard Error: 29_146
-			.saturating_add(Weight::from_parts(2_634, 0).saturating_mul(m.into()))
-			// Standard Error: 29_146
-			.saturating_add(Weight::from_parts(406_042, 0).saturating_mul(c.into()))
-			// Standard Error: 29_146
-			.saturating_add(Weight::from_parts(5_358_742, 0).saturating_mul(a.into()))
-			.saturating_add(RocksDbWeight::get().reads(1004_u64))
+		// Minimum execution time: 986_000_000 picoseconds.
+		Weight::from_parts(985_849_637, 2523990)
+			// Standard Error: 13_005
+			.saturating_add(Weight::from_parts(6_541, 0).saturating_mul(c.into()))
+			// Standard Error: 13_005
+			.saturating_add(Weight::from_parts(5_088_456, 0).saturating_mul(a.into()))
+			.saturating_add(RocksDbWeight::get().reads(1005_u64))
 			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(a.into())))
 			.saturating_add(RocksDbWeight::get().writes(1005_u64))
 			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(a.into())))
@@ -946,7 +961,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(8_u64))
 	}
 	/// Storage: `Nfts::Collection` (r:1 w:1)
-	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Attribute` (r:1 w:0)
 	/// Proof: `Nfts::Attribute` (`max_values`: None, `max_size`: Some(479), added: 2954, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::CollectionConfigOf` (r:1 w:0)
@@ -965,10 +980,10 @@ impl WeightInfo for () {
 	/// Proof: `Nfts::PendingSwapOf` (`max_values`: None, `max_size`: Some(71), added: 2546, mode: `MaxEncodedLen`)
 	fn transfer() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `609`
+		//  Measured:  `605`
 		//  Estimated: `6068`
-		// Minimum execution time: 39_000_000 picoseconds.
-		Weight::from_parts(41_000_000, 6068)
+		// Minimum execution time: 38_000_000 picoseconds.
+		Weight::from_parts(39_000_000, 6068)
 			.saturating_add(RocksDbWeight::get().reads(7_u64))
 			.saturating_add(RocksDbWeight::get().writes(8_u64))
 	}
@@ -1034,16 +1049,16 @@ impl WeightInfo for () {
 	/// Storage: `Nfts::OwnershipAcceptance` (r:1 w:1)
 	/// Proof: `Nfts::OwnershipAcceptance` (`max_values`: None, `max_size`: Some(52), added: 2527, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Collection` (r:1 w:1)
-	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
 	/// Storage: `System::Account` (r:1 w:1)
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::CollectionAccount` (r:0 w:2)
 	/// Proof: `Nfts::CollectionAccount` (`max_values`: None, `max_size`: Some(68), added: 2543, mode: `MaxEncodedLen`)
 	fn transfer_ownership() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `421`
+		//  Measured:  `417`
 		//  Estimated: `3593`
-		// Minimum execution time: 19_000_000 picoseconds.
+		// Minimum execution time: 18_000_000 picoseconds.
 		Weight::from_parts(19_000_000, 3593)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(5_u64))
@@ -1260,47 +1275,62 @@ impl WeightInfo for () {
 	/// Storage: `Nfts::CollectionConfigOf` (r:1 w:0)
 	/// Proof: `Nfts::CollectionConfigOf` (`max_values`: None, `max_size`: Some(73), added: 2548, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Collection` (r:1 w:1)
-	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
+	/// Storage: `Nfts::AccountAllowances` (r:1 w:1)
+	/// Proof: `Nfts::AccountAllowances` (`max_values`: None, `max_size`: Some(64), added: 2539, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Allowances` (r:1 w:1)
-	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(801), added: 3276, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(113), added: 2588, mode: `MaxEncodedLen`)
 	/// The range of component `i` is `[0, 1]`.
 	fn approve_transfer(i: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `304 + i * (33 ±0)`
-		//  Estimated: `4266 + i * (2163 ±0)`
+		//  Measured:  `360`
+		//  Estimated: `3578 + i * (2163 ±0)`
 		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(15_371_428, 4266)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+		Weight::from_parts(18_575_510, 3578)
+			.saturating_add(RocksDbWeight::get().reads(4_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
 			.saturating_add(Weight::from_parts(0, 2163).saturating_mul(i.into()))
 	}
 	/// Storage: `Nfts::Item` (r:1 w:1)
 	/// Proof: `Nfts::Item` (`max_values`: None, `max_size`: Some(861), added: 3336, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Collection` (r:1 w:1)
-	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Allowances` (r:1 w:1)
-	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(801), added: 3276, mode: `MaxEncodedLen`)
+	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(113), added: 2588, mode: `MaxEncodedLen`)
+	/// Storage: `Nfts::AccountAllowances` (r:1 w:1)
+	/// Proof: `Nfts::AccountAllowances` (`max_values`: None, `max_size`: Some(64), added: 2539, mode: `MaxEncodedLen`)
 	/// The range of component `i` is `[0, 1]`.
 	fn cancel_approval(i: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `397`
-		//  Estimated: `4266 + i * (2163 ±0)`
+		//  Measured:  `496`
+		//  Estimated: `3578 + i * (2163 ±0)`
 		// Minimum execution time: 11_000_000 picoseconds.
-		Weight::from_parts(17_800_000, 4266)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+		Weight::from_parts(21_048_979, 3578)
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
 			.saturating_add(Weight::from_parts(0, 2163).saturating_mul(i.into()))
 	}
+	/// Storage: `Nfts::Collection` (r:1 w:0)
+	/// Proof: `Nfts::Collection` (`max_values`: None, `max_size`: Some(84), added: 2559, mode: `MaxEncodedLen`)
+	/// Storage: `Nfts::AccountAllowances` (r:1 w:0)
+	/// Proof: `Nfts::AccountAllowances` (`max_values`: None, `max_size`: Some(64), added: 2539, mode: `MaxEncodedLen`)
 	/// Storage: `Nfts::Item` (r:1 w:1)
 	/// Proof: `Nfts::Item` (`max_values`: None, `max_size`: Some(861), added: 3336, mode: `MaxEncodedLen`)
-	fn clear_all_transfer_approvals() -> Weight {
+	/// Storage: `Nfts::Allowances` (r:20 w:20)
+	/// Proof: `Nfts::Allowances` (`max_values`: None, `max_size`: Some(113), added: 2588, mode: `MaxEncodedLen`)
+	/// The range of component `i` is `[0, 1]`.
+	/// The range of component `n` is `[0, 20]`.
+	fn clear_all_transfer_approvals(i: u32, n: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `345`
-		//  Estimated: `4326`
-		// Minimum execution time: 11_000_000 picoseconds.
-		Weight::from_parts(11_000_000, 4326)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		//  Measured:  `1614`
+		//  Estimated: `52750 + i * (4325 ±496_172_781_796_926)`
+		// Minimum execution time: 14_000_000 picoseconds.
+		Weight::from_parts(34_351_559, 52750)
+			// Standard Error: 3_279
+			.saturating_add(Weight::from_parts(46_401, 0).saturating_mul(n.into()))
+			.saturating_add(RocksDbWeight::get().reads(22_u64))
+			.saturating_add(RocksDbWeight::get().writes(22_u64))
+			.saturating_add(Weight::from_parts(0, 4325).saturating_mul(i.into()))
 	}
 	/// Storage: `Nfts::OwnershipAcceptance` (r:1 w:1)
 	/// Proof: `Nfts::OwnershipAcceptance` (`max_values`: None, `max_size`: Some(52), added: 2527, mode: `MaxEncodedLen`)


### PR DESCRIPTION
Refactoring the `Allowances` storage item to map the key as `(collection, owner)` with `ApprovalsOf<T, I>` as value. This change will reuse an existing `ApprovalOf` struct to provide the expiration feature for the collection approvals. 