### PR TITLE
chore: add api tracking template

### DIFF
--- a/.github/ISSUE_TEMPLATE/api_tracking.md
+++ b/.github/ISSUE_TEMPLATE/api_tracking.md
@@ -1,0 +1,68 @@
+---
+name: "New Pop API Feature"
+about: Create a feature request for a Pop API library.
+title: "feat(pop-api): <name-of-the-api>"
+assignees: ""
+---
+
+## Description
+
+<!-- Describes the new API request and input any consideration need to take to develop the new API -->
+
+## API Development Tracking
+
+- Contract size before:
+- Contract size after:
+
+<!-- Use the below checklist to keep track of the development of the API -->
+
+- [ ] Does it follow any contract standard? (e.g. PSP22, PSP34)
+
+  - Name of the standard: N/A
+
+  - Link to reference: N/A
+
+- [ ] Does it require a new pallet implementation?
+
+  - Name of the pallet: N/A
+
+    (e.g. `pallet-api/fungibles`, `pallet-api/nonfungibles`)
+
+- [ ] Does it require forking any upstream dependencies?
+
+  - Name of the pallet: N/A
+  - Link to reference: N/A
+  - Reason why forking the pallet: N/A
+
+- [ ] Does it require runtime configuration?
+- [ ] Does it require changes made to `pop-drink` crate?
+
+### Related Issues
+
+- [ ] Specification
+
+#### Runtime
+
+- [ ] Runtime configuration: <!-- Github URL -->
+- [ ] Chain extension configuration:
+- [ ] Runtime testing: <!-- Github URL -->
+
+#### Pallet
+
+- [ ] Pallet implementation: <!-- Github URL -->
+- [ ] Pallet testing: <!-- Github URL -->
+- [ ] Forked pallet implementation (optional): <!-- Github URL -->
+
+#### Contract
+
+- [ ] Contract API implementation: <!-- Github URL -->
+- [ ] Contract API integration test: <!-- Github URL -->
+- [ ] Contract API documentation: <!-- Github URL -->
+- [ ] Contract standard trait and error: <!-- Github URL -->
+- [ ] Contract example (optional): <!-- Github URL -->
+- [ ] Update Pop API documentation: <!-- Github URL -->
+
+#### Drink (optional)
+
+- [ ] New `pop-drink` API: <!-- Github URL -->
+- [ ] Contract example `pop-drink` test: <!-- Github URL -->


### PR DESCRIPTION
Adding a Pop API tracking template whenever we want to develop a new API to the library. 

Reference to the example issue: https://github.com/r0gue-io/pop-node/issues/335