### PR TITLE
feat(mainnet): add revive [DON'T MERGE]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,6 +3546,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c321610643004cf908ec0f5f2aa0d8f1f8e14b540562a2887a1111ff1ecbf7b"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-codec 0.7.0",
+ "impl-rlp",
+ "impl-serde 0.5.0",
+ "scale-info",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab15ed80916029f878e0267c3a9f92b67df55e79af370bf66199059ae2b4ee3"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-codec 0.7.0",
+ "impl-rlp",
+ "impl-serde 0.5.0",
+ "primitive-types 0.13.1",
+ "scale-info",
+ "uint 0.10.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4330,6 +4361,10 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper 0.4.0",
+]
 
 [[package]]
 name = "futures-util"
@@ -4445,12 +4480,62 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator 0.3.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gloo-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http 1.2.0",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "governor"
@@ -5207,6 +5292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ed8ad1f3877f7e775b8cbf30ed1bd3209a95401817f19a0eb4402d13f8cf90"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5531,7 +5625,7 @@ checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
 dependencies = [
  "jsonrpsee-client-transport 0.22.5",
  "jsonrpsee-core 0.22.5",
- "jsonrpsee-http-client",
+ "jsonrpsee-http-client 0.22.5",
  "jsonrpsee-types 0.22.5",
 ]
 
@@ -5552,10 +5646,13 @@ version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
 dependencies = [
+ "jsonrpsee-client-transport 0.24.7",
  "jsonrpsee-core 0.24.7",
+ "jsonrpsee-http-client 0.24.7",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types 0.24.7",
+ "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client 0.24.7",
  "tokio",
  "tracing",
@@ -5612,7 +5709,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "548125b159ba1314104f5bb5f38519e03a41862786aa3925cf349aae9cdd546e"
 dependencies = [
  "base64 0.22.1",
+ "futures-channel",
  "futures-util",
+ "gloo-net",
  "http 1.2.0",
  "jsonrpsee-core 0.24.7",
  "pin-project",
@@ -5697,6 +5796,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -5710,6 +5810,31 @@ dependencies = [
  "hyper-rustls 0.24.2",
  "jsonrpsee-core 0.22.5",
  "jsonrpsee-types 0.22.5",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3638bc4617f96675973253b3a45006933bde93c2fd8a6170b33c777cc389e5b"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "http-body 1.0.1",
+ "hyper 1.5.2",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
+ "jsonrpsee-core 0.24.7",
+ "jsonrpsee-types 0.24.7",
+ "rustls 0.23.20",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5795,6 +5920,17 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01cd500915d24ab28ca17527e23901ef1be6d659a2322451e1045532516c25"
+dependencies = [
+ "jsonrpsee-client-transport 0.24.7",
+ "jsonrpsee-core 0.24.7",
+ "jsonrpsee-types 0.24.7",
 ]
 
 [[package]]
@@ -6341,7 +6477,7 @@ dependencies = [
  "futures",
  "js-sys",
  "libp2p-core",
- "send_wrapper",
+ "send_wrapper 0.6.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -8458,6 +8594,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-revive"
+version = "0.1.0"
+source = "git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412#beb1c5265cc633b496a3b94ff2fbb8f860126357"
+dependencies = [
+ "bitflags 1.3.2",
+ "derive_more 0.99.18",
+ "environmental",
+ "ethereum-types",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "hex",
+ "impl-trait-for-tuples",
+ "jsonrpsee 0.24.7",
+ "log",
+ "pallet-balances",
+ "pallet-revive-fixtures",
+ "pallet-revive-proc-macro",
+ "pallet-revive-uapi",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "paste",
+ "polkavm 0.13.0",
+ "rlp",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412)",
+ "sp-weights",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "subxt-signer",
+]
+
+[[package]]
+name = "pallet-revive-fixtures"
+version = "0.1.0"
+source = "git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412#beb1c5265cc633b496a3b94ff2fbb8f860126357"
+dependencies = [
+ "anyhow",
+ "frame-system",
+ "log",
+ "parity-wasm",
+ "polkavm-linker 0.14.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "tempfile",
+ "toml 0.8.19",
+]
+
+[[package]]
+name = "pallet-revive-proc-macro"
+version = "0.1.0"
+source = "git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412#beb1c5265cc633b496a3b94ff2fbb8f860126357"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "pallet-revive-uapi"
+version = "0.1.0"
+source = "git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412#beb1c5265cc633b496a3b94ff2fbb8f860126357"
+dependencies = [
+ "bitflags 1.3.2",
+ "parity-scale-codec",
+ "paste",
+ "polkavm-derive 0.14.0",
+ "scale-info",
+]
+
+[[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
 source = "git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412#beb1c5265cc633b496a3b94ff2fbb8f860126357"
@@ -10242,9 +10456,22 @@ checksum = "8a3693e5efdb2bf74e449cd25fd777a28bd7ed87e41f5d5da75eb31b4de48b94"
 dependencies = [
  "libc",
  "log",
- "polkavm-assembler",
+ "polkavm-assembler 0.9.0",
  "polkavm-common 0.9.0",
- "polkavm-linux-raw",
+ "polkavm-linux-raw 0.9.0",
+]
+
+[[package]]
+name = "polkavm"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e79a14b15ed38cb5b9a1e38d02e933f19e3d180ae5b325fed606c5e5b9177e"
+dependencies = [
+ "libc",
+ "log",
+ "polkavm-assembler 0.13.0",
+ "polkavm-common 0.13.0",
+ "polkavm-linux-raw 0.13.0",
 ]
 
 [[package]]
@@ -10257,6 +10484,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-assembler"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8da55465000feb0a61bbf556ed03024db58f3420eca37721fc726b3b2136bf"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "polkavm-common"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10264,6 +10500,22 @@ checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "polkavm-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084b4339aae7dfdaaa5aa7d634110afd95970e0737b6fb2a0cb10db8b56b753c"
+dependencies = [
+ "log",
+ "polkavm-assembler 0.13.0",
+]
+
+[[package]]
+name = "polkavm-common"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711952a783e9c5ad407cdacb1ed147f36d37c5d43417c1091d86456d2999417b"
 
 [[package]]
 name = "polkavm-common"
@@ -10282,6 +10534,15 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4832a0aebf6cefc988bb7b2d74ea8c86c983164672e2fc96300f356a1babfc1"
+dependencies = [
+ "polkavm-derive-impl-macro 0.14.0",
+]
+
+[[package]]
+name = "polkavm-derive"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2eb703f3b6404c13228402e98a5eae063fd16b8f58afe334073ec105ee4117e"
@@ -10296,6 +10557,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
 dependencies = [
  "polkavm-common 0.9.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "polkavm-derive-impl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e339fc7c11310fe5adf711d9342278ac44a75c9784947937cce12bd4f30842f2"
+dependencies = [
+ "polkavm-common 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -10325,6 +10598,16 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl-macro"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b569754b15060d03000c09e3bf11509d527f60b75d79b4c30c3625b5071d9702"
+dependencies = [
+ "polkavm-derive-impl 0.14.0",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "polkavm-derive-impl-macro"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
@@ -10349,10 +10632,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-linker"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0959ac3b0f4fd5caf5c245c637705f19493efe83dba31a83bbba928b93b0116a"
+dependencies = [
+ "gimli 0.31.1",
+ "hashbrown 0.14.5",
+ "log",
+ "object 0.36.5",
+ "polkavm-common 0.14.0",
+ "regalloc2 0.9.3",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "polkavm-linux-raw"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26e85d3456948e650dff0cfc85603915847faf893ed1e66b020bb82ef4557120"
+
+[[package]]
+name = "polkavm-linux-raw"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686c4dd9c9c16cc22565b51bdbb269792318d0fd2e6b966b5f6c788534cad0e9"
 
 [[package]]
 name = "polling"
@@ -10644,6 +10948,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-preimage",
  "pallet-proxy",
+ "pallet-revive",
  "pallet-scheduler",
  "pallet-session",
  "pallet-sudo",
@@ -10849,6 +11154,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec 0.7.0",
  "impl-num-traits",
+ "impl-rlp",
  "impl-serde 0.5.0",
  "scale-info",
  "uint 0.10.0",
@@ -11512,6 +11818,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "rlp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -12500,7 +12816,7 @@ name = "sc-executor-common"
 version = "0.29.0"
 source = "git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412#beb1c5265cc633b496a3b94ff2fbb8f860126357"
 dependencies = [
- "polkavm",
+ "polkavm 0.9.3",
  "sc-allocator",
  "sp-maybe-compressed-blob",
  "sp-wasm-interface 20.0.0 (git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412)",
@@ -12514,7 +12830,7 @@ version = "0.29.0"
 source = "git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412#beb1c5265cc633b496a3b94ff2fbb8f860126357"
 dependencies = [
  "log",
- "polkavm",
+ "polkavm 0.9.3",
  "sc-executor-common",
  "sp-wasm-interface 20.0.0 (git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412)",
 ]
@@ -13508,6 +13824,12 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
@@ -14383,7 +14705,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#6bfe4523acf597ef47dfdcefd11b0eee396bc5c5"
+source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -14459,7 +14781,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#6bfe4523acf597ef47dfdcefd11b0eee396bc5c5"
+source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14479,7 +14801,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#6bfe4523acf597ef47dfdcefd11b0eee396bc5c5"
+source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14698,7 +15020,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#6bfe4523acf597ef47dfdcefd11b0eee396bc5c5"
+source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14730,7 +15052,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#6bfe4523acf597ef47dfdcefd11b0eee396bc5c5"
+source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
 dependencies = [
  "Inflector",
  "expander",
@@ -14819,7 +15141,7 @@ source = "git+https://github.com/r0gue-io/polkadot-sdk?branch=stable2412#beb1c52
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#6bfe4523acf597ef47dfdcefd11b0eee396bc5c5"
+source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
 
 [[package]]
 name = "sp-storage"
@@ -14836,7 +15158,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#6bfe4523acf597ef47dfdcefd11b0eee396bc5c5"
+source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -14871,7 +15193,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#6bfe4523acf597ef47dfdcefd11b0eee396bc5c5"
+source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -14968,7 +15290,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#6bfe4523acf597ef47dfdcefd11b0eee396bc5c5"
+source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15318,7 +15640,7 @@ dependencies = [
  "merkleized-metadata",
  "parity-scale-codec",
  "parity-wasm",
- "polkavm-linker",
+ "polkavm-linker 0.9.2",
  "sc-executor",
  "shlex",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ pallet-nft-fractionalization = { git = "https://github.com/r0gue-io/polkadot-sdk
 pallet-nfts-runtime-api = { git = "https://github.com/r0gue-io/polkadot-sdk", branch = "stable2412", default-features = false }
 pallet-preimage = { git = "https://github.com/r0gue-io/polkadot-sdk", branch = "stable2412", default-features = false }
 pallet-proxy = { git = "https://github.com/r0gue-io/polkadot-sdk", branch = "stable2412", default-features = false }
+pallet-revive = { git = "https://github.com/r0gue-io/polkadot-sdk", branch = "stable2412", default-features = false }
 pallet-scheduler = { git = "https://github.com/r0gue-io/polkadot-sdk", branch = "stable2412", default-features = false }
 pallet-session = { git = "https://github.com/r0gue-io/polkadot-sdk", branch = "stable2412", default-features = false }
 pallet-sudo = { git = "https://github.com/r0gue-io/polkadot-sdk", branch = "stable2412", default-features = false }

--- a/runtime/mainnet/Cargo.toml
+++ b/runtime/mainnet/Cargo.toml
@@ -40,6 +40,7 @@ pallet-message-queue.workspace = true
 pallet-multisig.workspace = true
 pallet-preimage.workspace = true
 pallet-proxy.workspace = true
+pallet-revive.workspace = true
 pallet-scheduler.workspace = true
 pallet-session.workspace = true
 pallet-sudo.workspace = true
@@ -118,6 +119,7 @@ std = [
 	"pallet-multisig/std",
 	"pallet-preimage/std",
 	"pallet-proxy/std",
+	"pallet-revive/std",
 	"pallet-scheduler/std",
 	"pallet-session/std",
 	"pallet-sudo/std",
@@ -166,6 +168,7 @@ runtime-benchmarks = [
 	"pallet-multisig/runtime-benchmarks",
 	"pallet-preimage/runtime-benchmarks",
 	"pallet-proxy/runtime-benchmarks",
+	"pallet-revive/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
@@ -199,6 +202,7 @@ try-runtime = [
 	"pallet-multisig/try-runtime",
 	"pallet-preimage/try-runtime",
 	"pallet-proxy/try-runtime",
+	"pallet-revive/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"pallet-session/try-runtime",
 	"pallet-sudo/try-runtime",

--- a/runtime/mainnet/src/apis.rs
+++ b/runtime/mainnet/src/apis.rs
@@ -4,8 +4,7 @@ use codec::Encode;
 use frame_support::{
 	genesis_builder_helper::{build_state, get_preset},
 	traits::tokens::{Fortitude::Polite, Preservation::Preserve},
-    weights::{Weight, WeightToFee as _},
-
+	weights::{Weight, WeightToFee as _},
 };
 use pallet_revive::AddressMapper;
 use sp_api::impl_runtime_apis;
@@ -29,12 +28,11 @@ use xcm_runtime_apis::{
 
 // Local module imports
 use super::{
-    AccountId, Balance, Balances, Block, BlockNumber, BlockWeights, Contracts, EventRecord,
-    Executive, ExtrinsicInclusionMode, InherentDataExt, Nonce, OriginCaller, ParachainSystem,
-    PolkadotXcm, Runtime, RuntimeBlockWeights, RuntimeCall, RuntimeEvent, RuntimeGenesisConfig,
-    RuntimeOrigin, SessionKeys, System, TransactionPayment, UncheckedExtrinsic, VERSION,
-    config::xcm as xcm_config,
-    fee::WeightToFee,
+	config::xcm as xcm_config, fee::WeightToFee, AccountId, Balance, Balances, Block, BlockNumber,
+	BlockWeights, Contracts, EventRecord, Executive, ExtrinsicInclusionMode, InherentDataExt,
+	Nonce, OriginCaller, ParachainSystem, PolkadotXcm, Runtime, RuntimeBlockWeights, RuntimeCall,
+	RuntimeEvent, RuntimeGenesisConfig, RuntimeOrigin, SessionKeys, System, TransactionPayment,
+	UncheckedExtrinsic, VERSION,
 };
 
 impl_runtime_apis! {

--- a/runtime/mainnet/src/apis.rs
+++ b/runtime/mainnet/src/apis.rs
@@ -29,8 +29,8 @@ use xcm_runtime_apis::{
 // Local module imports
 use super::{
 	config::xcm as xcm_config, fee::WeightToFee, AccountId, Balance, Balances, Block, BlockNumber,
-	BlockWeights, Contracts, EventRecord, Executive, ExtrinsicInclusionMode, InherentDataExt,
-	Nonce, OriginCaller, ParachainSystem, PolkadotXcm, Runtime, RuntimeBlockWeights, RuntimeCall,
+	BlockWeights, EventRecord, Executive, ExtrinsicInclusionMode, InherentDataExt, Nonce,
+	OriginCaller, ParachainSystem, PolkadotXcm, Revive, Runtime, RuntimeBlockWeights, RuntimeCall,
 	RuntimeEvent, RuntimeGenesisConfig, RuntimeOrigin, SessionKeys, System, TransactionPayment,
 	UncheckedExtrinsic, VERSION,
 };
@@ -370,12 +370,12 @@ impl_runtime_apis! {
 			let origin = <Runtime as pallet_revive::Config>::AddressMapper::to_account_id(&from);
 
 			let encoded_size = |pallet_call| {
-				let call = RuntimeCall::Contracts(pallet_call);
+				let call = RuntimeCall::Revive(pallet_call);
 				let uxt: UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic::new_bare(call).into();
 				uxt.encoded_size() as u32
 			};
 
-			Contracts::bare_eth_transact(
+			Revive::bare_eth_transact(
 				origin,
 				dest,
 				value,
@@ -396,7 +396,7 @@ impl_runtime_apis! {
 			storage_deposit_limit: Option<Balance>,
 			input_data: Vec<u8>,
 		) -> pallet_revive::ContractResult<pallet_revive::ExecReturnValue, Balance, EventRecord> {
-			Contracts::bare_call(
+			Revive::bare_call(
 				RuntimeOrigin::signed(origin),
 				dest,
 				value,
@@ -418,7 +418,7 @@ impl_runtime_apis! {
 			salt: Option<[u8; 32]>,
 		) -> pallet_revive::ContractResult<pallet_revive::InstantiateReturnValue, Balance, EventRecord>
 		{
-			Contracts::bare_instantiate(
+			Revive::bare_instantiate(
 				RuntimeOrigin::signed(origin),
 				value,
 				gas_limit.unwrap_or(RuntimeBlockWeights::get().max_block),
@@ -437,7 +437,7 @@ impl_runtime_apis! {
 			storage_deposit_limit: Option<Balance>,
 		) -> pallet_revive::CodeUploadResult<Balance>
 		{
-			Contracts::bare_upload_code(
+			Revive::bare_upload_code(
 				RuntimeOrigin::signed(origin),
 				code,
 				storage_deposit_limit.unwrap_or(u128::MAX),
@@ -448,7 +448,7 @@ impl_runtime_apis! {
 			address: H160,
 			key: [u8; 32],
 		) -> pallet_revive::GetStorageResult {
-			Contracts::get_storage(
+			Revive::get_storage(
 				address,
 				key
 			)

--- a/runtime/mainnet/src/config/contracts.rs
+++ b/runtime/mainnet/src/config/contracts.rs
@@ -6,13 +6,18 @@ use frame_system::EnsureSigned;
 
 use crate::{
 	deposit, Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
-	Timestamp,
+	Timestamp, UNIT,
 };
 
+const ETH: u128 = 1_000_000_000_000_000_000;
+
 parameter_types! {
+	// TODO: review implications of this
 	pub const DepositPerItem: Balance = deposit(1, 0);
+	// TODO: review implications of this
 	pub const DepositPerByte: Balance = deposit(0, 1);
 	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
+	pub const NativeToEthRatio: u32 = (ETH/UNIT) as u32;
 }
 
 impl pallet_revive::Config for Runtime {
@@ -26,7 +31,7 @@ impl pallet_revive::Config for Runtime {
 	type DepositPerByte = DepositPerByte;
 	type DepositPerItem = DepositPerItem;
 	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
-	type NativeToEthRatio = ConstU32<1>;
+	type NativeToEthRatio = NativeToEthRatio;
 	// TODO: review implications of this
 	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
 	type RuntimeCall = RuntimeCall;
@@ -50,5 +55,173 @@ impl TryFrom<RuntimeCall> for pallet_revive::Call<Runtime> {
 			RuntimeCall::Contracts(call) => Ok(call),
 			_ => Err(()),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::any::TypeId;
+
+	use frame_support::pallet_prelude::Get;
+
+	use super::*;
+
+	// 18 decimals
+	const ONE_ETH: u128 = 1_000_000_000_000_000_000;
+
+	#[test]
+	fn address_mapper_is_account_id32_mapper() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::AddressMapper>(),
+			TypeId::of::<pallet_revive::AccountId32Mapper<Runtime>>(),
+		);
+	}
+
+	#[test]
+	fn call_filter_is_nothing() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::CallFilter>(),
+			TypeId::of::<Nothing>(),
+		);
+	}
+
+	#[test]
+	fn chain_extension_is_unset() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::ChainExtension>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn chain_id_is_correct() {
+		assert_eq!(<<Runtime as pallet_revive::Config>::ChainId as Get<u64>>::get(), 3395);
+	}
+
+	#[test]
+	fn code_hash_lockup_deposit_percent_is_correct() {
+		// 30 percent
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::CodeHashLockupDepositPercent>(),
+			TypeId::of::<CodeHashLockupDepositPercent>(),
+		);
+	}
+
+	#[test]
+	fn currency_is_balances() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::Currency>(),
+			TypeId::of::<Balances>(),
+		);
+	}
+
+	#[test]
+	fn debug_is_unset() {
+		assert_eq!(TypeId::of::<<Runtime as pallet_revive::Config>::Debug>(), TypeId::of::<()>(),);
+	}
+
+	#[test]
+	fn deposit_per_byte_is_correct() {
+		assert_eq!(
+			<<Runtime as pallet_revive::Config>::DepositPerByte as Get<Balance>>::get(),
+			deposit(0, 1),
+		);
+	}
+
+	#[test]
+	fn deposit_per_item_is_correct() {
+		assert_eq!(
+			<<Runtime as pallet_revive::Config>::DepositPerItem as Get<Balance>>::get(),
+			deposit(1, 0),
+		);
+	}
+
+	#[test]
+	fn instantiate_origin_is_ensure_signed() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::InstantiateOrigin>(),
+			TypeId::of::<EnsureSigned<<Runtime as frame_system::Config>::AccountId>>(),
+		);
+	}
+
+	#[test]
+	fn eth_is_18_decimals() {
+		assert_eq!(ETH, ONE_ETH);
+	}
+
+	#[test]
+	fn native_to_eth_ratio_is_correct() {
+		// 18 decimals
+		let expected_ratio = (ONE_ETH / UNIT) as u32;
+		assert_eq!(
+			<<Runtime as pallet_revive::Config>::NativeToEthRatio as Get<u32>>::get(),
+			expected_ratio
+		);
+	}
+
+	#[test]
+	fn pvf_memory_is_correct() {
+		// 512 MB
+		assert_eq!(
+			<<Runtime as pallet_revive::Config>::PVFMemory as Get<u32>>::get(),
+			512 * 1024 * 1024
+		);
+	}
+
+	#[test]
+	fn runtime_memory_is_correct() {
+		// 128 MB
+		assert_eq!(
+			<<Runtime as pallet_revive::Config>::RuntimeMemory as Get<u32>>::get(),
+			128 * 1024 * 1024
+		);
+	}
+
+	#[test]
+	fn time_is_timestamp() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::Time>(),
+			TypeId::of::<Timestamp>(),
+		);
+	}
+
+	#[test]
+	fn unsafe_unstable_interface_is_disabled() {
+		assert_eq!(
+			<<Runtime as pallet_revive::Config>::UnsafeUnstableInterface as Get<bool>>::get(),
+			false,
+		);
+	}
+
+	#[test]
+	fn upload_origin_is_ensure_signed() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::UploadOrigin>(),
+			TypeId::of::<EnsureSigned<<Runtime as frame_system::Config>::AccountId>>(),
+		);
+	}
+
+	#[test]
+	fn weight_is_not_default() {
+		assert_ne!(
+			TypeId::of::<<Runtime as pallet_balances::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn weight_price_uses_transaction_payment() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::WeightPrice>(),
+			TypeId::of::<pallet_transaction_payment::Pallet<Runtime>>(),
+		);
+	}
+
+	#[test]
+	fn xcm_is_pallet_xcm() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::Xcm>(),
+			TypeId::of::<pallet_xcm::Pallet<Runtime>>(),
+		);
 	}
 }

--- a/runtime/mainnet/src/config/contracts.rs
+++ b/runtime/mainnet/src/config/contracts.rs
@@ -1,0 +1,54 @@
+use frame_support::{
+	parameter_types,
+	traits::{ConstBool, ConstU32, ConstU64, Nothing},
+};
+use frame_system::EnsureSigned;
+
+use crate::{
+	deposit, Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
+	Timestamp,
+};
+
+parameter_types! {
+	pub const DepositPerItem: Balance = deposit(1, 0);
+	pub const DepositPerByte: Balance = deposit(0, 1);
+	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
+}
+
+impl pallet_revive::Config for Runtime {
+	type AddressMapper = pallet_revive::AccountId32Mapper<Self>;
+	type CallFilter = Nothing;
+	type ChainExtension = ();
+	type ChainId = ConstU64<3395>;
+	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
+	type Currency = Balances;
+	type Debug = ();
+	type DepositPerByte = DepositPerByte;
+	type DepositPerItem = DepositPerItem;
+	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
+	type NativeToEthRatio = ConstU32<1>;
+	// TODO: review implications of this
+	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	// TODO: review implications of this
+	type RuntimeMemory = ConstU32<{ 128 * 1024 * 1024 }>;
+	type Time = Timestamp;
+	type UnsafeUnstableInterface = ConstBool<false>;
+	type UploadOrigin = EnsureSigned<Self::AccountId>;
+	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
+	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
+	type Xcm = pallet_xcm::Pallet<Self>;
+}
+
+impl TryFrom<RuntimeCall> for pallet_revive::Call<Runtime> {
+	type Error = ();
+
+	fn try_from(value: RuntimeCall) -> Result<Self, Self::Error> {
+		match value {
+			RuntimeCall::Contracts(call) => Ok(call),
+			_ => Err(()),
+		}
+	}
+}

--- a/runtime/mainnet/src/config/contracts.rs
+++ b/runtime/mainnet/src/config/contracts.rs
@@ -5,8 +5,8 @@ use frame_support::{
 use frame_system::EnsureSigned;
 
 use crate::{
-	deposit, Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
-	Timestamp, UNIT,
+	deposit, Balance, Balances, Perbill, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
+	RuntimeHoldReason, Timestamp, TransactionPayment, UNIT,
 };
 
 const ETH: u128 = 1_000_000_000_000_000_000;
@@ -43,8 +43,8 @@ impl pallet_revive::Config for Runtime {
 	type UnsafeUnstableInterface = ConstBool<false>;
 	type UploadOrigin = EnsureSigned<Self::AccountId>;
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
-	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
-	type Xcm = pallet_xcm::Pallet<Self>;
+	type WeightPrice = TransactionPayment;
+	type Xcm = PolkadotXcm;
 }
 
 impl TryFrom<RuntimeCall> for pallet_revive::Call<Runtime> {
@@ -63,6 +63,7 @@ mod tests {
 	use std::any::TypeId;
 
 	use frame_support::pallet_prelude::Get;
+	use pallet_revive::Config;
 
 	use super::*;
 
@@ -72,7 +73,7 @@ mod tests {
 	#[test]
 	fn address_mapper_is_account_id32_mapper() {
 		assert_eq!(
-			TypeId::of::<<Runtime as pallet_revive::Config>::AddressMapper>(),
+			TypeId::of::<<Runtime as Config>::AddressMapper>(),
 			TypeId::of::<pallet_revive::AccountId32Mapper<Runtime>>(),
 		);
 	}
@@ -95,51 +96,42 @@ mod tests {
 
 	#[test]
 	fn chain_id_is_correct() {
-		assert_eq!(<<Runtime as pallet_revive::Config>::ChainId as Get<u64>>::get(), 3395);
+		assert_eq!(<<Runtime as Config>::ChainId as Get<u64>>::get(), 3395);
 	}
 
 	#[test]
 	fn code_hash_lockup_deposit_percent_is_correct() {
 		// 30 percent
 		assert_eq!(
-			TypeId::of::<<Runtime as pallet_revive::Config>::CodeHashLockupDepositPercent>(),
+			TypeId::of::<<Runtime as Config>::CodeHashLockupDepositPercent>(),
 			TypeId::of::<CodeHashLockupDepositPercent>(),
 		);
 	}
 
 	#[test]
 	fn currency_is_balances() {
-		assert_eq!(
-			TypeId::of::<<Runtime as pallet_revive::Config>::Currency>(),
-			TypeId::of::<Balances>(),
-		);
+		assert_eq!(TypeId::of::<<Runtime as Config>::Currency>(), TypeId::of::<Balances>(),);
 	}
 
 	#[test]
 	fn debug_is_unset() {
-		assert_eq!(TypeId::of::<<Runtime as pallet_revive::Config>::Debug>(), TypeId::of::<()>(),);
+		assert_eq!(TypeId::of::<<Runtime as Config>::Debug>(), TypeId::of::<()>(),);
 	}
 
 	#[test]
 	fn deposit_per_byte_is_correct() {
-		assert_eq!(
-			<<Runtime as pallet_revive::Config>::DepositPerByte as Get<Balance>>::get(),
-			deposit(0, 1),
-		);
+		assert_eq!(<<Runtime as Config>::DepositPerByte as Get<Balance>>::get(), deposit(0, 1),);
 	}
 
 	#[test]
 	fn deposit_per_item_is_correct() {
-		assert_eq!(
-			<<Runtime as pallet_revive::Config>::DepositPerItem as Get<Balance>>::get(),
-			deposit(1, 0),
-		);
+		assert_eq!(<<Runtime as Config>::DepositPerItem as Get<Balance>>::get(), deposit(1, 0),);
 	}
 
 	#[test]
 	fn instantiate_origin_is_ensure_signed() {
 		assert_eq!(
-			TypeId::of::<<Runtime as pallet_revive::Config>::InstantiateOrigin>(),
+			TypeId::of::<<Runtime as Config>::InstantiateOrigin>(),
 			TypeId::of::<EnsureSigned<<Runtime as frame_system::Config>::AccountId>>(),
 		);
 	}
@@ -153,66 +145,48 @@ mod tests {
 	fn native_to_eth_ratio_is_correct() {
 		// 18 decimals
 		let expected_ratio = (ONE_ETH / UNIT) as u32;
-		assert_eq!(
-			<<Runtime as pallet_revive::Config>::NativeToEthRatio as Get<u32>>::get(),
-			expected_ratio
-		);
+		assert_eq!(<<Runtime as Config>::NativeToEthRatio as Get<u32>>::get(), expected_ratio);
 	}
 
 	#[test]
 	fn pvf_memory_is_correct() {
 		// 512 MB
-		assert_eq!(
-			<<Runtime as pallet_revive::Config>::PVFMemory as Get<u32>>::get(),
-			512 * 1024 * 1024
-		);
+		assert_eq!(<<Runtime as Config>::PVFMemory as Get<u32>>::get(), 512 * 1024 * 1024);
 	}
 
 	#[test]
 	fn runtime_memory_is_correct() {
 		// 128 MB
-		assert_eq!(
-			<<Runtime as pallet_revive::Config>::RuntimeMemory as Get<u32>>::get(),
-			128 * 1024 * 1024
-		);
+		assert_eq!(<<Runtime as Config>::RuntimeMemory as Get<u32>>::get(), 128 * 1024 * 1024);
 	}
 
 	#[test]
 	fn time_is_timestamp() {
-		assert_eq!(
-			TypeId::of::<<Runtime as pallet_revive::Config>::Time>(),
-			TypeId::of::<Timestamp>(),
-		);
+		assert_eq!(TypeId::of::<<Runtime as Config>::Time>(), TypeId::of::<Timestamp>(),);
 	}
 
 	#[test]
 	fn unsafe_unstable_interface_is_disabled() {
-		assert_eq!(
-			<<Runtime as pallet_revive::Config>::UnsafeUnstableInterface as Get<bool>>::get(),
-			false,
-		);
+		assert_eq!(<<Runtime as Config>::UnsafeUnstableInterface as Get<bool>>::get(), false,);
 	}
 
 	#[test]
 	fn upload_origin_is_ensure_signed() {
 		assert_eq!(
-			TypeId::of::<<Runtime as pallet_revive::Config>::UploadOrigin>(),
+			TypeId::of::<<Runtime as Config>::UploadOrigin>(),
 			TypeId::of::<EnsureSigned<<Runtime as frame_system::Config>::AccountId>>(),
 		);
 	}
 
 	#[test]
 	fn weight_is_not_default() {
-		assert_ne!(
-			TypeId::of::<<Runtime as pallet_balances::Config>::WeightInfo>(),
-			TypeId::of::<()>(),
-		);
+		assert_ne!(TypeId::of::<<Runtime as Config>::WeightInfo>(), TypeId::of::<()>(),);
 	}
 
 	#[test]
 	fn weight_price_uses_transaction_payment() {
 		assert_eq!(
-			TypeId::of::<<Runtime as pallet_revive::Config>::WeightPrice>(),
+			TypeId::of::<<Runtime as Config>::WeightPrice>(),
 			TypeId::of::<pallet_transaction_payment::Pallet<Runtime>>(),
 		);
 	}
@@ -220,7 +194,7 @@ mod tests {
 	#[test]
 	fn xcm_is_pallet_xcm() {
 		assert_eq!(
-			TypeId::of::<<Runtime as pallet_revive::Config>::Xcm>(),
+			TypeId::of::<<Runtime as Config>::Xcm>(),
 			TypeId::of::<pallet_xcm::Pallet<Runtime>>(),
 		);
 	}

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,3 +1,3 @@
-mod contracts;
 mod proxy;
+mod revive;
 pub mod xcm;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,2 +1,3 @@
+mod contracts;
 mod proxy;
 pub mod xcm;

--- a/runtime/mainnet/src/config/revive.rs
+++ b/runtime/mainnet/src/config/revive.rs
@@ -52,7 +52,7 @@ impl TryFrom<RuntimeCall> for pallet_revive::Call<Runtime> {
 
 	fn try_from(value: RuntimeCall) -> Result<Self, Self::Error> {
 		match value {
-			RuntimeCall::Contracts(call) => Ok(call),
+			RuntimeCall::Revive(call) => Ok(call),
 			_ => Err(()),
 		}
 	}

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -847,15 +847,13 @@ mod tests {
 		assert_eq!(
 			TypeId::of::<UncheckedExtrinsic>(),
 			TypeId::of::<
-				generic::UncheckedExtrinsic<
+				pallet_revive::evm::runtime::UncheckedExtrinsic<
 					// Multiple address formats supported.
 					MultiAddress<AccountId, ()>,
-					// The runtime calls available.
-					RuntimeCall,
 					// The signature scheme(s) supported.
 					MultiSignature,
 					// The transaction extensions.
-					TxExtension,
+					EthExtraImpl,
 				>,
 			>(),
 		);

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -104,9 +104,33 @@ pub type TxExtension = (
 	CheckMetadataHash<Runtime>,
 );
 
+/// Default extensions applied to Ethereum transactions.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct EthExtraImpl;
+
+impl pallet_revive::evm::runtime::EthExtra for EthExtraImpl {
+	type Config = Runtime;
+	type Extension = TxExtension;
+
+	fn get_eth_extension(nonce: u32, tip: Balance) -> Self::Extension {
+		(
+			CheckNonZeroSender::<Runtime>::new(),
+			CheckSpecVersion::<Runtime>::new(),
+			CheckTxVersion::<Runtime>::new(),
+			CheckGenesis::<Runtime>::new(),
+			CheckMortality::from(generic::Era::Immortal),
+			CheckNonce::<Runtime>::from(nonce),
+			CheckWeight::<Runtime>::new(),
+			ChargeTransactionPayment::<Runtime>::from(tip),
+			StorageWeightReclaim::<Runtime>::new(),
+			CheckMetadataHash::<Runtime>::new(false),
+		)
+	}
+}
+
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =
-	generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, TxExtension>;
+	pallet_revive::evm::runtime::UncheckedExtrinsic<Address, Signature, EthExtraImpl>;
 
 /// All migrations of the runtime, aside from the ones declared in the pallets.
 ///

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -693,7 +693,7 @@ mod runtime {
 
 	// Contracts (using pallet-revive)
 	#[runtime::pallet_index(40)]
-	pub type Contracts = pallet_revive::Pallet<Runtime>;
+	pub type Revive = pallet_revive::Pallet<Runtime>;
 
 	// Proxy
 	#[runtime::pallet_index(41)]

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -667,6 +667,10 @@ mod runtime {
 	#[runtime::pallet_index(33)]
 	pub type MessageQueue = pallet_message_queue::Pallet<Runtime>;
 
+	// Contracts (using pallet-revive)
+	#[runtime::pallet_index(40)]
+	pub type Contracts = pallet_revive::Pallet<Runtime>;
+
 	// Proxy
 	#[runtime::pallet_index(41)]
 	pub type Proxy = pallet_proxy::Pallet<Runtime>;


### PR DESCRIPTION
Prereq: https://github.com/r0gue-io/pop-node/pull/426 & https://github.com/r0gue-io/pop-node/pull/425

This PR adds pallet-revive to the mainnet runtime. This was added directly to mainnet as do not have a running mainnet, so we can start preparing the mainnet runtime for the launch. 

The revive configuration and pallet name (in our runtime config) will be contracts.rs and `Contracts`, respectively. 

Please review the commits and commit messages for individual components:

[feat(mainnet): add pallet-revive](https://github.com/r0gue-io/pop-node/commit/285ea11864ea3224a96e4ea5d702ea5ef767d18a)

[test(mainnet): revive configuration tests](https://github.com/r0gue-io/pop-node/commit/184ec1d71214c4959e1da6d51b1cf19ab4ab46fc)

[feat(mainnet): add EthExtraImpl for UncheckedExtrinsic](https://github.com/r0gue-io/pop-node/commit/16ca362e7f73cd0db3053976e36f907c7b0e4e82)

[feat(mainnet): add revive runtime api](https://github.com/r0gue-io/pop-node/commit/e096ef929940e61b905093f448aa54f8b4aae1cd)