### PR TITLE
chore: ink v5.1

### DIFF
--- a/pop-api/Cargo.toml
+++ b/pop-api/Cargo.toml
@@ -6,7 +6,7 @@ name = "pop-api"
 version = "0.0.0"
 
 [dependencies]
-ink = { version = "5.0.0", default-features = false }
+ink = { version = "5.1.0", default-features = false }
 pop-primitives = { path = "../primitives", default-features = false }
 sp-io = { version = "37.0.0", default-features = false, features = [
 	"disable_allocator",

--- a/pop-api/examples/fungibles/Cargo.toml
+++ b/pop-api/examples/fungibles/Cargo.toml
@@ -5,7 +5,7 @@ name = "fungibles"
 version = "0.1.0"
 
 [dependencies]
-ink = { version = "=5.0.0", default-features = false, features = [ "ink-debug" ] }
+ink = { version = "5.1.0", default-features = false, features = [ "ink-debug" ] }
 pop-api = { path = "../../../pop-api", default-features = false, features = [
 	"fungibles",
 ] }

--- a/pop-api/examples/fungibles/tests.rs
+++ b/pop-api/examples/fungibles/tests.rs
@@ -13,7 +13,6 @@ use drink::{
 	session::Session,
 	AssetsAPI, TestExternalities, NO_SALT,
 };
-use ink::scale::Encode;
 use pop_api::{
 	primitives::TokenId,
 	v0::fungibles::events::{Approval, Created, Transfer},

--- a/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.toml
+++ b/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.toml
@@ -4,7 +4,7 @@ name = "create_token_in_constructor"
 version = "0.1.0"
 
 [dependencies]
-ink = { version = "5.0.0", default-features = false }
+ink = { version = "5.1.0", default-features = false }
 pop-api = { path = "../../..", default-features = false, features = [ "fungibles" ] }
 
 [lib]

--- a/pop-api/integration-tests/contracts/fungibles/Cargo.toml
+++ b/pop-api/integration-tests/contracts/fungibles/Cargo.toml
@@ -4,7 +4,7 @@ name = "fungibles"
 version = "0.1.0"
 
 [dependencies]
-ink = { version = "5.0.0", default-features = false }
+ink = { version = "5.1.0", default-features = false }
 pop-api = { path = "../../../../pop-api", default-features = false, features = [ "fungibles" ] }
 
 [lib]

--- a/pop-api/src/v0/fungibles/errors.rs
+++ b/pop-api/src/v0/fungibles/errors.rs
@@ -129,6 +129,7 @@ mod tests {
 		},
 		StatusCode,
 	};
+	use ink::scale::{Decode, Encode};
 
 	fn error_into_status_code(error: Error) -> StatusCode {
 		let mut encoded_error = error.encode();

--- a/pop-api/src/v0/fungibles/errors.rs
+++ b/pop-api/src/v0/fungibles/errors.rs
@@ -3,7 +3,6 @@
 
 use ink::{
 	prelude::string::{String, ToString},
-	scale::{Decode, Encode},
 };
 
 use super::*;


### PR DESCRIPTION
In v5.0 there was an ugly warning from the linter which is fixed in v5.1. Also good to uplift the version.