### PR TITLE
refactor(mainnet): add governance & pallet_sudo tests

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,6 +1,6 @@
 use cumulus_primitives_core::ParaId;
 use pop_runtime_common::{AccountId, AuraId};
-use pop_runtime_mainnet::SudoAddress;
+use pop_runtime_mainnet::config::governance::SudoAddress;
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};

--- a/runtime/mainnet/src/config/governance.rs
+++ b/runtime/mainnet/src/config/governance.rs
@@ -1,5 +1,16 @@
-use crate::{Runtime, RuntimeCall, RuntimeEvent};
+use crate::{parameter_types, AccountId, Runtime, RuntimeCall, RuntimeEvent, Ss58Codec};
 
+// Multisig account for sudo, generated from the following signatories:
+// - 15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg
+// - 142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z
+// - 15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz
+// - 14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4
+// - Threshold 2
+const SUDO_ADDRESS: &str = "15NMV2JX1NeMwarQiiZvuJ8ixUcvayFDcu1F9Wz1HNpSc8gP";
+
+parameter_types! {
+	pub SudoAddress: AccountId = AccountId::from_ss58check(SUDO_ADDRESS).expect("sudo address is valid SS58");
+}
 impl pallet_sudo::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
@@ -12,6 +23,15 @@ mod tests {
 
 	use super::*;
 
+	#[test]
+	fn sudo_account_matches() {
+		// Doesn't use SUDO_ADDRESS constant on purpose.
+		assert_eq!(
+			SudoAddress::get(),
+			AccountId::from_ss58check("15NMV2JX1NeMwarQiiZvuJ8ixUcvayFDcu1F9Wz1HNpSc8gP")
+				.expect("sudo address is valid SS58")
+		);
+	}
 	#[test]
 	fn sudo_does_not_use_default_weights() {
 		assert_ne!(

--- a/runtime/mainnet/src/config/governance.rs
+++ b/runtime/mainnet/src/config/governance.rs
@@ -1,0 +1,22 @@
+use crate::{Runtime, RuntimeCall, RuntimeEvent};
+
+impl pallet_sudo::Config for Runtime {
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = pallet_sudo::weights::SubstrateWeight<Runtime>;
+}
+
+#[cfg(test)]
+mod tests {
+	use std::any::TypeId;
+
+	use super::*;
+
+	#[test]
+	fn sudo_does_not_use_default_weights() {
+		assert_ne!(
+			TypeId::of::<<Runtime as pallet_sudo::Config>::WeightInfo>(),
+			TypeId::of::<()>(),
+		);
+	}
+}

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,2 +1,3 @@
+mod governance;
 mod proxy;
 pub mod xcm;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,3 +1,3 @@
-mod governance;
+pub mod governance;
 mod proxy;
 pub mod xcm;

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -390,12 +390,6 @@ impl pallet_transaction_payment::Config for Runtime {
 	type WeightToFee = fee::WeightToFee;
 }
 
-impl pallet_sudo::Config for Runtime {
-	type RuntimeCall = RuntimeCall;
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-}
-
 parameter_types! {
 	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -15,7 +15,10 @@ extern crate alloc;
 use alloc::{borrow::Cow, vec::Vec};
 
 pub use apis::{RuntimeApi, RUNTIME_API_VERSIONS};
-use config::xcm::{RelayLocation, XcmOriginToTransactDispatchOrigin};
+use config::{
+	governance::SudoAddress,
+	xcm::{RelayLocation, XcmOriginToTransactDispatchOrigin},
+};
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim;
@@ -376,7 +379,6 @@ impl pallet_balances::Config for Runtime {
 parameter_types! {
 	/// Relay Chain `TransactionByteFee` / 10
 	pub const TransactionByteFee: Balance = fee::TRANSACTION_BYTE_FEE;
-	pub SudoAddress: AccountId = AccountId::from_ss58check("15NMV2JX1NeMwarQiiZvuJ8ixUcvayFDcu1F9Wz1HNpSc8gP").expect("sudo address is valid SS58");
 }
 
 impl pallet_transaction_payment::Config for Runtime {


### PR DESCRIPTION
Creates **governance** config module including:
- `pallet_sudo`


[sc-2205]