### PR TITLE
refactor: tests for collection approval

### DIFF
--- a/pallets/nfts/src/tests.rs
+++ b/pallets/nfts/src/tests.rs
@@ -4394,7 +4394,11 @@ fn clear_collection_approvals_works() {
 		// Partially remove collection approvals.
 		let limit = 1;
 		assert_eq!(
-			Nfts::clear_collection_approvals(RuntimeOrigin::signed(item_owner.clone()), collection_id, limit),
+			Nfts::clear_collection_approvals(
+				RuntimeOrigin::signed(item_owner.clone()),
+				collection_id,
+				limit
+			),
 			Ok(Some(WeightOf::clear_collection_approvals(limit)).into())
 		);
 		approvals = approvals - limit;
@@ -4412,7 +4416,11 @@ fn clear_collection_approvals_works() {
 		// Successfully remove all collection approvals. Only charges post-dispatch weight for
 		// the removed approvals.
 		assert_eq!(
-			Nfts::clear_collection_approvals(RuntimeOrigin::signed(item_owner.clone()), collection_id, 10),
+			Nfts::clear_collection_approvals(
+				RuntimeOrigin::signed(item_owner.clone()),
+				collection_id,
+				10
+			),
 			Ok(Some(WeightOf::clear_collection_approvals(approvals)).into())
 		);
 		assert_eq!(Balances::free_balance(&item_owner), balance);
@@ -4424,7 +4432,7 @@ fn clear_collection_approvals_works() {
 			owner: item_owner.clone(),
 			approvals,
 		}));
-		
+
 		// Remove collection approvals while there are none.
 		assert_eq!(
 			Nfts::force_clear_collection_approvals(root(), item_owner.clone(), collection_id, 10),
@@ -4516,7 +4524,12 @@ fn force_clear_collection_approvals_works() {
 		// Partially remove collection approvals.
 		let limit = 1;
 		assert_eq!(
-			Nfts::force_clear_collection_approvals(root(), item_owner.clone(), collection_id, limit),
+			Nfts::force_clear_collection_approvals(
+				root(),
+				item_owner.clone(),
+				collection_id,
+				limit
+			),
 			Ok(Some(WeightOf::clear_collection_approvals(limit)).into())
 		);
 		approvals = approvals - limit;
@@ -4847,7 +4860,11 @@ fn cancel_collection_approval_works() {
 		));
 		// Cancel an approval for a non existing collection.
 		assert_noop!(
-			Nfts::cancel_collection_approval(RuntimeOrigin::signed(item_owner.clone()), collection_id, delegate.clone()),
+			Nfts::cancel_collection_approval(
+				RuntimeOrigin::signed(item_owner.clone()),
+				collection_id,
+				delegate.clone()
+			),
 			Error::<Test>::Unapproved
 		);
 		assert_ok!(Nfts::approve_collection_transfer(
@@ -4858,7 +4875,11 @@ fn cancel_collection_approval_works() {
 		));
 		// Cancel an unapproved delegate.
 		assert_noop!(
-			Nfts::cancel_collection_approval(RuntimeOrigin::signed(item_owner.clone()), collection_id, account(69)),
+			Nfts::cancel_collection_approval(
+				RuntimeOrigin::signed(item_owner.clone()),
+				collection_id,
+				account(69)
+			),
 			Error::<Test>::Unapproved
 		);
 		// Successfully cancel a collection approval.
@@ -4876,7 +4897,7 @@ fn cancel_collection_approval_works() {
 				owner: item_owner.clone(),
 				delegate: delegate.clone(),
 			}
-				.into(),
+			.into(),
 		);
 	});
 }
@@ -4916,7 +4937,12 @@ fn force_cancel_collection_approval_works() {
 		));
 		// Cancel an approval for a non existing collection.
 		assert_noop!(
-			Nfts::force_cancel_collection_approval(root(), item_owner.clone(), collection_id, delegate.clone()),
+			Nfts::force_cancel_collection_approval(
+				root(),
+				item_owner.clone(),
+				collection_id,
+				delegate.clone()
+			),
 			Error::<Test>::Unapproved
 		);
 		assert_ok!(Nfts::approve_collection_transfer(
@@ -4927,12 +4953,21 @@ fn force_cancel_collection_approval_works() {
 		));
 		// Cancel an unapproved delegate.
 		assert_noop!(
-			Nfts::force_cancel_collection_approval(root(), item_owner.clone(), collection_id, account(69)),
+			Nfts::force_cancel_collection_approval(
+				root(),
+				item_owner.clone(),
+				collection_id,
+				account(69)
+			),
 			Error::<Test>::Unapproved
 		);
 		// Successfully cancel a collection approval.
-		assert_ok!(
-			Nfts::force_cancel_collection_approval(root(), item_owner.clone(), collection_id, delegate.clone()));
+		assert_ok!(Nfts::force_cancel_collection_approval(
+			root(),
+			item_owner.clone(),
+			collection_id,
+			delegate.clone()
+		));
 		assert_eq!(Balances::reserved_balance(&item_owner), 0);
 		assert!(!CollectionApprovals::contains_key((collection_id, &item_owner, &delegate)));
 		System::assert_last_event(

--- a/pallets/nfts/src/tests.rs
+++ b/pallets/nfts/src/tests.rs
@@ -2119,10 +2119,10 @@ fn cancel_approval_ensures_no_active_collection_approval() {
 			delegate.clone()
 		));
 		assert_ok!(Nfts::cancel_approval(
-			RuntimeOrigin::signed(owner.clone()),
+			RuntimeOrigin::signed(owner),
 			collection_id,
 			item_id,
-			delegate.clone()
+			delegate
 		));
 	});
 }
@@ -2500,7 +2500,7 @@ fn clear_all_transfer_approvals_ensures_no_active_collection_approval() {
 			delegate
 		));
 		assert_ok!(Nfts::clear_all_transfer_approvals(
-			RuntimeOrigin::signed(owner.clone()),
+			RuntimeOrigin::signed(owner),
 			collection_id,
 			item_id
 		));
@@ -4441,7 +4441,7 @@ fn clear_collection_approvals_works() {
 		assert_eq!(Balances::free_balance(&item_owner), balance);
 		assert!(events().contains(&Event::<Test>::ApprovalsCancelled {
 			collection: collection_id,
-			owner: item_owner.clone(),
+			owner: item_owner,
 			approvals: 0
 		}));
 
@@ -4568,7 +4568,7 @@ fn force_clear_collection_approvals_works() {
 		assert_eq!(Balances::free_balance(&item_owner), balance);
 		assert!(events().contains(&Event::<Test>::ApprovalsCancelled {
 			collection: collection_id,
-			owner: item_owner.clone(),
+			owner: item_owner,
 			approvals: 0
 		}));
 
@@ -4687,13 +4687,13 @@ fn approve_collection_transfer_works() {
 
 		// Set collection settings to non transferable.
 		assert_ok!(Nfts::lock_collection(
-			RuntimeOrigin::signed(collection_owner.clone()),
+			RuntimeOrigin::signed(collection_owner),
 			collection_id,
 			CollectionSettings::from_disabled(CollectionSetting::TransferableItems.into())
 		));
 		assert_noop!(
 			Nfts::approve_collection_transfer(
-				RuntimeOrigin::signed(item_owner.clone()),
+				RuntimeOrigin::signed(item_owner),
 				collection_id,
 				delegate,
 				None
@@ -4813,16 +4813,16 @@ fn force_approve_collection_transfer_works() {
 
 		// Set collection settings to non transferable.
 		assert_ok!(Nfts::lock_collection(
-			RuntimeOrigin::signed(collection_owner.clone()),
+			RuntimeOrigin::signed(collection_owner),
 			collection_id,
 			CollectionSettings::from_disabled(CollectionSetting::TransferableItems.into())
 		));
 		assert_noop!(
 			Nfts::force_approve_collection_transfer(
 				root(),
-				item_owner.clone(),
+				item_owner,
 				collection_id,
-				delegate.clone(),
+				delegate,
 				None
 			),
 			Error::<Test>::ItemsNonTransferable
@@ -4894,8 +4894,8 @@ fn cancel_collection_approval_works() {
 			Event::<Test>::ApprovalCancelled {
 				collection: collection_id,
 				item: None,
-				owner: item_owner.clone(),
-				delegate: delegate.clone(),
+				owner: item_owner,
+				delegate,
 			}
 			.into(),
 		);
@@ -4974,8 +4974,8 @@ fn force_cancel_collection_approval_works() {
 			Event::<Test>::ApprovalCancelled {
 				collection: collection_id,
 				item: None,
-				owner: item_owner.clone(),
-				delegate: delegate.clone(),
+				owner: item_owner,
+				delegate,
 			}
 			.into(),
 		);


### PR DESCRIPTION
Refactors some of the test by separating the e.g. approve_collection_transfer and force_approve_collection_transfer, and while doing so found some small improvements.