### PR TITLE
refactor(mainnet): config modules & config tests

### DIFF
--- a/runtime/mainnet/src/config/collation.rs
+++ b/runtime/mainnet/src/config/collation.rs
@@ -1,0 +1,278 @@
+use pop_runtime_common::{HOURS, SLOT_DURATION};
+
+use crate::{
+	parameter_types, AccountId, Aura, AuraId, Balances, CollatorSelection, ConstBool, ConstU32,
+	ConstU64, EnsureRoot, PalletId, Runtime, RuntimeEvent, Session, SessionKeys,
+};
+
+impl pallet_authorship::Config for Runtime {
+	type EventHandler = (CollatorSelection,);
+	type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
+}
+
+#[docify::export(aura_config)]
+impl pallet_aura::Config for Runtime {
+	type AllowMultipleBlocksPerSlot = ConstBool<true>;
+	type AuthorityId = AuraId;
+	type DisabledValidators = ();
+	type MaxAuthorities = ConstU32<3600>;
+	type SlotDuration = ConstU64<SLOT_DURATION>;
+}
+
+parameter_types! {
+	pub const PotId: PalletId = PalletId(*b"PotStake");
+}
+
+/// We allow root to execute privileged collator selection operations.
+pub type CollatorSelectionUpdateOrigin = EnsureRoot<AccountId>;
+
+impl pallet_collator_selection::Config for Runtime {
+	type Currency = Balances;
+	// should be a multiple of session or things will get inconsistent
+	type KickThreshold = Period;
+	type MaxCandidates = ConstU32<0>;
+	type MaxInvulnerables = ConstU32<20>;
+	type MinEligibleCollators = ConstU32<3>;
+	type PotId = PotId;
+	type RuntimeEvent = RuntimeEvent;
+	type UpdateOrigin = CollatorSelectionUpdateOrigin;
+	type ValidatorId = <Self as frame_system::Config>::AccountId;
+	type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+	type ValidatorRegistration = Session;
+	type WeightInfo = pallet_collator_selection::weights::SubstrateWeight<Runtime>;
+}
+
+impl cumulus_pallet_aura_ext::Config for Runtime {}
+
+parameter_types! {
+	pub const Period: u32 = 6 * HOURS;
+	pub const Offset: u32 = 0;
+}
+
+impl pallet_session::Config for Runtime {
+	type Keys = SessionKeys;
+	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type RuntimeEvent = RuntimeEvent;
+	// Essentially just Aura, but let's be pedantic.
+	type SessionHandler = <SessionKeys as sp_runtime::traits::OpaqueKeys>::KeyTypeIdProviders;
+	type SessionManager = CollatorSelection;
+	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+	type ValidatorId = <Self as frame_system::Config>::AccountId;
+	// we don't have stash and controller, thus we don't need the convert as well.
+	type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+	type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;
+}
+
+#[cfg(test)]
+mod tests {
+	use std::any::TypeId;
+
+	use sp_core::{crypto::Ss58Codec, ByteArray};
+	use sp_runtime::traits::{AccountIdConversion, Get};
+
+	use super::*;
+
+	#[test]
+	fn authorship_finds_block_author_via_index_from_digests_within_block_header() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_authorship::Config>::FindAuthor>(),
+			TypeId::of::<pallet_session::FindAccountFromAuthorIndex<Runtime, Aura>>(),
+		);
+	}
+
+	#[test]
+	fn authorship_notes_block_author_via_collator_selection() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_authorship::Config>::EventHandler>(),
+			TypeId::of::<(CollatorSelection,)>(),
+		);
+	}
+
+	#[test]
+	fn collator_selection_uses_native_asset() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_collator_selection::Config>::Currency>(),
+			TypeId::of::<Balances>(),
+		);
+	}
+
+	#[test]
+	fn collator_selection_update_origin_limited_to_root() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_collator_selection::Config>::UpdateOrigin>(),
+			TypeId::of::<EnsureRoot<<Runtime as frame_system::Config>::AccountId>>(),
+		);
+	}
+
+	#[test]
+	fn collator_selection_distributes_block_rewards_via_pot() {
+		// Context: block author receives rewards from 'pot', less ED. A keyless account
+		// 'pot' is generated from the `PotId` value configured for the pallet.
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_collator_selection::Config>::PotId>(),
+			TypeId::of::<PotId>(),
+		);
+		assert_eq!(CollatorSelection::account_id(), PotId::get().into_account_truncating());
+	}
+
+	#[test]
+	fn collator_selection_pot_account_is_valid() {
+		// "PotStake" module id to address via  https://www.shawntabrizi.com/substrate-js-utilities/
+		let expected =
+			AccountId::from_ss58check("5EYCAe5cKPAoFh2HnQQvpKqRYZGqBpaA87u4Zzw89qPE58is").unwrap();
+		assert_eq!(CollatorSelection::account_id(), expected);
+	}
+
+	#[test]
+	fn collator_selection_candidates_disabled() {
+		// Disabled to start until sufficient distribution/value to allow candidates to provide
+		// candidacy bond
+		assert_eq!(
+			<<Runtime as pallet_collator_selection::Config>::MaxCandidates as Get<u32>>::get(),
+			0
+		);
+	}
+
+	#[test]
+	fn collator_selection_requires_at_least_five_collators() {
+		assert_eq!(
+			<<Runtime as pallet_collator_selection::Config>::MinEligibleCollators as Get<u32>>::get(
+			),
+			3
+		);
+	}
+
+	#[test]
+	fn collator_selection_allows_max_twenty_invulnerables() {
+		// Additional invulnerables can be added after genesis via `UpdateOrigin`
+		assert_eq!(
+			<<Runtime as pallet_collator_selection::Config>::MaxInvulnerables as Get<u32>>::get(),
+			20
+		);
+	}
+
+	#[test]
+	fn collator_selection_identifies_collators_using_account_id() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_collator_selection::Config>::ValidatorId>(),
+			TypeId::of::<<Runtime as frame_system::Config>::AccountId>(),
+		);
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_collator_selection::Config>::ValidatorIdOf>(),
+			TypeId::of::<pallet_collator_selection::IdentityCollator>(),
+		);
+	}
+
+	#[test]
+	fn collator_selection_ensures_session_keys_registered() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_collator_selection::Config>::ValidatorRegistration>(),
+			TypeId::of::<Session>(),
+		);
+	}
+
+	#[test]
+	fn collator_selection_does_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as pallet_collator_selection::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn session_identifies_collators_using_account_id() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_session::Config>::ValidatorId>(),
+			TypeId::of::<<Runtime as frame_system::Config>::AccountId>(),
+		);
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_session::Config>::ValidatorIdOf>(),
+			TypeId::of::<pallet_collator_selection::IdentityCollator>(),
+		);
+	}
+
+	#[test]
+	fn session_length_is_predefined_period_of_blocks() {
+		assert_eq!(Period::get(), 6 * HOURS);
+		assert_eq!(Period::get(), (60 / 6) * 60 * 6); // 6s blocks per minute * minutes in an hour * hours
+		let periodic_sessions = TypeId::of::<pallet_session::PeriodicSessions<Period, Offset>>();
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_session::Config>::ShouldEndSession>(),
+			periodic_sessions,
+		);
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_session::Config>::NextSessionRotation>(),
+			periodic_sessions,
+		);
+	}
+
+	#[test]
+	fn session_collators_managed_by_collator_selection() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_session::Config>::SessionManager>(),
+			TypeId::of::<CollatorSelection>(),
+		);
+	}
+
+	#[test]
+	fn session_handled_by_aura() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_session::Config>::SessionHandler>(),
+			TypeId::of::<(Aura,)>(),
+		);
+	}
+
+	#[test]
+	fn session_keys_provided_by_aura() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_session::Config>::Keys>(),
+			TypeId::of::<SessionKeys>(),
+		);
+		// Session keys implementation uses aura-defined authority identifier type
+		SessionKeys {
+			aura: <Runtime as pallet_aura::Config>::AuthorityId::from_slice(&[0u8; 32]).unwrap(),
+		};
+	}
+
+	#[test]
+	fn session_does_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as pallet_session::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn aura_uses_sr25519_for_authority_id() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_aura::Config>::AuthorityId>(),
+			TypeId::of::<sp_consensus_aura::sr25519::AuthorityId>(),
+		);
+	}
+
+	#[test]
+	fn aura_max_authorities() {
+		assert_eq!(<<Runtime as pallet_aura::Config>::MaxAuthorities as Get<u32>>::get(), 3_600);
+	}
+
+	#[test]
+	fn aura_disabled_validators_not_used() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_aura::Config>::DisabledValidators>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn aura_allows_multiple_blocks_per_slot() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_aura::Config>::AllowMultipleBlocksPerSlot>(),
+			TypeId::of::<ConstBool<true>>(),
+		);
+	}
+
+	#[test]
+	fn aura_has_six_second_blocks() {
+		assert_eq!(<<Runtime as pallet_aura::Config>::SlotDuration as Get<u64>>::get(), 6_000);
+	}
+}

--- a/runtime/mainnet/src/config/governance.rs
+++ b/runtime/mainnet/src/config/governance.rs
@@ -1,0 +1,22 @@
+use crate::{Runtime, RuntimeCall, RuntimeEvent};
+
+impl pallet_sudo::Config for Runtime {
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = pallet_sudo::weights::SubstrateWeight<Runtime>;
+}
+
+#[cfg(test)]
+mod tests {
+	use std::any::TypeId;
+
+	use super::*;
+
+	#[test]
+	fn sudo_does_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as pallet_sudo::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+}

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod monetary;
 mod proxy;
 mod utility;
 pub mod xcm;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,3 +1,4 @@
+mod collation;
 pub(crate) mod monetary;
 mod proxy;
 mod utility;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -2,5 +2,6 @@ mod collation;
 mod governance;
 pub(crate) mod monetary;
 mod proxy;
+pub(crate) mod system;
 mod utility;
 pub mod xcm;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,2 +1,3 @@
 mod proxy;
+mod utility;
 pub mod xcm;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod collation;
+mod governance;
 pub(crate) mod monetary;
 mod proxy;
 mod utility;

--- a/runtime/mainnet/src/config/monetary.rs
+++ b/runtime/mainnet/src/config/monetary.rs
@@ -8,7 +8,7 @@ use crate::{
 
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
 	// src: https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/constants/src/polkadot.rs#L70
-	(items as Balance * 20 * UNIT + (bytes as Balance) * 100 * fee::MILLICENTS) / 100
+	(items as Balance * 20 * UNIT + (bytes as Balance) * 100 * fee::MILLI_CENTS) / 100
 }
 
 /// Constants related to Polkadot fee payment.
@@ -26,12 +26,12 @@ pub mod fee {
 	pub use sp_runtime::Perbill;
 
 	pub const CENTS: Balance = MILLI_UNIT * 10; // 100_000_000
-	pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000
+	pub const MILLI_CENTS: Balance = CENTS / 1_000; // 100_000
 
 	/// Cost of every transaction byte at Polkadot system parachains.
 	///
 	/// It is the Relay Chain (Polkadot) `TransactionByteFee` / 20.
-	pub const TRANSACTION_BYTE_FEE: Balance = MILLICENTS / 2;
+	pub const TRANSACTION_BYTE_FEE: Balance = MILLI_CENTS / 2;
 
 	/// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
 	/// node's balance type.
@@ -170,7 +170,7 @@ mod tests {
 
 		// fee specific units
 		assert_eq!(fee::CENTS, 100_000_000);
-		assert_eq!(fee::MILLICENTS, 100_000);
+		assert_eq!(fee::MILLI_CENTS, 100_000);
 	}
 
 	#[test]
@@ -365,7 +365,6 @@ mod tests {
 	}
 
 	#[test]
-	#[ignore]
 	fn transaction_payment_uses_weight_to_fee_conversion() {
 		assert_eq!(
 			TypeId::of::<<Runtime as pallet_transaction_payment::Config>::WeightToFee>(),

--- a/runtime/mainnet/src/config/monetary.rs
+++ b/runtime/mainnet/src/config/monetary.rs
@@ -21,11 +21,11 @@ pub mod fee {
 			WeightToFeeCoefficients, WeightToFeePolynomial,
 		},
 	};
-	use pop_runtime_common::{Balance, MILLIUNIT};
+	use pop_runtime_common::{Balance, MILLI_UNIT};
 	use smallvec::smallvec;
 	pub use sp_runtime::Perbill;
 
-	pub const CENTS: Balance = MILLIUNIT * 10; // 100_000_000
+	pub const CENTS: Balance = MILLI_UNIT * 10; // 100_000_000
 	pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000
 
 	/// Cost of every transaction byte at Polkadot system parachains.
@@ -105,6 +105,7 @@ impl pallet_balances::Config for Runtime {
 	type AccountStore = System;
 	/// The type for recording an account's balance.
 	type Balance = Balance;
+	type DoneSlashHandler = ();
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type FreezeIdentifier = RuntimeFreezeReason;
@@ -132,6 +133,7 @@ impl pallet_transaction_payment::Config for Runtime {
 		pallet_transaction_payment::FungibleAdapter<Balances, ResolveTo<SudoAddress, Balances>>;
 	type OperationalFeeMultiplier = ConstU8<5>;
 	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = pallet_transaction_payment::weights::SubstrateWeight<Runtime>;
 	type WeightToFee = fee::WeightToFee;
 }
 
@@ -144,7 +146,7 @@ mod tests {
 		traits::{fungible::Mutate, Get},
 	};
 	use pallet_transaction_payment::OnChargeTransaction as OnChargeTransactionT;
-	use pop_runtime_common::{MICROUNIT, MILLIUNIT};
+	use pop_runtime_common::{MICRO_UNIT, MILLI_UNIT};
 	use sp_runtime::{traits::Dispatchable, BuildStorage};
 
 	use super::*;
@@ -163,8 +165,8 @@ mod tests {
 	fn units_are_correct() {
 		// UNIT should have 10 decimals
 		assert_eq!(UNIT, 10_000_000_000);
-		assert_eq!(MILLIUNIT, 10_000_000);
-		assert_eq!(MICROUNIT, 10_000);
+		assert_eq!(MILLI_UNIT, 10_000_000);
+		assert_eq!(MICRO_UNIT, 10_000);
 
 		// fee specific units
 		assert_eq!(fee::CENTS, 100_000_000);
@@ -181,11 +183,11 @@ mod tests {
 		const UNITS: Balance = 10_000_000_000;
 		const DOLLARS: Balance = UNITS; // 10_000_000_000
 		const CENTS: Balance = DOLLARS / 100; // 100_000_000
-		const MILLICENTS: Balance = CENTS / 1_000; // 100_000
+		const MILLI_CENTS: Balance = CENTS / 1_000; // 100_000
 
 		// https://github.com/polkadot-fellows/runtimes/blob/e220854a081f30183999848ce6c11ca62647bcfa/relay/polkadot/constants/src/lib.rs#L36
 		fn relay_deposit(items: u32, bytes: u32) -> Balance {
-			items as Balance * 20 * DOLLARS + (bytes as Balance) * 100 * MILLICENTS
+			items as Balance * 20 * DOLLARS + (bytes as Balance) * 100 * MILLI_CENTS
 		}
 
 		// https://github.com/polkadot-fellows/runtimes/blob/e220854a081f30183999848ce6c11ca62647bcfa/system-parachains/constants/src/polkadot.rs#L70

--- a/runtime/mainnet/src/config/monetary.rs
+++ b/runtime/mainnet/src/config/monetary.rs
@@ -1,0 +1,373 @@
+use pop_runtime_common::UNIT;
+
+use crate::{
+	parameter_types, AccountId, Balance, Balances, ConstU32, ConstU8, ConstantMultiplier,
+	ResolveTo, Runtime, RuntimeEvent, RuntimeFreezeReason, RuntimeHoldReason,
+	SlowAdjustingFeeUpdate, Ss58Codec, System, VariantCountOf, EXISTENTIAL_DEPOSIT,
+};
+
+pub const fn deposit(items: u32, bytes: u32) -> Balance {
+	// src: https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/constants/src/polkadot.rs#L70
+	(items as Balance * 20 * UNIT + (bytes as Balance) * 100 * fee::MILLICENTS) / 100
+}
+
+/// Constants related to Polkadot fee payment.
+/// Source: https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/constants/src/polkadot.rs#L65C47-L65C58
+pub mod fee {
+	use frame_support::{
+		pallet_prelude::Weight,
+		weights::{
+			constants::ExtrinsicBaseWeight, FeePolynomial, WeightToFeeCoefficient,
+			WeightToFeeCoefficients, WeightToFeePolynomial,
+		},
+	};
+	use pop_runtime_common::{Balance, MILLIUNIT};
+	use smallvec::smallvec;
+	pub use sp_runtime::Perbill;
+
+	pub const CENTS: Balance = MILLIUNIT * 10; // 100_000_000
+	pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000
+
+	/// Cost of every transaction byte at Polkadot system parachains.
+	///
+	/// It is the Relay Chain (Polkadot) `TransactionByteFee` / 20.
+	pub const TRANSACTION_BYTE_FEE: Balance = MILLICENTS / 2;
+
+	/// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
+	/// node's balance type.
+	///
+	/// This should typically create a mapping between the following ranges:
+	///   - [0, MAXIMUM_BLOCK_WEIGHT]
+	///   - [Balance::min, Balance::max]
+	///
+	/// Yet, it can be used for any other sort of change to weight-fee. Some examples being:
+	///   - Setting it to `0` will essentially disable the weight fee.
+	///   - Setting it to `1` will cause the literal `#[weight = x]` values to be charged.
+	pub struct WeightToFee;
+	impl frame_support::weights::WeightToFee for WeightToFee {
+		type Balance = Balance;
+
+		fn weight_to_fee(weight: &Weight) -> Self::Balance {
+			let time_poly: FeePolynomial<Balance> = RefTimeToFee::polynomial().into();
+			let proof_poly: FeePolynomial<Balance> = ProofSizeToFee::polynomial().into();
+
+			// Take the maximum instead of the sum to charge by the more scarce resource.
+			time_poly.eval(weight.ref_time()).max(proof_poly.eval(weight.proof_size()))
+		}
+	}
+
+	/// Maps the reference time component of `Weight` to a fee.
+	pub struct RefTimeToFee;
+	impl WeightToFeePolynomial for RefTimeToFee {
+		type Balance = Balance;
+
+		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+			// In Polkadot, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
+			// The standard system parachain configuration is 1/20 of that, as in 1/200 CENT.
+			let p = CENTS;
+			let q = 200 * Balance::from(ExtrinsicBaseWeight::get().ref_time());
+
+			smallvec![WeightToFeeCoefficient {
+				degree: 1,
+				negative: false,
+				coeff_frac: Perbill::from_rational(p % q, q),
+				coeff_integer: p / q,
+			}]
+		}
+	}
+
+	/// Maps the proof size component of `Weight` to a fee.
+	pub struct ProofSizeToFee;
+	impl WeightToFeePolynomial for ProofSizeToFee {
+		type Balance = Balance;
+
+		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+			// Map 20kb proof to 1 CENT.
+			let p = CENTS;
+			let q = 20_000;
+
+			smallvec![WeightToFeeCoefficient {
+				degree: 1,
+				negative: false,
+				coeff_frac: Perbill::from_rational(p % q, q),
+				coeff_integer: p / q,
+			}]
+		}
+	}
+}
+
+parameter_types! {
+	// increase ED 100 times to match system chains: 1_000_000_000
+	pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT * 100;
+}
+
+impl pallet_balances::Config for Runtime {
+	type AccountStore = System;
+	/// The type for recording an account's balance.
+	type Balance = Balance;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type FreezeIdentifier = RuntimeFreezeReason;
+	type MaxFreezes = VariantCountOf<RuntimeFreezeReason>;
+	type MaxLocks = ConstU32<0>;
+	type MaxReserves = ConstU32<0>;
+	type ReserveIdentifier = ();
+	/// The ubiquitous event type.
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
+}
+
+parameter_types! {
+	/// Relay Chain `TransactionByteFee` / 10
+	pub const TransactionByteFee: Balance = fee::TRANSACTION_BYTE_FEE;
+	pub SudoAddress: AccountId = AccountId::from_ss58check("15NMV2JX1NeMwarQiiZvuJ8ixUcvayFDcu1F9Wz1HNpSc8gP").expect("sudo address is valid SS58");
+}
+
+impl pallet_transaction_payment::Config for Runtime {
+	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
+	type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
+	type OnChargeTransaction =
+		pallet_transaction_payment::FungibleAdapter<Balances, ResolveTo<SudoAddress, Balances>>;
+	type OperationalFeeMultiplier = ConstU8<5>;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightToFee = fee::WeightToFee;
+}
+
+#[cfg(test)]
+mod tests {
+	use std::any::TypeId;
+
+	use frame_support::{
+		dispatch::GetDispatchInfo,
+		traits::{fungible::Mutate, Get},
+	};
+	use pallet_transaction_payment::OnChargeTransaction as OnChargeTransactionT;
+	use pop_runtime_common::{MICROUNIT, MILLIUNIT};
+	use sp_runtime::{traits::Dispatchable, BuildStorage};
+
+	use super::*;
+	use crate::{RuntimeCall, RuntimeOrigin, UNIT};
+
+	type OnChargeTransaction = <Runtime as pallet_transaction_payment::Config>::OnChargeTransaction;
+
+	fn new_test_ext() -> sp_io::TestExternalities {
+		let storage = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+		let mut ext = sp_io::TestExternalities::new(storage);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+
+	#[test]
+	fn units_are_correct() {
+		// UNIT should have 10 decimals
+		assert_eq!(UNIT, 10_000_000_000);
+		assert_eq!(MILLIUNIT, 10_000_000);
+		assert_eq!(MICROUNIT, 10_000);
+
+		// fee specific units
+		assert_eq!(fee::CENTS, 100_000_000);
+		assert_eq!(fee::MILLICENTS, 100_000);
+	}
+
+	#[test]
+	fn transaction_byte_fee_is_correct() {
+		assert_eq!(fee::TRANSACTION_BYTE_FEE, 50_000);
+	}
+
+	#[test]
+	fn deposit_works() {
+		const UNITS: Balance = 10_000_000_000;
+		const DOLLARS: Balance = UNITS; // 10_000_000_000
+		const CENTS: Balance = DOLLARS / 100; // 100_000_000
+		const MILLICENTS: Balance = CENTS / 1_000; // 100_000
+
+		// https://github.com/polkadot-fellows/runtimes/blob/e220854a081f30183999848ce6c11ca62647bcfa/relay/polkadot/constants/src/lib.rs#L36
+		fn relay_deposit(items: u32, bytes: u32) -> Balance {
+			items as Balance * 20 * DOLLARS + (bytes as Balance) * 100 * MILLICENTS
+		}
+
+		// https://github.com/polkadot-fellows/runtimes/blob/e220854a081f30183999848ce6c11ca62647bcfa/system-parachains/constants/src/polkadot.rs#L70
+		fn system_para_deposit(items: u32, bytes: u32) -> Balance {
+			relay_deposit(items, bytes) / 100
+		}
+
+		assert_eq!(deposit(2, 64), system_para_deposit(2, 64))
+	}
+
+	#[test]
+	fn balances_stores_account_balances_in_system() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_balances::Config>::AccountStore>(),
+			TypeId::of::<System>(),
+		);
+	}
+
+	#[test]
+	fn balances_uses_u128_balance() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_balances::Config>::Balance>(),
+			TypeId::of::<u128>(),
+		);
+	}
+
+	#[test]
+	fn balances_dust_removal_handler_burns_tokens() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_balances::Config>::DustRemoval>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn balances_requires_existential_deposit() {
+		assert_eq!(ExistentialDeposit::get(), EXISTENTIAL_DEPOSIT * 100);
+		assert_eq!(ExistentialDeposit::get(), 1_000_000_000);
+	}
+
+	#[test]
+	fn balances_freeze_identifier_uses_runtime_freeze_reason() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_balances::Config>::FreezeIdentifier>(),
+			TypeId::of::<RuntimeFreezeReason>(),
+		);
+	}
+
+	#[test]
+	fn balances_max_freezes_uses_runtime_freeze_reason() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_balances::Config>::MaxFreezes>(),
+			TypeId::of::<VariantCountOf<RuntimeFreezeReason>>(),
+		);
+	}
+
+	#[test]
+	fn balances_max_locks_disabled() {
+		// Use of locks is deprecated in favour of freezes. See `https://github.com/paritytech/substrate/pull/12951/`
+		assert_eq!(<<Runtime as pallet_balances::Config>::MaxLocks as Get<u32>>::get(), 0);
+	}
+
+	#[test]
+	fn balances_max_reserves_disabled() {
+		// Use of reserves is deprecated in favour of holds. See `https://github.com/paritytech/substrate/pull/12951/`
+		assert_eq!(<<Runtime as pallet_balances::Config>::MaxReserves as Get<u32>>::get(), 0);
+	}
+
+	#[test]
+	fn balances_reserve_identifier_disabled() {
+		// Use of reserves is deprecated in favour of holds. See `https://github.com/paritytech/substrate/pull/12951/`
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_balances::Config>::ReserveIdentifier>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn balances_uses_runtime_freeze_reason() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_balances::Config>::RuntimeFreezeReason>(),
+			TypeId::of::<RuntimeFreezeReason>(),
+		);
+	}
+
+	#[test]
+	fn balances_uses_runtime_hold_reason() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_balances::Config>::RuntimeHoldReason>(),
+			TypeId::of::<RuntimeHoldReason>(),
+		);
+	}
+
+	#[test]
+	fn balances_does_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as pallet_balances::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn transaction_payment_uses_slow_adjusting_fee_multiplier() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_transaction_payment::Config>::FeeMultiplierUpdate>(),
+			TypeId::of::<SlowAdjustingFeeUpdate<Runtime>>(),
+		);
+	}
+
+	#[test]
+	fn transaction_payment_uses_constant_length_to_fee_multiplier() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_transaction_payment::Config>::LengthToFee>(),
+			TypeId::of::<ConstantMultiplier<Balance, TransactionByteFee>>(),
+		);
+	}
+
+	#[test]
+	fn transaction_payment_charges_fees_via_balances_and_funds_sudo() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_transaction_payment::Config>::OnChargeTransaction>(),
+			TypeId::of::<
+				pallet_transaction_payment::FungibleAdapter<
+					Balances,
+					ResolveTo<SudoAddress, Balances>,
+				>,
+			>(),
+		);
+
+		new_test_ext().execute_with(|| {
+			let who = AccountId::from([1u8; 32]);
+			let call = RuntimeCall::System(frame_system::Call::remark { remark: vec![] });
+			let fee = UNIT / 10;
+			let tip = UNIT / 2;
+			let fee_plus_tip = fee + tip;
+			let sudo_balance = Balances::free_balance(&SudoAddress::get());
+			let dispatch_info = call.get_dispatch_info();
+			let existential_deposit =
+				<<Runtime as pallet_balances::Config>::ExistentialDeposit>::get();
+
+			// NOTE: OnChargeTransaction functions expect tip to be included within fee
+			Balances::set_balance(&who, fee + tip + existential_deposit);
+			let liquidity_info =
+				<OnChargeTransaction as OnChargeTransactionT<Runtime>>::withdraw_fee(
+					&who,
+					&call,
+					&dispatch_info,
+					fee_plus_tip,
+					0,
+				)
+				.unwrap();
+			<OnChargeTransaction as OnChargeTransactionT<Runtime>>::correct_and_deposit_fee(
+				&who,
+				&dispatch_info,
+				&call.dispatch(RuntimeOrigin::signed(who.clone())).unwrap(),
+				fee_plus_tip,
+				0,
+				liquidity_info,
+			)
+			.unwrap();
+
+			assert_eq!(Balances::free_balance(&SudoAddress::get()), sudo_balance + fee + tip);
+			assert_eq!(Balances::free_balance(&who), existential_deposit);
+		})
+	}
+
+	#[test]
+	fn transaction_payment_uses_5x_operational_fee_multiplier() {
+		assert_eq!(
+			<<Runtime as pallet_transaction_payment::Config>::OperationalFeeMultiplier as Get<
+				u8,
+			>>::get(),
+			5
+		);
+	}
+
+	#[test]
+	#[ignore]
+	fn transaction_payment_uses_weight_to_fee_conversion() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_transaction_payment::Config>::WeightToFee>(),
+			TypeId::of::<fee::WeightToFee>(),
+		);
+	}
+}

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -1,11 +1,10 @@
 use frame_support::traits::InstanceFilter;
-use pop_runtime_common::proxy::{
-	AnnouncementDepositBase, AnnouncementDepositFactor, MaxPending, MaxProxies, ProxyDepositBase,
-	ProxyDepositFactor, ProxyType,
-};
-use sp_runtime::traits::BlakeTwo256;
+use pop_runtime_common::proxy::{MaxPending, MaxProxies, ProxyType};
 
-use crate::{Balances, Runtime, RuntimeCall, RuntimeEvent};
+use crate::{
+	config::monetary::deposit, parameter_types, Balance, Balances, BlakeTwo256, Runtime,
+	RuntimeCall, RuntimeEvent,
+};
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
@@ -41,6 +40,16 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	}
 }
 
+parameter_types! {
+	// One storage item; key size 32, value size 16.
+	pub const ProxyDepositBase: Balance = deposit(1, 48);
+	// Additional storage item size of AccountId 32 bytes + ProxyType 1 byte + BlockNum 4 bytes.
+	pub const ProxyDepositFactor: Balance = deposit(0, 37);
+	// One storage item; key size 32, value size 16.
+	pub const AnnouncementDepositBase: Balance = deposit(1, 48);
+	// Additional storage item 32 bytes AccountId + 32 bytes Hash + 4 bytes BlockNum.
+	pub const AnnouncementDepositFactor: Balance = deposit(0, 68);
+}
 impl pallet_proxy::Config for Runtime {
 	type AnnouncementDepositBase = AnnouncementDepositBase;
 	type AnnouncementDepositFactor = AnnouncementDepositFactor;
@@ -54,4 +63,87 @@ impl pallet_proxy::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_proxy::weights::SubstrateWeight<Self>;
+}
+
+#[cfg(test)]
+mod tests {
+	use std::any::TypeId;
+
+	use frame_support::traits::Get;
+
+	use super::*;
+
+	#[test]
+	fn proxy_does_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn pallet_proxy_uses_proxy_type() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::ProxyType>(),
+			TypeId::of::<ProxyType>(),
+		);
+	}
+
+	#[test]
+	fn proxy_has_deposit_factor() {
+		assert_eq!(
+			<<Runtime as pallet_proxy::Config>::ProxyDepositFactor as Get<Balance>>::get(),
+			deposit(0, 37),
+		);
+	}
+
+	#[test]
+	fn proxy_has_deposit_base() {
+		assert_eq!(
+			<<Runtime as pallet_proxy::Config>::ProxyDepositBase as Get<Balance>>::get(),
+			deposit(1, 48),
+		);
+	}
+
+	#[test]
+	fn proxy_uses_balances_as_currency() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::Currency>(),
+			TypeId::of::<Balances>(),
+		);
+	}
+
+	#[test]
+	fn proxy_configures_max_num_of_proxies() {
+		assert_eq!(<<Runtime as pallet_proxy::Config>::MaxProxies>::get(), 32,);
+	}
+
+	#[test]
+	fn proxy_configures_max_pending() {
+		assert_eq!(<<Runtime as pallet_proxy::Config>::MaxPending>::get(), 32,);
+	}
+
+	#[test]
+	fn proxy_uses_blaketwo256_as_hasher() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::CallHasher>(),
+			TypeId::of::<BlakeTwo256>(),
+		);
+	}
+
+	#[test]
+	fn proxy_has_announcement_deposit_factor() {
+		assert_eq!(
+			<<Runtime as pallet_proxy::Config>::AnnouncementDepositFactor as Get<Balance>>::get(),
+			deposit(0, 68),
+		);
+	}
+
+	#[test]
+	fn proxy_has_announcement_deposit_base() {
+		assert_eq!(
+			<<Runtime as pallet_proxy::Config>::AnnouncementDepositBase as Get<Balance>>::get(),
+			deposit(1, 48),
+		);
+	}
 }

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -1,0 +1,355 @@
+use polkadot_runtime_common::BlockHashCount;
+use pop_runtime_common::{
+	Nonce, AVERAGE_ON_INITIALIZE_RATIO, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+};
+use sp_runtime::traits::AccountIdLookup;
+
+use crate::{
+	parameter_types,
+	weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
+	AccountId, Balance, BlakeTwo256, Block, BlockLength, BlockWeights, DispatchClass, Everything,
+	Hash, PalletInfo, Perbill, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, RuntimeTask,
+	RuntimeVersion, VERSION,
+};
+
+parameter_types! {
+	pub const Version: RuntimeVersion = VERSION;
+	pub const SS58Prefix: u16 = 0;
+	// This part is copied from Substrate's `bin/node/runtime/src/lib.rs`.
+	//  The `RuntimeBlockLength` and `RuntimeBlockWeights` exist here because the
+	// `DeletionWeightLimit` and `DeletionQueueDepth` depend on those to parameterize
+	// the lazy contract deletion.
+	pub RuntimeBlockLength: BlockLength =
+		BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
+	pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
+		.base_block(BlockExecutionWeight::get())
+		.for_class(DispatchClass::all(), |weights| {
+			weights.base_extrinsic = ExtrinsicBaseWeight::get();
+		})
+		.for_class(DispatchClass::Normal, |weights| {
+			weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
+		})
+		.for_class(DispatchClass::Operational, |weights| {
+			weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
+			// Operational transactions have some extra reserved space, so that they
+			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
+			weights.reserved = Some(
+				MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT
+			);
+		})
+		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
+		.build_or_panic();
+}
+
+impl frame_system::Config for Runtime {
+	/// The data to be stored in an account.
+	type AccountData = pallet_balances::AccountData<Balance>;
+	/// The identifier used to distinguish between accounts.
+	type AccountId = AccountId;
+	/// The basic call filter to use in dispatchable. Supports everything as the default.
+	type BaseCallFilter = Everything;
+	/// The block type.
+	type Block = Block;
+	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
+	type BlockHashCount = BlockHashCount;
+	/// The maximum length of a block (in bytes).
+	type BlockLength = RuntimeBlockLength;
+	/// Block & extrinsics weights: base values and limits.
+	type BlockWeights = RuntimeBlockWeights;
+	/// The weight of database operations that the runtime can invoke.
+	type DbWeight = RocksDbWeight;
+	/// Weight information for the extensions of this pallet.
+	type ExtensionsWeightInfo = ();
+	/// The type for hashing blocks and tries.
+	type Hash = Hash;
+	/// The default hashing algorithm used.
+	type Hashing = BlakeTwo256;
+	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
+	type Lookup = AccountIdLookup<Self::AccountId, ()>;
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MultiBlockMigrator = ();
+	/// The index type for storing how many extrinsics an account has signed.
+	type Nonce = Nonce;
+	/// What to do if an account is fully reaped from the system.
+	type OnKilledAccount = ();
+	/// What to do if a new account is created.
+	type OnNewAccount = ();
+	/// The action to take on a Runtime Upgrade
+	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
+	/// Converts a module to the index of the module, injected by `construct_runtime!`.
+	type PalletInfo = PalletInfo;
+	type PostInherents = ();
+	type PostTransactions = ();
+	type PreInherents = ();
+	/// The aggregated dispatch type available for extrinsics, injected by
+	/// `construct_runtime!`.
+	type RuntimeCall = RuntimeCall;
+	/// The ubiquitous event type injected by `construct_runtime!`.
+	type RuntimeEvent = RuntimeEvent;
+	/// The ubiquitous origin type injected by `construct_runtime!`.
+	type RuntimeOrigin = RuntimeOrigin;
+	/// The aggregated Task type, injected by `construct_runtime!`.
+	type RuntimeTask = RuntimeTask;
+	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
+	type SS58Prefix = SS58Prefix;
+	type SingleBlockMigrations = ();
+	/// Weight information for the extrinsics of this pallet.
+	type SystemWeightInfo = frame_system::weights::SubstrateWeight<Self>;
+	/// Runtime version.
+	type Version = Version;
+}
+
+#[cfg(test)]
+mod tests {
+	use alloc::borrow::Cow;
+	use std::any::TypeId;
+
+	use cumulus_primitives_core::relay_chain::MAX_POV_SIZE;
+	use frame_support::{
+		dispatch::PerDispatchClass, traits::Get, weights::constants::WEIGHT_REF_TIME_PER_SECOND,
+	};
+	use frame_system::limits::WeightsPerClass;
+	use sp_core::crypto::AccountId32;
+	use sp_runtime::generic;
+
+	use super::*;
+	use crate::{Header, UncheckedExtrinsic, Weight};
+
+	#[test]
+	fn base_call_filter_allows_everything() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::BaseCallFilter>(),
+			TypeId::of::<Everything>(),
+		);
+	}
+
+	#[test]
+	fn system_account_id_is_32_bytes() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::AccountId>(),
+			TypeId::of::<AccountId32>(),
+		);
+	}
+
+	#[test]
+	fn system_block_configured() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::Block>(),
+			TypeId::of::<generic::Block<Header, UncheckedExtrinsic>>(),
+		);
+	}
+
+	#[test]
+	fn system_block_hash_count() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::BlockHashCount>(),
+			TypeId::of::<BlockHashCount>(),
+		);
+		assert_eq!(BlockHashCount::get(), 4096);
+	}
+
+	#[test]
+	fn system_block_length_restricted_by_pov() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::BlockLength>(),
+			TypeId::of::<RuntimeBlockLength>(),
+		);
+		// Normal extrinsics limited to 75% of max PoV size
+		assert_eq!(
+			*RuntimeBlockLength::get().max.get(DispatchClass::Normal),
+			Perbill::from_percent(75) * MAX_POV_SIZE
+		);
+		// Operational / mandatory (inherents) limited to max PoV size
+		assert_eq!(*RuntimeBlockLength::get().max.get(DispatchClass::Operational), MAX_POV_SIZE);
+		assert_eq!(*RuntimeBlockLength::get().max.get(DispatchClass::Mandatory), MAX_POV_SIZE);
+	}
+
+	#[test]
+	fn system_block_weights_restricted_by_dispatch_class() {
+		let max_block_weight =
+			// Two seconds compute per 6s block, max PoV size
+			Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), MAX_POV_SIZE as u64);
+		let base_extrinsic = ExtrinsicBaseWeight::get();
+		let expected_per_class = PerDispatchClass::new(|dc| match dc {
+			DispatchClass::Normal => {
+				let max_total = Perbill::from_percent(75) * max_block_weight; // 75% of block
+				WeightsPerClass {
+					base_extrinsic,
+					max_extrinsic: Some(
+						max_total - (Perbill::from_percent(5) * max_block_weight) - base_extrinsic,
+					), // max - average initialise ratio - base weight
+					max_total: Some(max_total),
+					reserved: Some(Weight::zero()),
+				}
+			},
+			DispatchClass::Operational => WeightsPerClass {
+				base_extrinsic,
+				max_extrinsic: Some(
+					max_block_weight -
+						(Perbill::from_percent(5) * max_block_weight) -
+						base_extrinsic,
+				),
+				max_total: Some(max_block_weight),
+				reserved: Some(Perbill::from_percent(25) * max_block_weight),
+			},
+			DispatchClass::Mandatory => WeightsPerClass {
+				base_extrinsic,
+				max_extrinsic: None,
+				max_total: None,
+				reserved: None,
+			},
+		});
+
+		assert_eq!(MAXIMUM_BLOCK_WEIGHT, max_block_weight);
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::BlockWeights>(),
+			TypeId::of::<RuntimeBlockWeights>(),
+		);
+		assert_eq!(RuntimeBlockWeights::get().base_block, BlockExecutionWeight::get());
+		assert_eq!(RuntimeBlockWeights::get().max_block, max_block_weight);
+
+		let actual = RuntimeBlockWeights::get();
+		for class in [DispatchClass::Normal, DispatchClass::Operational, DispatchClass::Mandatory] {
+			let actual = actual.per_class.get(class);
+			let expected = expected_per_class.get(class);
+			println!("{class:?}\nactual   {actual:?}\nexpected {expected:?}\n");
+			assert_eq!(actual.base_extrinsic, expected.base_extrinsic);
+			assert_eq!(actual.max_extrinsic, expected.max_extrinsic);
+			assert_eq!(actual.max_total, expected.max_total);
+			assert_eq!(actual.reserved, expected.reserved);
+		}
+	}
+
+	#[test]
+	fn system_db_weight_uses_rocks_db() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::DbWeight>(),
+			TypeId::of::<RocksDbWeight>(),
+		);
+	}
+
+	#[test]
+	fn system_uses_blake2_hashing() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::Hashing>(),
+			TypeId::of::<BlakeTwo256>(),
+		);
+	}
+
+	#[test]
+	fn system_uses_multi_address_lookup() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::Lookup>(),
+			TypeId::of::<AccountIdLookup<AccountId, ()>>(),
+		);
+	}
+
+	#[test]
+	fn system_max_consumers_limited_to_16() {
+		assert_eq!(<<Runtime as frame_system::Config>::MaxConsumers as Get<u32>>::get(), 16);
+	}
+
+	#[test]
+	fn system_multi_block_migrator_disabled() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::MultiBlockMigrator>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn system_nonce_uses_u32() {
+		assert_eq!(TypeId::of::<<Runtime as frame_system::Config>::Nonce>(), TypeId::of::<u32>(),);
+	}
+
+	#[test]
+	fn system_account_killed_handler_disabled() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::OnKilledAccount>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn system_new_account_handler_disabled() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::OnNewAccount>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn system_set_code_handler_managed_by_parachain_system() {
+		// Runtime upgrades orchestrated by parachain system pallet
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::OnSetCode>(),
+			TypeId::of::<cumulus_pallet_parachain_system::ParachainSetCode<Runtime>>(),
+		);
+	}
+
+	#[test]
+	fn system_post_inherent_handler_disabled() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::PostInherents>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn system_post_transactions_handler_disabled() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::PostTransactions>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn system_pre_inherent_handler_disabled() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::PreInherents>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn system_single_block_migrations_is_empty() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::SingleBlockMigrations>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn system_ss58_prefix_matches_relay() {
+		assert_eq!(<<Runtime as frame_system::Config>::SS58Prefix>::get(), 0);
+	}
+
+	#[test]
+	fn system_does_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as frame_system::Config>::SystemWeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	#[ignore]
+	fn system_extensions_do_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as frame_system::Config>::ExtensionsWeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn system_versions_runtime() {
+		assert_eq!(
+			TypeId::of::<<Runtime as frame_system::Config>::Version>(),
+			TypeId::of::<Version>(),
+		);
+
+		assert_eq!(Version::get().spec_name, Cow::Borrowed("pop"));
+		assert_eq!(Version::get().impl_name, Cow::Borrowed("pop"));
+		assert_eq!(Version::get().spec_version, 100);
+	}
+}

--- a/runtime/mainnet/src/config/utility.rs
+++ b/runtime/mainnet/src/config/utility.rs
@@ -1,0 +1,89 @@
+use frame_support::parameter_types;
+use crate::{Balance, Balances, OriginCaller, Runtime, RuntimeCall, RuntimeEvent, deposit};
+
+parameter_types! {
+	// One storage item; key size is 32 + 32; value is size 4+4+16+32 bytes = 120 bytes.
+	pub const DepositBase: Balance = deposit(1, 120);
+	// Additional storage item size of 32 bytes.
+	pub const DepositFactor: Balance = deposit(0, 32);
+	pub const MaxSignatories: u32 = 100;
+}
+
+impl pallet_multisig::Config for Runtime {
+    type Currency = Balances;
+    type DepositBase = DepositBase;
+    type DepositFactor = DepositFactor;
+    type MaxSignatories = MaxSignatories;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
+}
+
+impl pallet_utility::Config for Runtime {
+    type PalletsOrigin = OriginCaller;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::TypeId;
+
+    use frame_support::traits::Get;
+
+    use super::*;
+
+    #[test]
+    fn utility_caller_origin_provided_by_runtime() {
+        assert_eq!(
+			TypeId::of::<<Runtime as pallet_utility::Config>::PalletsOrigin>(),
+			TypeId::of::<OriginCaller>(),
+		);
+    }
+
+    #[test]
+    fn utility_does_not_use_default_weights() {
+        assert_ne!(
+			TypeId::of::<<Runtime as pallet_utility::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+    }
+
+    #[test]
+    fn multisig_uses_balances_for_deposits() {
+        assert_eq!(
+			TypeId::of::<<Runtime as pallet_multisig::Config>::Currency>(),
+			TypeId::of::<Balances>(),
+		);
+    }
+
+    #[test]
+    fn multisig_call_deposit_has_base_amount() {
+        assert_eq!(
+            <<Runtime as pallet_multisig::Config>::DepositBase as Get<Balance>>::get(),
+            deposit(1, 120)
+        );
+    }
+
+    #[test]
+    fn multisig_call_deposit_has_additional_factor() {
+        assert_eq!(
+            <<Runtime as pallet_multisig::Config>::DepositFactor as Get<Balance>>::get(),
+            deposit(0, 32)
+        );
+    }
+
+    #[test]
+    fn multisig_restricts_max_signatories() {
+        assert_eq!(<<Runtime as pallet_multisig::Config>::MaxSignatories as Get<u32>>::get(), 100);
+    }
+
+    #[test]
+    fn multisig_does_not_use_default_weights() {
+        assert_ne!(
+			TypeId::of::<<Runtime as pallet_multisig::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+    }
+}

--- a/runtime/mainnet/src/config/utility.rs
+++ b/runtime/mainnet/src/config/utility.rs
@@ -1,5 +1,9 @@
-use frame_support::parameter_types;
-use crate::{Balance, Balances, OriginCaller, Runtime, RuntimeCall, RuntimeEvent, deposit};
+use monetary::deposit;
+
+use crate::{
+	config::monetary, parameter_types, Balance, Balances, OriginCaller, Runtime, RuntimeCall,
+	RuntimeEvent,
+};
 
 parameter_types! {
 	// One storage item; key size is 32 + 32; value is size 4+4+16+32 bytes = 120 bytes.
@@ -10,80 +14,80 @@ parameter_types! {
 }
 
 impl pallet_multisig::Config for Runtime {
-    type Currency = Balances;
-    type DepositBase = DepositBase;
-    type DepositFactor = DepositFactor;
-    type MaxSignatories = MaxSignatories;
-    type RuntimeCall = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
-    type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
+	type Currency = Balances;
+	type DepositBase = DepositBase;
+	type DepositFactor = DepositFactor;
+	type MaxSignatories = MaxSignatories;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
 }
 
 impl pallet_utility::Config for Runtime {
-    type PalletsOrigin = OriginCaller;
-    type RuntimeCall = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
-    type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
+	type PalletsOrigin = OriginCaller;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
 }
 
 #[cfg(test)]
 mod tests {
-    use std::any::TypeId;
+	use std::any::TypeId;
 
-    use frame_support::traits::Get;
+	use frame_support::traits::Get;
 
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn utility_caller_origin_provided_by_runtime() {
-        assert_eq!(
+	#[test]
+	fn utility_caller_origin_provided_by_runtime() {
+		assert_eq!(
 			TypeId::of::<<Runtime as pallet_utility::Config>::PalletsOrigin>(),
 			TypeId::of::<OriginCaller>(),
 		);
-    }
+	}
 
-    #[test]
-    fn utility_does_not_use_default_weights() {
-        assert_ne!(
+	#[test]
+	fn utility_does_not_use_default_weights() {
+		assert_ne!(
 			TypeId::of::<<Runtime as pallet_utility::Config>::WeightInfo>(),
 			TypeId::of::<()>(),
 		);
-    }
+	}
 
-    #[test]
-    fn multisig_uses_balances_for_deposits() {
-        assert_eq!(
+	#[test]
+	fn multisig_uses_balances_for_deposits() {
+		assert_eq!(
 			TypeId::of::<<Runtime as pallet_multisig::Config>::Currency>(),
 			TypeId::of::<Balances>(),
 		);
-    }
+	}
 
-    #[test]
-    fn multisig_call_deposit_has_base_amount() {
-        assert_eq!(
-            <<Runtime as pallet_multisig::Config>::DepositBase as Get<Balance>>::get(),
-            deposit(1, 120)
-        );
-    }
+	#[test]
+	fn multisig_call_deposit_has_base_amount() {
+		assert_eq!(
+			<<Runtime as pallet_multisig::Config>::DepositBase as Get<Balance>>::get(),
+			deposit(1, 120)
+		);
+	}
 
-    #[test]
-    fn multisig_call_deposit_has_additional_factor() {
-        assert_eq!(
-            <<Runtime as pallet_multisig::Config>::DepositFactor as Get<Balance>>::get(),
-            deposit(0, 32)
-        );
-    }
+	#[test]
+	fn multisig_call_deposit_has_additional_factor() {
+		assert_eq!(
+			<<Runtime as pallet_multisig::Config>::DepositFactor as Get<Balance>>::get(),
+			deposit(0, 32)
+		);
+	}
 
-    #[test]
-    fn multisig_restricts_max_signatories() {
-        assert_eq!(<<Runtime as pallet_multisig::Config>::MaxSignatories as Get<u32>>::get(), 100);
-    }
+	#[test]
+	fn multisig_restricts_max_signatories() {
+		assert_eq!(<<Runtime as pallet_multisig::Config>::MaxSignatories as Get<u32>>::get(), 100);
+	}
 
-    #[test]
-    fn multisig_does_not_use_default_weights() {
-        assert_ne!(
+	#[test]
+	fn multisig_does_not_use_default_weights() {
+		assert_ne!(
 			TypeId::of::<<Runtime as pallet_multisig::Config>::WeightInfo>(),
 			TypeId::of::<()>(),
 		);
-    }
+	}
 }

--- a/runtime/mainnet/src/config/xcm.rs
+++ b/runtime/mainnet/src/config/xcm.rs
@@ -24,8 +24,9 @@ use xcm_builder::{
 use xcm_executor::XcmExecutor;
 
 use crate::{
-	fee::WeightToFee, AccountId, AllPalletsWithSystem, Balances, ParachainInfo, ParachainSystem,
-	PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, SudoAddress, XcmpQueue,
+	config::monetary::{fee::WeightToFee, SudoAddress},
+	AccountId, AllPalletsWithSystem, Balances, ParachainInfo, ParachainSystem, PolkadotXcm,
+	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, XcmpQueue,
 };
 
 parameter_types! {

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -570,31 +570,6 @@ impl pallet_preimage::Config for Runtime {
 	type WeightInfo = pallet_preimage::weights::SubstrateWeight<Runtime>;
 }
 
-parameter_types! {
-	// One storage item; key size is 32; value is size 4+4+16+32 bytes = 56 bytes.
-	pub const DepositBase: Balance = deposit(1, 88);
-	// Additional storage item size of 32 bytes.
-	pub const DepositFactor: Balance = deposit(0, 32);
-	pub const MaxSignatories: u32 = 100;
-}
-
-impl pallet_multisig::Config for Runtime {
-	type Currency = Balances;
-	type DepositBase = DepositBase;
-	type DepositFactor = DepositFactor;
-	type MaxSignatories = MaxSignatories;
-	type RuntimeCall = RuntimeCall;
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
-}
-
-impl pallet_utility::Config for Runtime {
-	type PalletsOrigin = OriginCaller;
-	type RuntimeCall = RuntimeCall;
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
-}
-
 #[frame_support::runtime]
 mod runtime {
 	// Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -9,11 +9,15 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 pub mod config;
 mod weights;
 
+
 extern crate alloc;
 
 use alloc::{borrow::Cow, vec::Vec};
 
-use config::xcm::{RelayLocation, XcmOriginToTransactDispatchOrigin};
+use config::{
+	monetary::deposit,
+	xcm::{RelayLocation, XcmOriginToTransactDispatchOrigin},
+};
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
@@ -118,96 +122,6 @@ pub type Executive = frame_executive::Executive<
 	AllPalletsWithSystem,
 	Migrations,
 >;
-
-pub const fn deposit(items: u32, bytes: u32) -> Balance {
-	// src: https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/constants/src/polkadot.rs#L70
-	(items as Balance * 20 * UNIT + (bytes as Balance) * 100 * fee::MILLICENTS) / 100
-}
-
-/// Constants related to Polkadot fee payment.
-/// Source: https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/constants/src/polkadot.rs#L65C47-L65C58
-pub mod fee {
-	use frame_support::{
-		pallet_prelude::Weight,
-		weights::{
-			constants::ExtrinsicBaseWeight, FeePolynomial, WeightToFeeCoefficient,
-			WeightToFeeCoefficients, WeightToFeePolynomial,
-		},
-	};
-	use pop_runtime_common::{Balance, MILLI_UNIT};
-	use smallvec::smallvec;
-	pub use sp_runtime::Perbill;
-
-	pub const CENTS: Balance = MILLI_UNIT * 10; // 100_000_000
-	pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000
-
-	/// Cost of every transaction byte at Polkadot system parachains.
-	///
-	/// It is the Relay Chain (Polkadot) `TransactionByteFee` / 20.
-	pub const TRANSACTION_BYTE_FEE: Balance = MILLICENTS / 2;
-
-	/// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
-	/// node's balance type.
-	///
-	/// This should typically create a mapping between the following ranges:
-	///   - [0, MAXIMUM_BLOCK_WEIGHT]
-	///   - [Balance::min, Balance::max]
-	///
-	/// Yet, it can be used for any other sort of change to weight-fee. Some examples being:
-	///   - Setting it to `0` will essentially disable the weight fee.
-	///   - Setting it to `1` will cause the literal `#[weight = x]` values to be charged.
-	pub struct WeightToFee;
-	impl frame_support::weights::WeightToFee for WeightToFee {
-		type Balance = Balance;
-
-		fn weight_to_fee(weight: &Weight) -> Self::Balance {
-			let time_poly: FeePolynomial<Balance> = RefTimeToFee::polynomial().into();
-			let proof_poly: FeePolynomial<Balance> = ProofSizeToFee::polynomial().into();
-
-			// Take the maximum instead of the sum to charge by the more scarce resource.
-			time_poly.eval(weight.ref_time()).max(proof_poly.eval(weight.proof_size()))
-		}
-	}
-
-	/// Maps the reference time component of `Weight` to a fee.
-	pub struct RefTimeToFee;
-	impl WeightToFeePolynomial for RefTimeToFee {
-		type Balance = Balance;
-
-		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-			// In Polkadot, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
-			// The standard system parachain configuration is 1/20 of that, as in 1/200 CENT.
-			let p = CENTS;
-			let q = 200 * Balance::from(ExtrinsicBaseWeight::get().ref_time());
-
-			smallvec![WeightToFeeCoefficient {
-				degree: 1,
-				negative: false,
-				coeff_frac: Perbill::from_rational(p % q, q),
-				coeff_integer: p / q,
-			}]
-		}
-	}
-
-	/// Maps the proof size component of `Weight` to a fee.
-	pub struct ProofSizeToFee;
-	impl WeightToFeePolynomial for ProofSizeToFee {
-		type Balance = Balance;
-
-		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-			// Map 20kb proof to 1 CENT.
-			let p = CENTS;
-			let q = 20_000;
-
-			smallvec![WeightToFeeCoefficient {
-				degree: 1,
-				negative: false,
-				coeff_frac: Perbill::from_rational(p % q, q),
-				coeff_integer: p / q,
-			}]
-		}
-	}
-}
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
@@ -348,47 +262,6 @@ impl pallet_timestamp::Config for Runtime {
 impl pallet_authorship::Config for Runtime {
 	type EventHandler = (CollatorSelection,);
 	type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
-}
-
-parameter_types! {
-	// increase ED 100 times to match system chains: 1_000_000_000
-	pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT * 100;
-}
-
-impl pallet_balances::Config for Runtime {
-	type AccountStore = System;
-	/// The type for recording an account's balance.
-	type Balance = Balance;
-	type DoneSlashHandler = ();
-	type DustRemoval = ();
-	type ExistentialDeposit = ExistentialDeposit;
-	type FreezeIdentifier = RuntimeFreezeReason;
-	type MaxFreezes = VariantCountOf<RuntimeFreezeReason>;
-	type MaxLocks = ConstU32<50>;
-	type MaxReserves = ConstU32<50>;
-	type ReserveIdentifier = [u8; 8];
-	/// The ubiquitous event type.
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeFreezeReason = RuntimeFreezeReason;
-	type RuntimeHoldReason = RuntimeHoldReason;
-	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
-}
-
-parameter_types! {
-	/// Relay Chain `TransactionByteFee` / 10
-	pub const TransactionByteFee: Balance = fee::TRANSACTION_BYTE_FEE;
-	pub SudoAddress: AccountId = AccountId::from_ss58check("15NMV2JX1NeMwarQiiZvuJ8ixUcvayFDcu1F9Wz1HNpSc8gP").expect("sudo address is valid SS58");
-}
-
-impl pallet_transaction_payment::Config for Runtime {
-	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
-	type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
-	type OnChargeTransaction =
-		pallet_transaction_payment::FungibleAdapter<Balances, ResolveTo<SudoAddress, Balances>>;
-	type OperationalFeeMultiplier = ConstU8<5>;
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-	type WeightToFee = fee::WeightToFee;
 }
 
 impl pallet_sudo::Config for Runtime {
@@ -971,48 +844,5 @@ mod tests {
 			TypeId::of::<<Runtime as frame_system::Config>::BaseCallFilter>(),
 			TypeId::of::<EverythingBut<FilteredCalls>>(),
 		);
-	}
-
-	#[test]
-	fn ed_is_correct() {
-		assert_eq!(ExistentialDeposit::get(), EXISTENTIAL_DEPOSIT * 100);
-		assert_eq!(ExistentialDeposit::get(), 1_000_000_000);
-	}
-
-	#[test]
-	fn units_are_correct() {
-		// UNIT should have 10 decimals
-		assert_eq!(UNIT, 10_000_000_000);
-		assert_eq!(MILLI_UNIT, 10_000_000);
-		assert_eq!(MICRO_UNIT, 10_000);
-
-		// fee specific units
-		assert_eq!(fee::CENTS, 100_000_000);
-		assert_eq!(fee::MILLICENTS, 100_000);
-	}
-
-	#[test]
-	fn transaction_byte_fee_is_correct() {
-		assert_eq!(fee::TRANSACTION_BYTE_FEE, 50_000);
-	}
-
-	#[test]
-	fn deposit_works() {
-		const UNITS: Balance = 10_000_000_000;
-		const DOLLARS: Balance = UNITS; // 10_000_000_000
-		const CENTS: Balance = DOLLARS / 100; // 100_000_000
-		const MILLICENTS: Balance = CENTS / 1_000; // 100_000
-
-		// https://github.com/polkadot-fellows/runtimes/blob/e220854a081f30183999848ce6c11ca62647bcfa/relay/polkadot/constants/src/lib.rs#L36
-		fn relay_deposit(items: u32, bytes: u32) -> Balance {
-			items as Balance * 20 * DOLLARS + (bytes as Balance) * 100 * MILLICENTS
-		}
-
-		// https://github.com/polkadot-fellows/runtimes/blob/e220854a081f30183999848ce6c11ca62647bcfa/system-parachains/constants/src/polkadot.rs#L70
-		fn system_para_deposit(items: u32, bytes: u32) -> Balance {
-			relay_deposit(items, bytes) / 100
-		}
-
-		assert_eq!(deposit(2, 64), system_para_deposit(2, 64))
 	}
 }

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -9,7 +9,6 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 pub mod config;
 mod weights;
 
-
 extern crate alloc;
 
 use alloc::{borrow::Cow, vec::Vec};

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -252,12 +252,6 @@ impl pallet_timestamp::Config for Runtime {
 	type WeightInfo = ();
 }
 
-impl pallet_sudo::Config for Runtime {
-	type RuntimeCall = RuntimeCall;
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-}
-
 parameter_types! {
 	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -17,14 +17,12 @@ use config::{monetary::deposit, xcm::XcmOriginToTransactDispatchOrigin};
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
-	derive_impl,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
 	traits::{
 		fungible::HoldConsideration, tokens::imbalance::ResolveTo, ConstBool, ConstU32, ConstU64,
-		ConstU8, Contains, EqualPrivilegeOnly, EverythingBut, LinearStoragePrice, TransformOrigin,
-		VariantCountOf,
+		ConstU8, Everything, LinearStoragePrice, TransformOrigin, VariantCountOf,
 	},
 	weights::{ConstantMultiplier, Weight},
 	PalletId,
@@ -33,11 +31,10 @@ use frame_system::{
 	limits::{BlockLength, BlockWeights},
 	EnsureRoot,
 };
-use pallet_balances::Call as BalancesCall;
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 use polkadot_runtime_common::xcm_sender::NoPriceForMessageDelivery;
 // Polkadot imports
-use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
+use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 pub use pop_runtime_common::{
 	AuraId, Balance, BlockNumber, Hash, Nonce, Signature, AVERAGE_ON_INITIALIZE_RATIO,
 	BLOCK_PROCESSING_VELOCITY, DAYS, EXISTENTIAL_DEPOSIT, HOURS, MAXIMUM_BLOCK_WEIGHT, MICRO_UNIT,
@@ -61,7 +58,6 @@ pub use sp_runtime::{ExtrinsicInclusionMode, MultiAddress, Perbill, Permill};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
@@ -163,87 +159,6 @@ pub fn native_version() -> NativeVersion {
 	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
-parameter_types! {
-	pub const Version: RuntimeVersion = VERSION;
-
-	// This part is copied from Substrate's `bin/node/runtime/src/lib.rs`.
-	//  The `RuntimeBlockLength` and `RuntimeBlockWeights` exist here because the
-	// `DeletionWeightLimit` and `DeletionQueueDepth` depend on those to parameterize
-	// the lazy contract deletion.
-	pub RuntimeBlockLength: BlockLength =
-		BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
-	pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
-		.base_block(BlockExecutionWeight::get())
-		.for_class(DispatchClass::all(), |weights| {
-			weights.base_extrinsic = ExtrinsicBaseWeight::get();
-		})
-		.for_class(DispatchClass::Normal, |weights| {
-			weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
-		})
-		.for_class(DispatchClass::Operational, |weights| {
-			weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
-			// Operational transactions have some extra reserved space, so that they
-			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
-			weights.reserved = Some(
-				MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT
-			);
-		})
-		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
-		.build_or_panic();
-	pub const SS58Prefix: u16 = 0;
-}
-
-/// A type to identify filtered calls.
-pub struct FilteredCalls;
-impl Contains<RuntimeCall> for FilteredCalls {
-	fn contains(c: &RuntimeCall) -> bool {
-		use BalancesCall::*;
-		matches!(
-			c,
-			RuntimeCall::Balances(
-				force_adjust_total_issuance { .. } |
-					force_set_balance { .. } |
-					force_transfer { .. } |
-					force_unreserve { .. }
-			)
-		)
-	}
-}
-
-/// The default types are being injected by [`derive_impl`](`frame_support::derive_impl`) from
-/// [`ParaChainDefaultConfig`](`struct@frame_system::config_preludes::ParaChainDefaultConfig`),
-/// but overridden as needed.
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
-impl frame_system::Config for Runtime {
-	/// The data to be stored in an account.
-	type AccountData = pallet_balances::AccountData<Balance>;
-	/// The identifier used to distinguish between accounts.
-	type AccountId = AccountId;
-	/// The basic call filter to use in dispatchable. Supports everything as the default.
-	type BaseCallFilter = EverythingBut<FilteredCalls>;
-	/// The block type.
-	type Block = Block;
-	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
-	type BlockHashCount = BlockHashCount;
-	/// The maximum length of a block (in bytes).
-	type BlockLength = RuntimeBlockLength;
-	/// Block & extrinsics weights: base values and limits.
-	type BlockWeights = RuntimeBlockWeights;
-	/// The weight of database operations that the runtime can invoke.
-	type DbWeight = RocksDbWeight;
-	/// The type for hashing blocks and tries.
-	type Hash = Hash;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	/// The index type for storing how many extrinsics an account has signed.
-	type Nonce = Nonce;
-	/// The action to take on a Runtime Upgrade
-	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
-	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
-	type SS58Prefix = SS58Prefix;
-	/// Runtime version.
-	type Version = Version;
-}
-
 impl pallet_timestamp::Config for Runtime {
 	type MinimumPeriod = ConstU64<0>;
 	/// A timestamp: milliseconds since the unix epoch.
@@ -283,6 +198,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 
 impl parachain_info::Config for Runtime {}
 
+use crate::config::system::RuntimeBlockWeights;
 parameter_types! {
 	pub MessageQueueServiceWeight: Weight = Perbill::from_percent(35) * RuntimeBlockWeights::get().max_block;
 	pub MessageQueueIdleServiceWeight: Weight = Perbill::from_percent(20) * RuntimeBlockWeights::get().max_block;
@@ -325,27 +241,6 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type WeightInfo = ();
 	// Enqueue XCMP messages from siblings for later processing.
 	type XcmpQueue = TransformOrigin<MessageQueue, AggregateMessageOrigin, ParaId, ParaIdToSibling>;
-}
-
-parameter_types! {
-	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(60) *
-		RuntimeBlockWeights::get().max_block;
-}
-
-impl pallet_scheduler::Config for Runtime {
-	#[cfg(feature = "runtime-benchmarks")]
-	type MaxScheduledPerBlock = ConstU32<512>;
-	#[cfg(not(feature = "runtime-benchmarks"))]
-	type MaxScheduledPerBlock = ConstU32<50>;
-	type MaximumWeight = MaximumSchedulerWeight;
-	type OriginPrivilegeCmp = EqualPrivilegeOnly;
-	type PalletsOrigin = OriginCaller;
-	type Preimages = Preimage;
-	type RuntimeCall = RuntimeCall;
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeOrigin = RuntimeOrigin;
-	type ScheduleOrigin = EnsureRoot<AccountId>;
-	type WeightInfo = pallet_scheduler::weights::SubstrateWeight<Runtime>;
 }
 
 parameter_types! {
@@ -718,55 +613,4 @@ impl_runtime_apis! {
 cumulus_pallet_parachain_system::register_validate_block! {
 	Runtime = Runtime,
 	BlockExecutor = cumulus_pallet_aura_ext::BlockExecutor::<Runtime, Executive>,
-}
-
-#[cfg(test)]
-mod tests {
-	use std::any::TypeId;
-
-	use pallet_balances::AdjustmentDirection;
-	use BalancesCall::*;
-	use RuntimeCall::Balances;
-
-	use super::*;
-	#[test]
-	fn filtering_force_adjust_total_issuance_works() {
-		assert!(FilteredCalls::contains(&Balances(force_adjust_total_issuance {
-			direction: AdjustmentDirection::Increase,
-			delta: 0
-		})));
-	}
-
-	#[test]
-	fn filtering_force_set_balance_works() {
-		assert!(FilteredCalls::contains(&Balances(force_set_balance {
-			who: MultiAddress::Address32([0u8; 32]),
-			new_free: 0,
-		})));
-	}
-
-	#[test]
-	fn filtering_force_transfer_works() {
-		assert!(FilteredCalls::contains(&Balances(force_transfer {
-			source: MultiAddress::Address32([0u8; 32]),
-			dest: MultiAddress::Address32([0u8; 32]),
-			value: 0,
-		})));
-	}
-
-	#[test]
-	fn filtering_force_unreserve_works() {
-		assert!(FilteredCalls::contains(&Balances(force_unreserve {
-			who: MultiAddress::Address32([0u8; 32]),
-			amount: 0
-		})));
-	}
-
-	#[test]
-	fn filtering_configured() {
-		assert_eq!(
-			TypeId::of::<<Runtime as frame_system::Config>::BaseCallFilter>(),
-			TypeId::of::<EverythingBut<FilteredCalls>>(),
-		);
-	}
 }

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -13,7 +13,7 @@ extern crate alloc;
 
 use alloc::{borrow::Cow, vec::Vec};
 
-use config::{monetary::deposit, xcm::XcmOriginToTransactDispatchOrigin};
+use config::xcm::XcmOriginToTransactDispatchOrigin;
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
@@ -241,25 +241,6 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type WeightInfo = ();
 	// Enqueue XCMP messages from siblings for later processing.
 	type XcmpQueue = TransformOrigin<MessageQueue, AggregateMessageOrigin, ParaId, ParaIdToSibling>;
-}
-
-parameter_types! {
-	pub const PreimageHoldReason: RuntimeHoldReason = RuntimeHoldReason::Preimage(pallet_preimage::HoldReason::Preimage);
-	pub const PreimageBaseDeposit: Balance = deposit(2, 64);
-	pub const PreimageByteDeposit: Balance = deposit(0, 1);
-}
-
-impl pallet_preimage::Config for Runtime {
-	type Consideration = HoldConsideration<
-		AccountId,
-		Balances,
-		PreimageHoldReason,
-		LinearStoragePrice<PreimageBaseDeposit, PreimageByteDeposit, Balance>,
-	>;
-	type Currency = Balances;
-	type ManagerOrigin = EnsureRoot<AccountId>;
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = pallet_preimage::weights::SubstrateWeight<Runtime>;
 }
 
 #[frame_support::runtime]


### PR DESCRIPTION
Instead of having every pallet config in a big main file, this PR refactors the structure grouping the pallets into modules, organized by "use case".

It does include some tests to avoid accidental changes of configuration.

Configuration is divided into the following modules:
- [x] collation
- [x] governance
- [x] monetary
- [x] proxy
- [ ] system
- [ ] utility
- [ ] xcm