### PR TITLE
refactor(mainnet): system config

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -417,7 +417,7 @@ pub fn run() -> Result<()> {
 						#[cfg(not(feature = "ismp"))]
 						{
 							sp_core::crypto::set_default_ss58_version(
-								pop_runtime_mainnet::SS58Prefix::get().into(),
+								pop_runtime_mainnet::config::system::SS58Prefix::get().into(),
 							);
 							crate::service::start_parachain_node::<pop_runtime_mainnet::RuntimeApi>(
 								config,

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,5 +1,9 @@
+/// Governance configuration of pop.
 pub mod governance;
+/// Proxy configuration of pop.
 pub(crate) mod proxy;
+/// Configuration related to pop's system modules.
 pub mod system;
 mod utility;
+/// Cross chain configuration of pop.
 pub mod xcm;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -2,7 +2,7 @@
 pub mod governance;
 /// Proxy configuration of pop.
 pub(crate) mod proxy;
-/// Configuration related to pop's system modules.
+/// System functionality.
 pub mod system;
 mod utility;
 /// XCM.

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,4 +1,5 @@
 pub mod governance;
-mod proxy;
+pub(crate) mod proxy;
+pub(crate) mod system;
 mod utility;
 pub mod xcm;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,6 +1,6 @@
 /// Governance configuration of pop.
 pub mod governance;
-/// Proxy configuration of pop.
+/// Proxy.
 pub(crate) mod proxy;
 /// System functionality.
 pub mod system;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,4 +1,4 @@
-/// Governance configuration of pop.
+/// Governance.
 pub mod governance;
 /// Proxy.
 pub(crate) mod proxy;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,5 +1,5 @@
 pub mod governance;
 pub(crate) mod proxy;
-pub(crate) mod system;
+pub mod system;
 mod utility;
 pub mod xcm;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -5,5 +5,5 @@ pub(crate) mod proxy;
 /// Configuration related to pop's system modules.
 pub mod system;
 mod utility;
-/// Cross chain configuration of pop.
+/// XCM.
 pub mod xcm;

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -110,6 +110,7 @@ parameter_types! {
 }
 
 #[docify::export]
+/// Provides means to manage the backlog of unincluded blocks.
 pub type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
 	Runtime,
 	RELAY_CHAIN_SLOT_DURATION_MILLIS,
@@ -419,7 +420,7 @@ mod tests {
 				cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
 					Runtime,
 					6000, // Relay chain slot duration of 6s.
-					1,    // Para blocks per slot.
+					1,    // Blocks per slot.
 					3,    // Max unincluded blocks accepted by runtime simultaneously
 				>,
 			>(),

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -9,9 +9,9 @@ use sp_runtime::traits::AccountIdLookup;
 use crate::{
 	parameter_types,
 	weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
-	AccountId, Balance, BlakeTwo256, Block, BlockLength, BlockWeights, DispatchClass, Everything,
-	Executive, Hash, MessageQueue, PalletInfo, RelayOrigin, ReservedDmpWeight, ReservedXcmpWeight,
-	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, RuntimeTask, RuntimeVersion, XcmpQueue,
+	AccountId, AggregateMessageOrigin, Balance, BlakeTwo256, Block, BlockLength, BlockWeights,
+	DispatchClass, Everything, Executive, Hash, MessageQueue, PalletInfo, Runtime, RuntimeCall,
+	RuntimeEvent, RuntimeOrigin, RuntimeTask, RuntimeVersion, Weight, XcmpQueue,
 	BLOCK_PROCESSING_VELOCITY, RELAY_CHAIN_SLOT_DURATION_MILLIS, UNINCLUDED_SEGMENT_CAPACITY,
 	VERSION,
 };
@@ -103,6 +103,12 @@ impl frame_system::Config for Runtime {
 	type Version = Version;
 }
 
+parameter_types! {
+	pub const RelayOrigin: AggregateMessageOrigin = AggregateMessageOrigin::Parent;
+	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+}
+
 #[docify::export]
 pub type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
 	Runtime,
@@ -131,6 +137,8 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type WeightInfo = cumulus_pallet_parachain_system::weights::SubstrateWeight<Runtime>;
 	type XcmpMessageHandler = XcmpQueue;
 }
+
+impl parachain_info::Config for Runtime {}
 
 #[cfg(test)]
 mod tests {

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -1,0 +1,100 @@
+use polkadot_runtime_common::BlockHashCount;
+use pop_runtime_common::{
+	Nonce, AVERAGE_ON_INITIALIZE_RATIO, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+};
+use sp_runtime::traits::AccountIdLookup;
+
+use crate::{
+	parameter_types,
+	weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
+	AccountId, Balance, BlakeTwo256, Block, BlockLength, BlockWeights, DispatchClass, Everything,
+	Hash, PalletInfo, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, RuntimeTask,
+	RuntimeVersion, VERSION,
+};
+
+parameter_types! {
+	pub const Version: RuntimeVersion = VERSION;
+	pub const SS58Prefix: u16 = 0;
+	// This part is copied from Substrate's `bin/node/runtime/src/lib.rs`.
+	//  The `RuntimeBlockLength` and `RuntimeBlockWeights` exist here because the
+	// `DeletionWeightLimit` and `DeletionQueueDepth` depend on those to parameterize
+	// the lazy contract deletion.
+	pub RuntimeBlockLength: BlockLength =
+		BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
+	pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
+		.base_block(BlockExecutionWeight::get())
+		.for_class(DispatchClass::all(), |weights| {
+			weights.base_extrinsic = ExtrinsicBaseWeight::get();
+		})
+		.for_class(DispatchClass::Normal, |weights| {
+			weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
+		})
+		.for_class(DispatchClass::Operational, |weights| {
+			weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
+			// Operational transactions have some extra reserved space, so that they
+			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
+			weights.reserved = Some(
+				MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT
+			);
+		})
+		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
+		.build_or_panic();
+}
+
+impl frame_system::Config for Runtime {
+	/// The data to be stored in an account.
+	type AccountData = pallet_balances::AccountData<Balance>;
+	/// The identifier used to distinguish between accounts.
+	type AccountId = AccountId;
+	/// The basic call filter to use in dispatchable. Supports everything as the default.
+	type BaseCallFilter = Everything;
+	/// The block type.
+	type Block = Block;
+	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
+	type BlockHashCount = BlockHashCount;
+	/// The maximum length of a block (in bytes).
+	type BlockLength = RuntimeBlockLength;
+	/// Block & extrinsics weights: base values and limits.
+	type BlockWeights = RuntimeBlockWeights;
+	/// The weight of database operations that the runtime can invoke.
+	type DbWeight = RocksDbWeight;
+	/// Weight information for the extensions of this pallet.
+	type ExtensionsWeightInfo = ();
+	/// The type for hashing blocks and tries.
+	type Hash = Hash;
+	/// The default hashing algorithm used.
+	type Hashing = BlakeTwo256;
+	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
+	type Lookup = AccountIdLookup<Self::AccountId, ()>;
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MultiBlockMigrator = ();
+	/// The index type for storing how many extrinsics an account has signed.
+	type Nonce = Nonce;
+	/// What to do if an account is fully reaped from the system.
+	type OnKilledAccount = ();
+	/// What to do if a new account is created.
+	type OnNewAccount = ();
+	/// The action to take on a Runtime Upgrade
+	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
+	/// Converts a module to the index of the module, injected by `construct_runtime!`.
+	type PalletInfo = PalletInfo;
+	type PostInherents = ();
+	type PostTransactions = ();
+	type PreInherents = ();
+	/// The aggregated dispatch type available for extrinsics, injected by
+	/// `construct_runtime!`.
+	type RuntimeCall = RuntimeCall;
+	/// The ubiquitous event type injected by `construct_runtime!`.
+	type RuntimeEvent = RuntimeEvent;
+	/// The ubiquitous origin type injected by `construct_runtime!`.
+	type RuntimeOrigin = RuntimeOrigin;
+	/// The aggregated Task type, injected by `construct_runtime!`.
+	type RuntimeTask = RuntimeTask;
+	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
+	type SS58Prefix = SS58Prefix;
+	type SingleBlockMigrations = ();
+	/// Weight information for the extrinsics of this pallet.
+	type SystemWeightInfo = frame_system::weights::SubstrateWeight<Self>;
+	/// Runtime version.
+	type Version = Version;
+}

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -268,9 +268,11 @@ mod tests {
 
 		#[test]
 		fn block_weights_restricted_by_dispatch_class() {
-			// Two seconds compute per 6s block, max PoV size
-			let max_block_weight =
-				Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), MAX_POV_SIZE as u64);
+			// Two seconds compute per 6s block, max PoV size.
+			let max_block_weight = Weight::from_parts(
+				WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
+				MAX_POV_SIZE as u64,
+			);
 			let base_extrinsic = ExtrinsicBaseWeight::get();
 			let expected_per_class = PerDispatchClass::new(|dc| match dc {
 				DispatchClass::Normal => {
@@ -331,6 +333,14 @@ mod tests {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::DbWeight>(),
 				TypeId::of::<RocksDbWeight>(),
+			);
+		}
+
+		#[test]
+		fn h256_is_hash() {
+			assert_eq!(
+				TypeId::of::<<Runtime as frame_system::Config>::Hash>(),
+				TypeId::of::<sp_core::H256>(),
 			);
 		}
 
@@ -421,16 +431,16 @@ mod tests {
 		}
 
 		#[test]
+		fn ss58_prefix_matches_relay() {
+			assert_eq!(<<Runtime as frame_system::Config>::SS58Prefix>::get(), 0);
+		}
+
+		#[test]
 		fn single_block_migrations_is_empty() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::SingleBlockMigrations>(),
 				TypeId::of::<()>(),
 			);
-		}
-
-		#[test]
-		fn ss58_prefix_matches_relay() {
-			assert_eq!(<<Runtime as frame_system::Config>::SS58Prefix>::get(), 0);
 		}
 
 		#[test]

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -1,3 +1,4 @@
+use frame_support::traits::ConstU32;
 use polkadot_runtime_common::BlockHashCount;
 use pop_runtime_common::{
 	Nonce, AVERAGE_ON_INITIALIZE_RATIO, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
@@ -66,7 +67,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
 	type Lookup = AccountIdLookup<Self::AccountId, ()>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = ConstU32<16>;
 	type MultiBlockMigrator = ();
 	/// The index type for storing how many extrinsics an account has signed.
 	type Nonce = Nonce;
@@ -113,7 +114,7 @@ mod tests {
 	use sp_runtime::generic;
 
 	use super::*;
-	use crate::{Header, UncheckedExtrinsic, Weight};
+	use crate::{Header, Perbill, UncheckedExtrinsic, Weight};
 
 	#[test]
 	fn base_call_filter_allows_everything() {

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -26,12 +26,13 @@ use crate::{
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const SS58Prefix: u16 = 0;
-	// This part is copied from Substrate's `bin/node/runtime/src/lib.rs`.
-	// The `RuntimeBlockLength` and `RuntimeBlockWeights` exist here because the
-	// `DeletionWeightLimit` and `DeletionQueueDepth` depend on those to parameterize
-	// the lazy contract deletion.
+
+	/// Defines the length limit in bytes for a block.
+	// BlockLength is created with max for Operational & Mandatory and normal * max for Normal `DispatchClass`.
 	pub RuntimeBlockLength: BlockLength =
 		BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
+
+	/// Defines the block weight in terms of the different `DispatchClass` limits.
 	pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
 		.base_block(BlockExecutionWeight::get())
 		.for_class(DispatchClass::all(), |weights| {

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -268,8 +268,8 @@ mod tests {
 
 		#[test]
 		fn block_weights_restricted_by_dispatch_class() {
+			// Two seconds compute per 6s block, max PoV size
 			let max_block_weight =
-				// Two seconds compute per 6s block, max PoV size
 				Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), MAX_POV_SIZE as u64);
 			let base_extrinsic = ExtrinsicBaseWeight::get();
 			let expected_per_class = PerDispatchClass::new(|dc| match dc {

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -384,4 +384,107 @@ mod tests {
 		assert_eq!(Version::get().impl_name, Cow::Borrowed("pop"));
 		assert_eq!(Version::get().spec_version, 100);
 	}
+
+	#[test]
+	fn parachain_system_ensures_relay_block_increases_monotonically() {
+		assert_eq!(
+			TypeId::of::<
+				<Runtime as cumulus_pallet_parachain_system::Config>::CheckAssociatedRelayNumber,
+			>(),
+			TypeId::of::<RelayNumberMonotonicallyIncreases>(),
+		);
+	}
+
+	#[test]
+	fn parachain_system_manages_unincluded_block_authoring() {
+		assert_eq!(
+			TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::ConsensusHook>(),
+			TypeId::of::<
+				cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
+					Runtime,
+					6000, // Relay chain slot duration of 6s.
+					1,    // Para blocks per slot.
+					3,    // Max unincluded blocks accepted by runtime simultaneously
+				>,
+			>(),
+		);
+	}
+
+	#[test]
+	fn parachain_system_enqueues_dmp_messages() {
+		assert_eq!(
+			TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::DmpQueue>(),
+			TypeId::of::<EnqueueWithOrigin<MessageQueue, RelayOrigin>>(),
+		);
+	}
+
+	#[test]
+	fn parachain_system_system_event_handler_disabled() {
+		assert_eq!(
+			TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::OnSystemEvent>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn parachain_system_outbound_messages_sourced_from_xcmp_queue() {
+		assert_eq!(
+			TypeId::of::<
+				<Runtime as cumulus_pallet_parachain_system::Config>::OutboundXcmpMessageSource,
+			>(),
+			TypeId::of::<XcmpQueue>(),
+		);
+	}
+
+	#[test]
+	fn parachain_system_reserves_weight_for_dmp_messages() {
+		assert_eq!(
+			TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::ReservedDmpWeight>(),
+			TypeId::of::<ReservedDmpWeight>(),
+		);
+		assert_eq!(ReservedDmpWeight::get(), MAXIMUM_BLOCK_WEIGHT / 4);
+	}
+
+	#[test]
+	fn parachain_system_reserves_weight_for_xcmp_messages() {
+		assert_eq!(
+			TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::ReservedXcmpWeight>(
+			),
+			TypeId::of::<ReservedXcmpWeight>(),
+		);
+		assert_eq!(ReservedXcmpWeight::get(), MAXIMUM_BLOCK_WEIGHT / 4);
+	}
+
+	#[test]
+	fn parachain_system_uses_lookahead_core_selector() {
+		assert_eq!(
+			TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::SelectCore>(),
+			TypeId::of::<cumulus_pallet_parachain_system::LookaheadCoreSelector::<Runtime>>(),
+		);
+	}
+
+	#[test]
+	fn parachain_system_looks_up_para_id_from_parachain_info() {
+		assert_eq!(
+			TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::SelfParaId>(),
+			TypeId::of::<parachain_info::Pallet<Runtime>>(),
+		);
+	}
+
+	#[test]
+	fn parachain_system_does_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn parachain_system_uses_xcmp_queue_as_xcmp_message_handler() {
+		assert_eq!(
+			TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::XcmpMessageHandler>(
+			),
+			TypeId::of::<XcmpQueue>(),
+		);
+	}
 }

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -8,7 +8,7 @@ use crate::{
 	parameter_types,
 	weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
 	AccountId, Balance, BlakeTwo256, Block, BlockLength, BlockWeights, DispatchClass, Everything,
-	Hash, PalletInfo, Perbill, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, RuntimeTask,
+	Hash, PalletInfo, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, RuntimeTask,
 	RuntimeVersion, VERSION,
 };
 

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -196,7 +196,7 @@ mod tests {
 		use super::*;
 
 		#[test]
-		fn system_account_id_is_32_bytes() {
+		fn account_id_is_32_bytes() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::AccountId>(),
 				TypeId::of::<AccountId32>(),
@@ -204,7 +204,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_base_call_filter_allows_everything_but_filtered_calls() {
+		fn base_call_filter_allows_everything_but_filtered_calls() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::BaseCallFilter>(),
 				TypeId::of::<EverythingBut<FilteredCalls>>(),
@@ -231,7 +231,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_block_configured() {
+		fn block_configured() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::Block>(),
 				TypeId::of::<generic::Block<Header, UncheckedExtrinsic>>(),
@@ -239,7 +239,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_block_hash_count() {
+		fn block_hash_count() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::BlockHashCount>(),
 				TypeId::of::<BlockHashCount>(),
@@ -248,7 +248,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_block_length_restricted_by_pov() {
+		fn block_length_restricted_by_pov() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::BlockLength>(),
 				TypeId::of::<RuntimeBlockLength>(),
@@ -267,7 +267,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_block_weights_restricted_by_dispatch_class() {
+		fn block_weights_restricted_by_dispatch_class() {
 			let max_block_weight =
 				// Two seconds compute per 6s block, max PoV size
 				Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), MAX_POV_SIZE as u64);
@@ -327,7 +327,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_db_weight_uses_rocks_db() {
+		fn db_weight_uses_rocks_db() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::DbWeight>(),
 				TypeId::of::<RocksDbWeight>(),
@@ -335,7 +335,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_uses_blake2_hashing() {
+		fn uses_blake2_hashing() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::Hashing>(),
 				TypeId::of::<BlakeTwo256>(),
@@ -343,7 +343,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_uses_multi_address_lookup() {
+		fn uses_multi_address_lookup() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::Lookup>(),
 				TypeId::of::<AccountIdLookup<AccountId, ()>>(),
@@ -351,12 +351,12 @@ mod tests {
 		}
 
 		#[test]
-		fn system_max_consumers_limited_to_16() {
+		fn max_consumers_limited_to_16() {
 			assert_eq!(<<Runtime as frame_system::Config>::MaxConsumers as Get<u32>>::get(), 16);
 		}
 
 		#[test]
-		fn system_multi_block_migrator_disabled() {
+		fn multi_block_migrator_disabled() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::MultiBlockMigrator>(),
 				TypeId::of::<()>(),
@@ -364,7 +364,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_nonce_uses_u32() {
+		fn nonce_uses_u32() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::Nonce>(),
 				TypeId::of::<u32>(),
@@ -372,7 +372,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_account_killed_handler_disabled() {
+		fn account_killed_handler_disabled() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::OnKilledAccount>(),
 				TypeId::of::<()>(),
@@ -380,7 +380,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_new_account_handler_disabled() {
+		fn new_account_handler_disabled() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::OnNewAccount>(),
 				TypeId::of::<()>(),
@@ -388,7 +388,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_set_code_handler_managed_by_parachain_system() {
+		fn set_code_handler_managed_by_parachain_system() {
 			// Runtime upgrades orchestrated by parachain system pallet
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::OnSetCode>(),
@@ -397,7 +397,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_post_inherent_handler_disabled() {
+		fn post_inherent_handler_disabled() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::PostInherents>(),
 				TypeId::of::<()>(),
@@ -405,7 +405,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_post_transactions_handler_disabled() {
+		fn post_transactions_handler_disabled() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::PostTransactions>(),
 				TypeId::of::<()>(),
@@ -413,7 +413,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_pre_inherent_handler_disabled() {
+		fn pre_inherent_handler_disabled() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::PreInherents>(),
 				TypeId::of::<()>(),
@@ -421,7 +421,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_single_block_migrations_is_empty() {
+		fn single_block_migrations_is_empty() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::SingleBlockMigrations>(),
 				TypeId::of::<()>(),
@@ -429,12 +429,12 @@ mod tests {
 		}
 
 		#[test]
-		fn system_ss58_prefix_matches_relay() {
+		fn ss58_prefix_matches_relay() {
 			assert_eq!(<<Runtime as frame_system::Config>::SS58Prefix>::get(), 0);
 		}
 
 		#[test]
-		fn system_does_not_use_default_weights() {
+		fn does_not_use_default_weights() {
 			assert_ne!(
 				TypeId::of::<<Runtime as frame_system::Config>::SystemWeightInfo>(),
 				TypeId::of::<()>(),
@@ -443,7 +443,7 @@ mod tests {
 
 		#[test]
 		#[ignore]
-		fn system_extensions_do_not_use_default_weights() {
+		fn extensions_do_not_use_default_weights() {
 			assert_ne!(
 				TypeId::of::<<Runtime as frame_system::Config>::ExtensionsWeightInfo>(),
 				TypeId::of::<()>(),
@@ -451,7 +451,7 @@ mod tests {
 		}
 
 		#[test]
-		fn system_versions_runtime() {
+		fn versions_runtime() {
 			assert_eq!(
 				TypeId::of::<<Runtime as frame_system::Config>::Version>(),
 				TypeId::of::<Version>(),
@@ -467,7 +467,7 @@ mod tests {
 		use super::*;
 
 		#[test]
-		fn parachain_system_ensures_relay_block_increases_monotonically() {
+		fn ensures_relay_block_increases_monotonically() {
 			assert_eq!(
 			TypeId::of::<
 				<Runtime as cumulus_pallet_parachain_system::Config>::CheckAssociatedRelayNumber,
@@ -477,7 +477,7 @@ mod tests {
 		}
 
 		#[test]
-		fn parachain_system_manages_unincluded_block_authoring() {
+		fn manages_unincluded_block_authoring() {
 			assert_eq!(
 				TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::ConsensusHook>(),
 				TypeId::of::<
@@ -492,7 +492,7 @@ mod tests {
 		}
 
 		#[test]
-		fn parachain_system_enqueues_dmp_messages() {
+		fn enqueues_dmp_messages() {
 			assert_eq!(
 				TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::DmpQueue>(),
 				TypeId::of::<EnqueueWithOrigin<MessageQueue, RelayOrigin>>(),
@@ -500,7 +500,7 @@ mod tests {
 		}
 
 		#[test]
-		fn parachain_system_system_event_handler_disabled() {
+		fn event_handler_disabled() {
 			assert_eq!(
 				TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::OnSystemEvent>(),
 				TypeId::of::<()>(),
@@ -508,7 +508,7 @@ mod tests {
 		}
 
 		#[test]
-		fn parachain_system_outbound_messages_sourced_from_xcmp_queue() {
+		fn outbound_messages_sourced_from_xcmp_queue() {
 			assert_eq!(
 				TypeId::of::<
 					<Runtime as cumulus_pallet_parachain_system::Config>::OutboundXcmpMessageSource,
@@ -518,7 +518,7 @@ mod tests {
 		}
 
 		#[test]
-		fn parachain_system_reserves_weight_for_dmp_messages() {
+		fn reserves_weight_for_dmp_messages() {
 			assert_eq!(
 				TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::ReservedDmpWeight>(
 				),
@@ -528,7 +528,7 @@ mod tests {
 		}
 
 		#[test]
-		fn parachain_system_reserves_weight_for_xcmp_messages() {
+		fn reserves_weight_for_xcmp_messages() {
 			assert_eq!(
 				TypeId::of::<
 					<Runtime as cumulus_pallet_parachain_system::Config>::ReservedXcmpWeight,
@@ -539,7 +539,7 @@ mod tests {
 		}
 
 		#[test]
-		fn parachain_system_uses_lookahead_core_selector() {
+		fn uses_lookahead_core_selector() {
 			assert_eq!(
 				TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::SelectCore>(),
 				TypeId::of::<cumulus_pallet_parachain_system::LookaheadCoreSelector::<Runtime>>(),
@@ -547,7 +547,7 @@ mod tests {
 		}
 
 		#[test]
-		fn parachain_system_looks_up_para_id_from_parachain_info() {
+		fn looks_up_para_id_from_parachain_info() {
 			assert_eq!(
 				TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::SelfParaId>(),
 				TypeId::of::<parachain_info::Pallet<Runtime>>(),
@@ -555,7 +555,7 @@ mod tests {
 		}
 
 		#[test]
-		fn parachain_system_does_not_use_default_weights() {
+		fn does_not_use_default_weights() {
 			assert_ne!(
 				TypeId::of::<<Runtime as cumulus_pallet_parachain_system::Config>::WeightInfo>(),
 				TypeId::of::<()>(),
@@ -563,7 +563,7 @@ mod tests {
 		}
 
 		#[test]
-		fn parachain_system_uses_xcmp_queue_as_xcmp_message_handler() {
+		fn uses_xcmp_queue_as_xcmp_message_handler() {
 			assert_eq!(
 				TypeId::of::<
 					<Runtime as cumulus_pallet_parachain_system::Config>::XcmpMessageHandler,
@@ -577,7 +577,7 @@ mod tests {
 		use super::*;
 
 		#[test]
-		fn timestamp_min_period_is_zero() {
+		fn min_period_is_zero() {
 			assert_eq!(
 				<<Runtime as pallet_timestamp::Config>::MinimumPeriod as Get<u64>>::get(),
 				0
@@ -585,7 +585,7 @@ mod tests {
 		}
 
 		#[test]
-		fn timestamp_uses_u64_moment() {
+		fn uses_u64_moment() {
 			assert_eq!(
 				TypeId::of::<<Runtime as pallet_timestamp::Config>::Moment>(),
 				TypeId::of::<u64>(),
@@ -593,7 +593,7 @@ mod tests {
 		}
 
 		#[test]
-		fn timestamp_handler_is_aura() {
+		fn handler_is_aura() {
 			assert_eq!(
 				TypeId::of::<<Runtime as pallet_timestamp::Config>::OnTimestampSet>(),
 				TypeId::of::<Aura>(),
@@ -601,7 +601,7 @@ mod tests {
 		}
 
 		#[test]
-		fn timestamp_does_not_use_default_weights() {
+		fn does_not_use_default_weights() {
 			assert_ne!(
 				TypeId::of::<<Runtime as pallet_timestamp::Config>::WeightInfo>(),
 				TypeId::of::<()>(),

--- a/runtime/mainnet/src/config/system.rs
+++ b/runtime/mainnet/src/config/system.rs
@@ -6,12 +6,18 @@ use pop_runtime_common::{
 };
 use sp_runtime::traits::AccountIdLookup;
 
+// Allowing `unsued_imports` here because `Executive` is being used in the
+// `register_validate_block` macro but yet the compiler warns about it not being used.
+// Duplicating the crate import to reduce the amount of imports that could pass unnoticed
+// because of this.
+#[allow(unused_imports)]
+use crate::Executive;
 use crate::{
 	parameter_types,
 	weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
 	AccountId, AggregateMessageOrigin, Aura, Balance, BlakeTwo256, Block, BlockLength,
-	BlockWeights, DispatchClass, Everything, Executive, Hash, MessageQueue, PalletInfo, Runtime,
-	RuntimeCall, RuntimeEvent, RuntimeOrigin, RuntimeTask, RuntimeVersion, Weight, XcmpQueue,
+	BlockWeights, DispatchClass, Everything, Hash, MessageQueue, PalletInfo, Runtime, RuntimeCall,
+	RuntimeEvent, RuntimeOrigin, RuntimeTask, RuntimeVersion, Weight, XcmpQueue,
 	BLOCK_PROCESSING_VELOCITY, RELAY_CHAIN_SLOT_DURATION_MILLIS, UNINCLUDED_SEGMENT_CAPACITY,
 	VERSION,
 };

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -558,6 +558,10 @@ cumulus_pallet_parachain_system::register_validate_block! {
 
 #[cfg(test)]
 mod tests {
+	use std::any::TypeId;
+
+	use sp_runtime::MultiSignature;
+
 	use super::*;
 
 	#[test]

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -308,14 +308,6 @@ impl pallet_transaction_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
-	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
-	pub const RelayOrigin: AggregateMessageOrigin = AggregateMessageOrigin::Parent;
-}
-
-impl parachain_info::Config for Runtime {}
-
-parameter_types! {
 	pub MessageQueueServiceWeight: Weight = Perbill::from_percent(35) * RuntimeBlockWeights::get().max_block;
 	pub MessageQueueIdleServiceWeight: Weight = Perbill::from_percent(20) * RuntimeBlockWeights::get().max_block;
 }

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -17,6 +17,7 @@ use alloc::{borrow::Cow, vec::Vec};
 pub use apis::{RuntimeApi, RUNTIME_API_VERSIONS};
 use config::{
 	governance::SudoAddress,
+	system::RuntimeBlockWeights,
 	xcm::{RelayLocation, XcmOriginToTransactDispatchOrigin},
 };
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
@@ -24,7 +25,6 @@ use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim;
 use frame_metadata_hash_extension::CheckMetadataHash;
 use frame_support::{
-	derive_impl,
 	dispatch::DispatchClass,
 	parameter_types,
 	traits::{
@@ -46,7 +46,7 @@ use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 use polkadot_runtime_common::xcm_sender::NoPriceForMessageDelivery;
 // Polkadot imports
-use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
+use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 pub use pop_runtime_common::{
 	AuraId, Balance, BlockNumber, Hash, Nonce, Signature, AVERAGE_ON_INITIALIZE_RATIO,
 	BLOCK_PROCESSING_VELOCITY, DAYS, EXISTENTIAL_DEPOSIT, HOURS, MAXIMUM_BLOCK_WEIGHT, MICRO_UNIT,
@@ -64,7 +64,6 @@ pub use sp_runtime::{ExtrinsicInclusionMode, MultiAddress, Perbill, Permill};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 // XCM Imports
 use xcm::latest::prelude::BodyId;
 
@@ -256,87 +255,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
 	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
-}
-
-parameter_types! {
-	pub const Version: RuntimeVersion = VERSION;
-
-	// This part is copied from Substrate's `bin/node/runtime/src/lib.rs`.
-	//  The `RuntimeBlockLength` and `RuntimeBlockWeights` exist here because the
-	// `DeletionWeightLimit` and `DeletionQueueDepth` depend on those to parameterize
-	// the lazy contract deletion.
-	pub RuntimeBlockLength: BlockLength =
-		BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
-	pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
-		.base_block(BlockExecutionWeight::get())
-		.for_class(DispatchClass::all(), |weights| {
-			weights.base_extrinsic = ExtrinsicBaseWeight::get();
-		})
-		.for_class(DispatchClass::Normal, |weights| {
-			weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
-		})
-		.for_class(DispatchClass::Operational, |weights| {
-			weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
-			// Operational transactions have some extra reserved space, so that they
-			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
-			weights.reserved = Some(
-				MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT
-			);
-		})
-		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
-		.build_or_panic();
-	pub const SS58Prefix: u16 = 0;
-}
-
-/// A type to identify filtered calls.
-pub struct FilteredCalls;
-impl Contains<RuntimeCall> for FilteredCalls {
-	fn contains(c: &RuntimeCall) -> bool {
-		use BalancesCall::*;
-		matches!(
-			c,
-			RuntimeCall::Balances(
-				force_adjust_total_issuance { .. } |
-					force_set_balance { .. } |
-					force_transfer { .. } |
-					force_unreserve { .. }
-			)
-		)
-	}
-}
-
-/// The default types are being injected by [`derive_impl`](`frame_support::derive_impl`) from
-/// [`ParaChainDefaultConfig`](`struct@frame_system::config_preludes::ParaChainDefaultConfig`),
-/// but overridden as needed.
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
-impl frame_system::Config for Runtime {
-	/// The data to be stored in an account.
-	type AccountData = pallet_balances::AccountData<Balance>;
-	/// The identifier used to distinguish between accounts.
-	type AccountId = AccountId;
-	/// The basic call filter to use in dispatchable. Supports everything as the default.
-	type BaseCallFilter = EverythingBut<FilteredCalls>;
-	/// The block type.
-	type Block = Block;
-	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
-	type BlockHashCount = BlockHashCount;
-	/// The maximum length of a block (in bytes).
-	type BlockLength = RuntimeBlockLength;
-	/// Block & extrinsics weights: base values and limits.
-	type BlockWeights = RuntimeBlockWeights;
-	/// The weight of database operations that the runtime can invoke.
-	type DbWeight = RocksDbWeight;
-	/// The type for hashing blocks and tries.
-	type Hash = Hash;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	/// The index type for storing how many extrinsics an account has signed.
-	type Nonce = Nonce;
-	/// The action to take on a Runtime Upgrade
-	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
-	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
-	type SS58Prefix = SS58Prefix;
-	/// Runtime version.
-	type Version = Version;
 }
 
 impl pallet_timestamp::Config for Runtime {
@@ -650,46 +568,6 @@ mod tests {
 	use RuntimeCall::Balances;
 
 	use super::*;
-	#[test]
-	fn filtering_force_adjust_total_issuance_works() {
-		assert!(FilteredCalls::contains(&Balances(force_adjust_total_issuance {
-			direction: AdjustmentDirection::Increase,
-			delta: 0
-		})));
-	}
-
-	#[test]
-	fn filtering_force_set_balance_works() {
-		assert!(FilteredCalls::contains(&Balances(force_set_balance {
-			who: MultiAddress::Address32([0u8; 32]),
-			new_free: 0,
-		})));
-	}
-
-	#[test]
-	fn filtering_force_transfer_works() {
-		assert!(FilteredCalls::contains(&Balances(force_transfer {
-			source: MultiAddress::Address32([0u8; 32]),
-			dest: MultiAddress::Address32([0u8; 32]),
-			value: 0,
-		})));
-	}
-
-	#[test]
-	fn filtering_force_unreserve_works() {
-		assert!(FilteredCalls::contains(&Balances(force_unreserve {
-			who: MultiAddress::Address32([0u8; 32]),
-			amount: 0
-		})));
-	}
-
-	#[test]
-	fn filtering_configured() {
-		assert_eq!(
-			TypeId::of::<<Runtime as frame_system::Config>::BaseCallFilter>(),
-			TypeId::of::<EverythingBut<FilteredCalls>>(),
-		);
-	}
 
 	#[test]
 	fn ed_is_correct() {

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -17,10 +17,9 @@ use alloc::{borrow::Cow, vec::Vec};
 pub use apis::{RuntimeApi, RUNTIME_API_VERSIONS};
 use config::{
 	governance::SudoAddress,
-	system::RuntimeBlockWeights,
+	system::{ConsensusHook, RuntimeBlockWeights},
 	xcm::{RelayLocation, XcmOriginToTransactDispatchOrigin},
 };
-use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim;
 use frame_metadata_hash_extension::CheckMetadataHash;
@@ -314,29 +313,6 @@ parameter_types! {
 	pub const RelayOrigin: AggregateMessageOrigin = AggregateMessageOrigin::Parent;
 }
 
-#[docify::export]
-type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
-	Runtime,
-	RELAY_CHAIN_SLOT_DURATION_MILLIS,
-	BLOCK_PROCESSING_VELOCITY,
-	UNINCLUDED_SEGMENT_CAPACITY,
->;
-
-impl cumulus_pallet_parachain_system::Config for Runtime {
-	type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
-	type ConsensusHook = ConsensusHook;
-	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
-	type OnSystemEvent = ();
-	type OutboundXcmpMessageSource = XcmpQueue;
-	type ReservedDmpWeight = ReservedDmpWeight;
-	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type RuntimeEvent = RuntimeEvent;
-	type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Runtime>;
-	type SelfParaId = parachain_info::Pallet<Runtime>;
-	type WeightInfo = ();
-	type XcmpMessageHandler = XcmpQueue;
-}
-
 impl parachain_info::Config for Runtime {}
 
 parameter_types! {
@@ -548,12 +524,6 @@ impl Runtime {
 	) -> bool {
 		ConsensusHook::can_build_upon(included_hash, slot)
 	}
-}
-
-#[docify::export(register_validate_block)]
-cumulus_pallet_parachain_system::register_validate_block! {
-	Runtime = Runtime,
-	BlockExecutor = cumulus_pallet_aura_ext::BlockExecutor::<Runtime, Executive>,
 }
 
 #[cfg(test)]

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -28,7 +28,7 @@ use frame_support::{
 	parameter_types,
 	traits::{
 		fungible::HoldConsideration, tokens::imbalance::ResolveTo, ConstBool, ConstU32, ConstU64,
-		ConstU8, EitherOfDiverse, Everything, LinearStoragePrice, TransformOrigin, VariantCountOf,
+		ConstU8, EitherOfDiverse, LinearStoragePrice, TransformOrigin, VariantCountOf,
 	},
 	weights::{ConstantMultiplier, Weight},
 	PalletId,

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -29,8 +29,7 @@ use frame_support::{
 	parameter_types,
 	traits::{
 		fungible::HoldConsideration, tokens::imbalance::ResolveTo, ConstBool, ConstU32, ConstU64,
-		ConstU8, Contains, EitherOfDiverse, EverythingBut, LinearStoragePrice, TransformOrigin,
-		VariantCountOf,
+		ConstU8, EitherOfDiverse, Everything, LinearStoragePrice, TransformOrigin, VariantCountOf,
 	},
 	weights::{ConstantMultiplier, Weight},
 	PalletId,
@@ -40,7 +39,6 @@ use frame_system::{
 	CheckGenesis, CheckMortality, CheckNonZeroSender, CheckNonce, CheckSpecVersion, CheckTxVersion,
 	CheckWeight, EnsureRoot,
 };
-use pallet_balances::Call as BalancesCall;
 use pallet_transaction_payment::ChargeTransactionPayment;
 use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -254,14 +254,6 @@ pub fn native_version() -> NativeVersion {
 	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
-impl pallet_timestamp::Config for Runtime {
-	type MinimumPeriod = ConstU64<0>;
-	/// A timestamp: milliseconds since the unix epoch.
-	type Moment = u64;
-	type OnTimestampSet = Aura;
-	type WeightInfo = ();
-}
-
 impl pallet_authorship::Config for Runtime {
 	type EventHandler = (CollatorSelection,);
 	type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -560,13 +560,6 @@ cumulus_pallet_parachain_system::register_validate_block! {
 
 #[cfg(test)]
 mod tests {
-	use std::any::TypeId;
-
-	use pallet_balances::AdjustmentDirection;
-	use sp_runtime::MultiSignature;
-	use BalancesCall::*;
-	use RuntimeCall::Balances;
-
 	use super::*;
 
 	#[test]


### PR DESCRIPTION
Creates **system** config module including:
- `frame_system`

Notable configuration items are:

- SS58

`pub const SS58Prefix: u16 = 0;`

---

- `frame_system`

`extensionsWeightInfo` needs to be configured after benchmark is run. Configured to use default weights a the moment.
No calls area filtered.
No permanent migrations included at genesis.

```rust
type BaseCallFilter = Everything;
type ExtensionsWeightInfo = (); // Needs to be updated after benchmarks
type Lookup = AccountIdLookup<Self::AccountId, ()>;
type SingleBlockMigrations = ();
```

---

- `parachain_system`

```rust
type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
type ReservedDmpWeight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);;
type ReservedXcmpWeight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);;
type SelectCore = cumulus_pallet_parachain_system::LookaheadCoreSelector<Runtime>;
```

---

- `pallet_timestamp`

```rust
type MinimumPeriod = ConstU64<0>;
```

[sc-2205]