### PR TITLE
refactor(mainnet): pallet_proxy config & tests

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -116,6 +116,12 @@ pub mod proxy {
 		NonTransfer,
 		/// Proxy with the ability to reject time-delay proxy announcements.
 		CancelProxy,
+		/// Assets proxy. Can execute any call from `assets`, **including asset transfers**.
+		Assets,
+		/// Owner proxy. Can execute calls related to asset ownership.
+		AssetOwner,
+		/// Asset manager. Can execute calls related to asset management.
+		AssetManager,
 		/// Collator selection proxy. Can execute calls related to collator selection mechanism.
 		Collator,
 	}
@@ -131,6 +137,8 @@ pub mod proxy {
 				(x, y) if x == y => true,
 				(ProxyType::Any, _) => true,
 				(_, ProxyType::Any) => false,
+				(ProxyType::Assets, ProxyType::AssetOwner) => true,
+				(ProxyType::Assets, ProxyType::AssetManager) => true,
 				(ProxyType::NonTransfer, ProxyType::Collator) => true,
 				_ => false,
 			}

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -116,12 +116,6 @@ pub mod proxy {
 		NonTransfer,
 		/// Proxy with the ability to reject time-delay proxy announcements.
 		CancelProxy,
-		/// Assets proxy. Can execute any call from `assets`, **including asset transfers**.
-		Assets,
-		/// Owner proxy. Can execute calls related to asset ownership.
-		AssetOwner,
-		/// Asset manager. Can execute calls related to asset management.
-		AssetManager,
 		/// Collator selection proxy. Can execute calls related to collator selection mechanism.
 		Collator,
 	}
@@ -137,8 +131,6 @@ pub mod proxy {
 				(x, y) if x == y => true,
 				(ProxyType::Any, _) => true,
 				(_, ProxyType::Any) => false,
-				(ProxyType::Assets, ProxyType::AssetOwner) => true,
-				(ProxyType::Assets, ProxyType::AssetManager) => true,
 				(ProxyType::NonTransfer, ProxyType::Collator) => true,
 				_ => false,
 			}

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -31,8 +31,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 }
 
 parameter_types! {
-	// One storage item; key size 32, value size 16.
-	pub const ProxyDepositBase: Balance = deposit(1, 48);
+	// One storage item; key size 32 + hash size 8.
+	pub const ProxyDepositBase: Balance = deposit(1, 40);
 	// Additional storage item size of AccountId 32 bytes + ProxyType 1 byte + BlockNum 4 bytes.
 	pub const ProxyDepositFactor: Balance = deposit(0, 37);
 	// One storage item; key size 32, value size 16.

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -16,15 +16,6 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Utility { .. } |
 					RuntimeCall::Multisig { .. }
 			),
-			ProxyType::Assets => {
-				matches!(c, RuntimeCall::Utility { .. } | RuntimeCall::Multisig { .. })
-			},
-			ProxyType::AssetOwner => {
-				matches!(c, RuntimeCall::Utility { .. } | RuntimeCall::Multisig { .. })
-			},
-			ProxyType::AssetManager => {
-				matches!(c, RuntimeCall::Utility { .. } | RuntimeCall::Multisig { .. })
-			},
 			ProxyType::Collator => matches!(
 				c,
 				RuntimeCall::CollatorSelection { .. } |

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -184,7 +184,7 @@ mod tests {
 	fn proxy_has_deposit_base() {
 		assert_eq!(
 			<<Runtime as pallet_proxy::Config>::ProxyDepositBase as Get<Balance>>::get(),
-			deposit(1, 48),
+			deposit(1, 40),
 		);
 	}
 

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -42,6 +42,10 @@ impl Default for ProxyType {
 }
 
 impl ProxyType {
+	/// Defines proxies permission hierarchy.
+	// Example: A proxy that is not superset of another one won't be able to remove
+	// that proxy relationship
+	// src: https://github.com/paritytech/polkadot-sdk/blob/4cd07c56378291fddb9fceab3b508cf99034126a/substrate/frame/proxy/src/lib.rs#L802
 	pub fn is_superset(s: &ProxyType, o: &ProxyType) -> bool {
 		match (s, o) {
 			(x, y) if x == y => true,

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -1,11 +1,9 @@
 use frame_support::traits::InstanceFilter;
-use pop_runtime_common::proxy::{
-	AnnouncementDepositBase, AnnouncementDepositFactor, MaxPending, MaxProxies, ProxyDepositBase,
-	ProxyDepositFactor, ProxyType,
-};
-use sp_runtime::traits::BlakeTwo256;
+use pop_runtime_common::proxy::{MaxPending, MaxProxies, ProxyType};
 
-use crate::{Balances, Runtime, RuntimeCall, RuntimeEvent};
+use crate::{
+	deposit, parameter_types, Balance, Balances, BlakeTwo256, Runtime, RuntimeCall, RuntimeEvent,
+};
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
@@ -41,6 +39,17 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	}
 }
 
+parameter_types! {
+	// One storage item; key size 32, value size 16.
+	pub const ProxyDepositBase: Balance = deposit(1, 48);
+	// Additional storage item size of AccountId 32 bytes + ProxyType 1 byte + BlockNum 4 bytes.
+	pub const ProxyDepositFactor: Balance = deposit(0, 37);
+	// One storage item; key size 32, value size 16.
+	pub const AnnouncementDepositBase: Balance = deposit(1, 48);
+	// Additional storage item 32 bytes AccountId + 32 bytes Hash + 4 bytes BlockNum.
+	pub const AnnouncementDepositFactor: Balance = deposit(0, 68);
+}
+
 impl pallet_proxy::Config for Runtime {
 	type AnnouncementDepositBase = AnnouncementDepositBase;
 	type AnnouncementDepositFactor = AnnouncementDepositFactor;
@@ -54,4 +63,87 @@ impl pallet_proxy::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_proxy::weights::SubstrateWeight<Self>;
+}
+
+#[cfg(test)]
+mod tests {
+	use std::any::TypeId;
+
+	use frame_support::traits::Get;
+
+	use super::*;
+
+	#[test]
+	fn proxy_does_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn pallet_proxy_uses_proxy_type() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::ProxyType>(),
+			TypeId::of::<ProxyType>(),
+		);
+	}
+
+	#[test]
+	fn proxy_has_deposit_factor() {
+		assert_eq!(
+			<<Runtime as pallet_proxy::Config>::ProxyDepositFactor as Get<Balance>>::get(),
+			deposit(0, 37),
+		);
+	}
+
+	#[test]
+	fn proxy_has_deposit_base() {
+		assert_eq!(
+			<<Runtime as pallet_proxy::Config>::ProxyDepositBase as Get<Balance>>::get(),
+			deposit(1, 48),
+		);
+	}
+
+	#[test]
+	fn proxy_uses_balances_as_currency() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::Currency>(),
+			TypeId::of::<Balances>(),
+		);
+	}
+
+	#[test]
+	fn proxy_configures_max_num_of_proxies() {
+		assert_eq!(<<Runtime as pallet_proxy::Config>::MaxProxies>::get(), 32,);
+	}
+
+	#[test]
+	fn proxy_configures_max_pending() {
+		assert_eq!(<<Runtime as pallet_proxy::Config>::MaxPending>::get(), 32,);
+	}
+
+	#[test]
+	fn proxy_uses_blaketwo256_as_hasher() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::CallHasher>(),
+			TypeId::of::<BlakeTwo256>(),
+		);
+	}
+
+	#[test]
+	fn proxy_has_announcement_deposit_factor() {
+		assert_eq!(
+			<<Runtime as pallet_proxy::Config>::AnnouncementDepositFactor as Get<Balance>>::get(),
+			deposit(0, 68),
+		);
+	}
+
+	#[test]
+	fn proxy_has_announcement_deposit_base() {
+		assert_eq!(
+			<<Runtime as pallet_proxy::Config>::AnnouncementDepositBase as Get<Balance>>::get(),
+			deposit(1, 48),
+		);
+	}
 }

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -74,34 +74,25 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn proxy_does_not_use_default_weights() {
-		assert_ne!(
-			TypeId::of::<<Runtime as pallet_proxy::Config>::WeightInfo>(),
-			TypeId::of::<()>(),
-		);
-	}
-
-	#[test]
-	fn pallet_proxy_uses_proxy_type() {
+	fn proxy_has_announcement_deposit_base() {
 		assert_eq!(
-			TypeId::of::<<Runtime as pallet_proxy::Config>::ProxyType>(),
-			TypeId::of::<ProxyType>(),
-		);
-	}
-
-	#[test]
-	fn proxy_has_deposit_factor() {
-		assert_eq!(
-			<<Runtime as pallet_proxy::Config>::ProxyDepositFactor as Get<Balance>>::get(),
-			deposit(0, 37),
-		);
-	}
-
-	#[test]
-	fn proxy_has_deposit_base() {
-		assert_eq!(
-			<<Runtime as pallet_proxy::Config>::ProxyDepositBase as Get<Balance>>::get(),
+			<<Runtime as pallet_proxy::Config>::AnnouncementDepositBase as Get<Balance>>::get(),
 			deposit(1, 48),
+		);
+	}
+	#[test]
+	fn proxy_has_announcement_deposit_factor() {
+		assert_eq!(
+			<<Runtime as pallet_proxy::Config>::AnnouncementDepositFactor as Get<Balance>>::get(),
+			deposit(0, 68),
+		);
+	}
+
+	#[test]
+	fn proxy_uses_blaketwo256_as_hasher() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::CallHasher>(),
+			TypeId::of::<BlakeTwo256>(),
 		);
 	}
 
@@ -114,36 +105,44 @@ mod tests {
 	}
 
 	#[test]
-	fn proxy_configures_max_num_of_proxies() {
-		assert_eq!(<<Runtime as pallet_proxy::Config>::MaxProxies>::get(), 32,);
-	}
-
-	#[test]
 	fn proxy_configures_max_pending() {
 		assert_eq!(<<Runtime as pallet_proxy::Config>::MaxPending>::get(), 32,);
 	}
 
 	#[test]
-	fn proxy_uses_blaketwo256_as_hasher() {
-		assert_eq!(
-			TypeId::of::<<Runtime as pallet_proxy::Config>::CallHasher>(),
-			TypeId::of::<BlakeTwo256>(),
-		);
+	fn proxy_configures_max_num_of_proxies() {
+		assert_eq!(<<Runtime as pallet_proxy::Config>::MaxProxies>::get(), 32,);
 	}
 
 	#[test]
-	fn proxy_has_announcement_deposit_factor() {
+	fn proxy_has_deposit_base() {
 		assert_eq!(
-			<<Runtime as pallet_proxy::Config>::AnnouncementDepositFactor as Get<Balance>>::get(),
-			deposit(0, 68),
-		);
-	}
-
-	#[test]
-	fn proxy_has_announcement_deposit_base() {
-		assert_eq!(
-			<<Runtime as pallet_proxy::Config>::AnnouncementDepositBase as Get<Balance>>::get(),
+			<<Runtime as pallet_proxy::Config>::ProxyDepositBase as Get<Balance>>::get(),
 			deposit(1, 48),
+		);
+	}
+
+	#[test]
+	fn proxy_has_deposit_factor() {
+		assert_eq!(
+			<<Runtime as pallet_proxy::Config>::ProxyDepositFactor as Get<Balance>>::get(),
+			deposit(0, 37),
+		);
+	}
+
+	#[test]
+	fn pallet_proxy_uses_proxy_type() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::ProxyType>(),
+			TypeId::of::<ProxyType>(),
+		);
+	}
+
+	#[test]
+	fn proxy_does_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as pallet_proxy::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
 		);
 	}
 }

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -8,6 +8,10 @@ use crate::{
 };
 
 /// The type used to represent the kinds of proxying allowed.
+// Mainnet will use this definition of ProxyType instead of the ones in
+// `pop-common` crates until `pallet-assets` is integrated in the runtime.
+// `ProxyType` in `pop-common` include Assets specific proxies which won't
+// make much sense in this runtime.
 #[derive(
 	Copy,
 	Clone,


### PR DESCRIPTION
Extends **proxy** config module for the pallet:
- `pallet_proxy`

Notable configuration items are:

- `pallet_proxy`

Updated deposits for mainnet runtime:

```rust
// One storage item; key size 32 + 8.
pub const ProxyDepositBase: Balance = deposit(1, 40);
// Additional storage item size of AccountId 32 bytes + ProxyType 1 byte + BlockNum 4 bytes.
pub const ProxyDepositFactor: Balance = deposit(0, 37);
// One storage item; key size 32, value size 16.
pub const AnnouncementDepositBase: Balance = deposit(1, 48);
// Additional storage item 32 bytes AccountId + 32 bytes Hash + 4 bytes BlockNum.
pub const AnnouncementDepositFactor: Balance = deposit(0, 68);
```

```rust
type MaxPending = 32;
type MaxProxies = 32;
```

[sc-2205]