### PR TITLE
feat(mainnet): add pallet revive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13873,6 +13873,7 @@ dependencies = [
  "pallet-multisig 39.0.0",
  "pallet-preimage 39.0.0",
  "pallet-proxy 39.0.0",
+ "pallet-revive",
  "pallet-scheduler 40.0.0",
  "pallet-session 39.0.0",
  "pallet-sudo 39.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ pallet-nft-fractionalization = { git = "https://github.com/paritytech/polkadot-s
 pallet-nfts-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
 pallet-preimage = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
 pallet-proxy = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
 pallet-scheduler = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
 pallet-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
 pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }

--- a/runtime/mainnet/Cargo.toml
+++ b/runtime/mainnet/Cargo.toml
@@ -40,6 +40,7 @@ pallet-message-queue.workspace = true
 pallet-multisig.workspace = true
 pallet-preimage.workspace = true
 pallet-proxy.workspace = true
+pallet-revive.workspace = true
 pallet-scheduler.workspace = true
 pallet-session.workspace = true
 pallet-sudo.workspace = true
@@ -118,6 +119,7 @@ std = [
 	"pallet-multisig/std",
 	"pallet-preimage/std",
 	"pallet-proxy/std",
+	"pallet-revive/std",
 	"pallet-scheduler/std",
 	"pallet-session/std",
 	"pallet-sudo/std",
@@ -166,6 +168,7 @@ runtime-benchmarks = [
 	"pallet-multisig/runtime-benchmarks",
 	"pallet-preimage/runtime-benchmarks",
 	"pallet-proxy/runtime-benchmarks",
+	"pallet-revive/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
@@ -199,6 +202,7 @@ try-runtime = [
 	"pallet-multisig/try-runtime",
 	"pallet-preimage/try-runtime",
 	"pallet-proxy/try-runtime",
+	"pallet-revive/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"pallet-session/try-runtime",
 	"pallet-sudo/try-runtime",

--- a/runtime/mainnet/src/apis.rs
+++ b/runtime/mainnet/src/apis.rs
@@ -1,12 +1,15 @@
 use alloc::vec::Vec;
 
+use codec::Encode;
 use frame_support::{
 	genesis_builder_helper::{build_state, get_preset},
+	traits::tokens::{Fortitude::Polite, Preservation::Preserve},
 	weights::{Weight, WeightToFee as _},
 };
+use pallet_revive::AddressMapper;
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
+use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H160};
 use sp_runtime::{
 	traits::Block as BlockT,
 	transaction_validity::{TransactionSource, TransactionValidity},
@@ -25,10 +28,11 @@ use xcm_runtime_apis::{
 
 // Local module imports
 use super::{
-	config::xcm as xcm_config, fee::WeightToFee, AccountId, Balance, Block, Executive,
-	ExtrinsicInclusionMode, InherentDataExt, Nonce, OriginCaller, ParachainSystem, PolkadotXcm,
-	Runtime, RuntimeCall, RuntimeEvent, RuntimeGenesisConfig, SessionKeys, System,
-	TransactionPayment, VERSION,
+	config::xcm as xcm_config, fee::WeightToFee, AccountId, Balance, Balances, Block, BlockNumber,
+	BlockWeights, EventRecord, Executive, ExtrinsicInclusionMode, InherentDataExt, Nonce,
+	OriginCaller, ParachainSystem, PolkadotXcm, Revive, Runtime, RuntimeBlockWeights, RuntimeCall,
+	RuntimeEvent, RuntimeGenesisConfig, RuntimeOrigin, SessionKeys, System, TransactionPayment,
+	UncheckedExtrinsic, VERSION,
 };
 
 impl_runtime_apis! {
@@ -336,6 +340,118 @@ impl_runtime_apis! {
 
 		fn is_trusted_teleporter(asset: VersionedAsset, location: VersionedLocation) -> XcmTrustedQueryResult {
 			PolkadotXcm::is_trusted_teleporter(asset, location)
+		}
+	}
+
+	impl pallet_revive::ReviveApi<Block, AccountId, Balance, Nonce, BlockNumber, EventRecord> for Runtime
+	{
+		fn balance(address: H160) -> Balance {
+			use frame_support::traits::fungible::Inspect;
+			let account = <Runtime as pallet_revive::Config>::AddressMapper::to_account_id(&address);
+			Balances::reducible_balance(&account, Preserve, Polite)
+		}
+
+		fn nonce(address: H160) -> Nonce {
+			let account = <Runtime as pallet_revive::Config>::AddressMapper::to_account_id(&address);
+			System::account_nonce(account)
+		}
+
+		fn eth_transact(
+			from: H160,
+			dest: Option<H160>,
+			value: Balance,
+			input: Vec<u8>,
+			gas_limit: Option<Weight>,
+			storage_deposit_limit: Option<Balance>,
+		) -> pallet_revive::EthContractResult<Balance>
+		{
+			use pallet_revive::AddressMapper;
+			let blockweights: BlockWeights = <Runtime as frame_system::Config>::BlockWeights::get();
+			let origin = <Runtime as pallet_revive::Config>::AddressMapper::to_account_id(&from);
+
+			let encoded_size = |pallet_call| {
+				let call = RuntimeCall::Revive(pallet_call);
+				let uxt: UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic::new_bare(call).into();
+				uxt.encoded_size() as u32
+			};
+
+			Revive::bare_eth_transact(
+				origin,
+				dest,
+				value,
+				input,
+				gas_limit.unwrap_or(blockweights.max_block),
+				storage_deposit_limit.unwrap_or(u128::MAX),
+				encoded_size,
+				pallet_revive::DebugInfo::UnsafeDebug,
+				pallet_revive::CollectEvents::UnsafeCollect,
+			)
+		}
+
+		fn call(
+			origin: AccountId,
+			dest: H160,
+			value: Balance,
+			gas_limit: Option<Weight>,
+			storage_deposit_limit: Option<Balance>,
+			input_data: Vec<u8>,
+		) -> pallet_revive::ContractResult<pallet_revive::ExecReturnValue, Balance, EventRecord> {
+			Revive::bare_call(
+				RuntimeOrigin::signed(origin),
+				dest,
+				value,
+				gas_limit.unwrap_or(RuntimeBlockWeights::get().max_block),
+				storage_deposit_limit.unwrap_or(u128::MAX),
+				input_data,
+				pallet_revive::DebugInfo::UnsafeDebug,
+				pallet_revive::CollectEvents::UnsafeCollect,
+			)
+		}
+
+		fn instantiate(
+			origin: AccountId,
+			value: Balance,
+			gas_limit: Option<Weight>,
+			storage_deposit_limit: Option<Balance>,
+			code: pallet_revive::Code,
+			data: Vec<u8>,
+			salt: Option<[u8; 32]>,
+		) -> pallet_revive::ContractResult<pallet_revive::InstantiateReturnValue, Balance, EventRecord>
+		{
+			Revive::bare_instantiate(
+				RuntimeOrigin::signed(origin),
+				value,
+				gas_limit.unwrap_or(RuntimeBlockWeights::get().max_block),
+				storage_deposit_limit.unwrap_or(u128::MAX),
+				code,
+				data,
+				salt,
+				pallet_revive::DebugInfo::UnsafeDebug,
+				pallet_revive::CollectEvents::UnsafeCollect,
+			)
+		}
+
+		fn upload_code(
+			origin: AccountId,
+			code: Vec<u8>,
+			storage_deposit_limit: Option<Balance>,
+		) -> pallet_revive::CodeUploadResult<Balance>
+		{
+			Revive::bare_upload_code(
+				RuntimeOrigin::signed(origin),
+				code,
+				storage_deposit_limit.unwrap_or(u128::MAX),
+			)
+		}
+
+		fn get_storage(
+			address: H160,
+			key: [u8; 32],
+		) -> pallet_revive::GetStorageResult {
+			Revive::get_storage(
+				address,
+				key
+			)
 		}
 	}
 }

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,2 +1,3 @@
 mod proxy;
+mod revive;
 pub mod xcm;

--- a/runtime/mainnet/src/config/revive.rs
+++ b/runtime/mainnet/src/config/revive.rs
@@ -1,0 +1,54 @@
+use frame_support::{
+	parameter_types,
+	traits::{ConstBool, ConstU32, ConstU64, Nothing},
+};
+use frame_system::EnsureSigned;
+
+use crate::{
+	deposit, Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
+	Timestamp,
+};
+
+parameter_types! {
+	pub const DepositPerItem: Balance = deposit(1, 0);
+	pub const DepositPerByte: Balance = deposit(0, 1);
+	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
+}
+
+impl pallet_revive::Config for Runtime {
+	type AddressMapper = pallet_revive::AccountId32Mapper<Self>;
+	type CallFilter = Nothing;
+	type ChainExtension = ();
+	type ChainId = ConstU64<3395>;
+	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
+	type Currency = Balances;
+	type Debug = ();
+	type DepositPerByte = DepositPerByte;
+	type DepositPerItem = DepositPerItem;
+	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
+	type NativeToEthRatio = ConstU32<1>;
+	// TODO: review implications of this
+	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	// TODO: review implications of this
+	type RuntimeMemory = ConstU32<{ 128 * 1024 * 1024 }>;
+	type Time = Timestamp;
+	type UnsafeUnstableInterface = ConstBool<false>;
+	type UploadOrigin = EnsureSigned<Self::AccountId>;
+	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
+	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
+	type Xcm = pallet_xcm::Pallet<Self>;
+}
+
+impl TryFrom<RuntimeCall> for pallet_revive::Call<Runtime> {
+	type Error = ();
+
+	fn try_from(value: RuntimeCall) -> Result<Self, Self::Error> {
+		match value {
+			RuntimeCall::Revive(call) => Ok(call),
+			_ => Err(()),
+		}
+	}
+}

--- a/runtime/mainnet/src/config/revive.rs
+++ b/runtime/mainnet/src/config/revive.rs
@@ -5,14 +5,19 @@ use frame_support::{
 use frame_system::EnsureSigned;
 
 use crate::{
-	deposit, Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
-	Timestamp,
+	deposit, Balance, Balances, Perbill, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
+	RuntimeHoldReason, Timestamp, TransactionPayment, UNIT,
 };
 
+const ETH: u128 = 1_000_000_000_000_000_000;
+
 parameter_types! {
+	// TODO: review implications of this
 	pub const DepositPerItem: Balance = deposit(1, 0);
+	// TODO: review implications of this
 	pub const DepositPerByte: Balance = deposit(0, 1);
 	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
+	pub const NativeToEthRatio: u32 = (ETH/UNIT) as u32;
 }
 
 impl pallet_revive::Config for Runtime {
@@ -26,7 +31,7 @@ impl pallet_revive::Config for Runtime {
 	type DepositPerByte = DepositPerByte;
 	type DepositPerItem = DepositPerItem;
 	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
-	type NativeToEthRatio = ConstU32<1>;
+	type NativeToEthRatio = NativeToEthRatio;
 	// TODO: review implications of this
 	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
 	type RuntimeCall = RuntimeCall;
@@ -38,8 +43,8 @@ impl pallet_revive::Config for Runtime {
 	type UnsafeUnstableInterface = ConstBool<false>;
 	type UploadOrigin = EnsureSigned<Self::AccountId>;
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
-	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
-	type Xcm = pallet_xcm::Pallet<Self>;
+	type WeightPrice = TransactionPayment;
+	type Xcm = PolkadotXcm;
 }
 
 impl TryFrom<RuntimeCall> for pallet_revive::Call<Runtime> {
@@ -50,5 +55,147 @@ impl TryFrom<RuntimeCall> for pallet_revive::Call<Runtime> {
 			RuntimeCall::Revive(call) => Ok(call),
 			_ => Err(()),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::any::TypeId;
+
+	use frame_support::pallet_prelude::Get;
+	use pallet_revive::Config;
+
+	use super::*;
+
+	// 18 decimals
+	const ONE_ETH: u128 = 1_000_000_000_000_000_000;
+
+	#[test]
+	fn address_mapper_is_account_id32_mapper() {
+		assert_eq!(
+			TypeId::of::<<Runtime as Config>::AddressMapper>(),
+			TypeId::of::<pallet_revive::AccountId32Mapper<Runtime>>(),
+		);
+	}
+
+	#[test]
+	fn call_filter_is_nothing() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::CallFilter>(),
+			TypeId::of::<Nothing>(),
+		);
+	}
+
+	#[test]
+	fn chain_extension_is_unset() {
+		assert_eq!(
+			TypeId::of::<<Runtime as pallet_revive::Config>::ChainExtension>(),
+			TypeId::of::<()>(),
+		);
+	}
+
+	#[test]
+	fn chain_id_is_correct() {
+		assert_eq!(<<Runtime as Config>::ChainId as Get<u64>>::get(), 3395);
+	}
+
+	#[test]
+	fn code_hash_lockup_deposit_percent_is_correct() {
+		// 30 percent
+		assert_eq!(
+			TypeId::of::<<Runtime as Config>::CodeHashLockupDepositPercent>(),
+			TypeId::of::<CodeHashLockupDepositPercent>(),
+		);
+	}
+
+	#[test]
+	fn currency_is_balances() {
+		assert_eq!(TypeId::of::<<Runtime as Config>::Currency>(), TypeId::of::<Balances>(),);
+	}
+
+	#[test]
+	fn debug_is_unset() {
+		assert_eq!(TypeId::of::<<Runtime as Config>::Debug>(), TypeId::of::<()>(),);
+	}
+
+	#[test]
+	fn deposit_per_byte_is_correct() {
+		assert_eq!(<<Runtime as Config>::DepositPerByte as Get<Balance>>::get(), deposit(0, 1),);
+	}
+
+	#[test]
+	fn deposit_per_item_is_correct() {
+		assert_eq!(<<Runtime as Config>::DepositPerItem as Get<Balance>>::get(), deposit(1, 0),);
+	}
+
+	#[test]
+	fn instantiate_origin_is_ensure_signed() {
+		assert_eq!(
+			TypeId::of::<<Runtime as Config>::InstantiateOrigin>(),
+			TypeId::of::<EnsureSigned<<Runtime as frame_system::Config>::AccountId>>(),
+		);
+	}
+
+	#[test]
+	fn eth_is_18_decimals() {
+		assert_eq!(ETH, ONE_ETH);
+	}
+
+	#[test]
+	fn native_to_eth_ratio_is_correct() {
+		// 18 decimals
+		let expected_ratio = (ONE_ETH / UNIT) as u32;
+		assert_eq!(<<Runtime as Config>::NativeToEthRatio as Get<u32>>::get(), expected_ratio);
+	}
+
+	#[test]
+	fn pvf_memory_is_correct() {
+		// 512 MB
+		assert_eq!(<<Runtime as Config>::PVFMemory as Get<u32>>::get(), 512 * 1024 * 1024);
+	}
+
+	#[test]
+	fn runtime_memory_is_correct() {
+		// 128 MB
+		assert_eq!(<<Runtime as Config>::RuntimeMemory as Get<u32>>::get(), 128 * 1024 * 1024);
+	}
+
+	#[test]
+	fn time_is_timestamp() {
+		assert_eq!(TypeId::of::<<Runtime as Config>::Time>(), TypeId::of::<Timestamp>(),);
+	}
+
+	#[test]
+	fn unsafe_unstable_interface_is_disabled() {
+		assert_eq!(<<Runtime as Config>::UnsafeUnstableInterface as Get<bool>>::get(), false,);
+	}
+
+	#[test]
+	fn upload_origin_is_ensure_signed() {
+		assert_eq!(
+			TypeId::of::<<Runtime as Config>::UploadOrigin>(),
+			TypeId::of::<EnsureSigned<<Runtime as frame_system::Config>::AccountId>>(),
+		);
+	}
+
+	#[test]
+	fn weight_is_not_default() {
+		assert_ne!(TypeId::of::<<Runtime as Config>::WeightInfo>(), TypeId::of::<()>(),);
+	}
+
+	#[test]
+	fn weight_price_uses_transaction_payment() {
+		assert_eq!(
+			TypeId::of::<<Runtime as Config>::WeightPrice>(),
+			TypeId::of::<pallet_transaction_payment::Pallet<Runtime>>(),
+		);
+	}
+
+	#[test]
+	fn xcm_is_pallet_xcm() {
+		assert_eq!(
+			TypeId::of::<<Runtime as Config>::Xcm>(),
+			TypeId::of::<pallet_xcm::Pallet<Runtime>>(),
+		);
 	}
 }

--- a/runtime/mainnet/src/config/revive.rs
+++ b/runtime/mainnet/src/config/revive.rs
@@ -105,10 +105,13 @@ mod tests {
 
 	#[test]
 	fn code_hash_lockup_deposit_percent_is_correct() {
-		// 30 percent
 		assert_eq!(
 			TypeId::of::<<Runtime as Config>::CodeHashLockupDepositPercent>(),
 			TypeId::of::<CodeHashLockupDepositPercent>(),
+		);
+		assert_eq!(
+			<<Runtime as Config>::CodeHashLockupDepositPercent as Get<Perbill>>::get(),
+			Perbill::from_percent(30),
 		);
 	}
 

--- a/runtime/mainnet/src/config/revive.rs
+++ b/runtime/mainnet/src/config/revive.rs
@@ -84,18 +84,12 @@ mod tests {
 
 	#[test]
 	fn call_filter_is_nothing() {
-		assert_eq!(
-			TypeId::of::<<Runtime as pallet_revive::Config>::CallFilter>(),
-			TypeId::of::<Nothing>(),
-		);
+		assert_eq!(TypeId::of::<<Runtime as Config>::CallFilter>(), TypeId::of::<Nothing>(),);
 	}
 
 	#[test]
 	fn chain_extension_is_unset() {
-		assert_eq!(
-			TypeId::of::<<Runtime as pallet_revive::Config>::ChainExtension>(),
-			TypeId::of::<()>(),
-		);
+		assert_eq!(TypeId::of::<<Runtime as Config>::ChainExtension>(), TypeId::of::<()>(),);
 	}
 
 	#[test]

--- a/runtime/mainnet/src/config/revive.rs
+++ b/runtime/mainnet/src/config/revive.rs
@@ -9,12 +9,11 @@ use crate::{
 	RuntimeHoldReason, Timestamp, TransactionPayment, UNIT,
 };
 
+// 18 decimals
 const ETH: u128 = 1_000_000_000_000_000_000;
 
 parameter_types! {
-	// TODO: review implications of this
 	pub const DepositPerItem: Balance = deposit(1, 0);
-	// TODO: review implications of this
 	pub const DepositPerByte: Balance = deposit(0, 1);
 	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
 	pub const NativeToEthRatio: u32 = (ETH/UNIT) as u32;
@@ -22,24 +21,29 @@ parameter_types! {
 
 impl pallet_revive::Config for Runtime {
 	type AddressMapper = pallet_revive::AccountId32Mapper<Self>;
+	// No runtime dispatchables are callable from contracts.
 	type CallFilter = Nothing;
 	type ChainExtension = ();
-	type ChainId = ConstU64<3395>;
+	// EVM chain id. 3,395 is a unique ID still.
+	type ChainId = ConstU64<3_395>;
+	// 30 percent of storage deposit held for using a code hash.
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type Currency = Balances;
 	type Debug = ();
 	type DepositPerByte = DepositPerByte;
 	type DepositPerItem = DepositPerItem;
 	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
+	// 1 ETH : 1_000_000 UNIT
 	type NativeToEthRatio = NativeToEthRatio;
-	// TODO: review implications of this
+	// 512 MB. Used in an integrity test that verifies the runtime has enough memory.
 	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;
-	// TODO: review implications of this
+	// 128 MB. Used in an integrity that verifies the runtime has enough memory.
 	type RuntimeMemory = ConstU32<{ 128 * 1024 * 1024 }>;
 	type Time = Timestamp;
+	// Disables access to unsafe host fns such as xcm_send.
 	type UnsafeUnstableInterface = ConstBool<false>;
 	type UploadOrigin = EnsureSigned<Self::AccountId>;
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -72,6 +72,12 @@ pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::Account
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;
 
+/// Record of an event happening.
+pub type EventRecord = frame_system::EventRecord<
+	<Runtime as frame_system::Config>::RuntimeEvent,
+	<Runtime as frame_system::Config>::Hash,
+>;
+
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -98,9 +98,33 @@ pub type TxExtension = (
 	CheckMetadataHash<Runtime>,
 );
 
+/// Default extensions applied to Ethereum transactions.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct EthExtraImpl;
+
+impl pallet_revive::evm::runtime::EthExtra for EthExtraImpl {
+	type Config = Runtime;
+	type Extension = TxExtension;
+
+	fn get_eth_extension(nonce: u32, tip: Balance) -> Self::Extension {
+		(
+			CheckNonZeroSender::<Runtime>::new(),
+			CheckSpecVersion::<Runtime>::new(),
+			CheckTxVersion::<Runtime>::new(),
+			CheckGenesis::<Runtime>::new(),
+			CheckMortality::from(generic::Era::Immortal),
+			CheckNonce::<Runtime>::from(nonce),
+			CheckWeight::<Runtime>::new(),
+			ChargeTransactionPayment::<Runtime>::from(tip),
+			StorageWeightReclaim::<Runtime>::new(),
+			CheckMetadataHash::<Runtime>::new(false),
+		)
+	}
+}
+
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =
-	generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, TxExtension>;
+	pallet_revive::evm::runtime::UncheckedExtrinsic<Address, Signature, EthExtraImpl>;
 
 /// All migrations of the runtime, aside from the ones declared in the pallets.
 ///

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -104,7 +104,7 @@ pub type TxExtension = (
 	CheckMetadataHash<Runtime>,
 );
 
-/// Default extensions applied to Ethereum transactions.
+/// EthExtra converts an unsigned Call::eth_transact into a CheckedExtrinsic.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct EthExtraImpl;
 
@@ -852,7 +852,8 @@ mod tests {
 					MultiAddress<AccountId, ()>,
 					// The signature scheme(s) supported.
 					MultiSignature,
-					// The transaction extensions.
+					// The transaction extensions that has an additional extension to convert
+					// an eth transaction into a checked extrinsic.
 					EthExtraImpl,
 				>,
 			>(),

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -661,6 +661,10 @@ mod runtime {
 	#[runtime::pallet_index(33)]
 	pub type MessageQueue = pallet_message_queue::Pallet<Runtime>;
 
+	// Contracts (using pallet-revive)
+	#[runtime::pallet_index(40)]
+	pub type Revive = pallet_revive::Pallet<Runtime>;
+
 	// Proxy
 	#[runtime::pallet_index(41)]
 	pub type Proxy = pallet_proxy::Pallet<Runtime>;

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -817,15 +817,13 @@ mod tests {
 		assert_eq!(
 			TypeId::of::<UncheckedExtrinsic>(),
 			TypeId::of::<
-				generic::UncheckedExtrinsic<
+				pallet_revive::evm::runtime::UncheckedExtrinsic<
 					// Multiple address formats supported.
 					MultiAddress<AccountId, ()>,
-					// The runtime calls available.
-					RuntimeCall,
 					// The signature scheme(s) supported.
 					MultiSignature,
 					// The transaction extensions.
-					TxExtension,
+					EthExtraImpl,
 				>,
 			>(),
 		);


### PR DESCRIPTION
Adds pallet revive to the mainnet runtime. 

Please review individual commits for specific components added (pallet, apis, tests).

Supersedes https://github.com/r0gue-io/pop-node/pull/427

[sc-2219]