### PR TITLE
refactor: integration tests mainnet xcm

### DIFF
--- a/integration-tests/src/chains/pop_network/genesis.rs
+++ b/integration-tests/src/chains/pop_network/genesis.rs
@@ -1,9 +1,13 @@
 use emulated_integration_tests_common::{build_genesis_storage, collators};
 use pop_runtime_common::Balance;
-use pop_runtime_devnet as runtime;
 use sp_core::storage::Storage;
 
+use super::runtime;
+
+#[cfg(not(feature = "mainnet"))]
 pub(crate) const ED: Balance = runtime::EXISTENTIAL_DEPOSIT;
+#[cfg(feature = "mainnet")]
+pub(crate) const ED: Balance = runtime::EXISTENTIAL_DEPOSIT * 100;
 const PARA_ID: u32 = 9090;
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 

--- a/integration-tests/src/chains/pop_network/mod.rs
+++ b/integration-tests/src/chains/pop_network/mod.rs
@@ -6,11 +6,11 @@ use emulated_integration_tests_common::{
 };
 use frame_support::traits::OnInitialize;
 #[cfg(feature = "devnet")]
-use pop_runtime_devnet as runtime;
+pub(crate) use pop_runtime_devnet as runtime;
 #[cfg(feature = "mainnet")]
-use pop_runtime_mainnet as runtime;
+pub(crate) use pop_runtime_mainnet as runtime;
 #[cfg(feature = "testnet")]
-use pop_runtime_testnet as runtime;
+pub(crate) use pop_runtime_testnet as runtime;
 
 // PopNetwork Parachain declaration
 decl_test_parachains! {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -7,8 +7,7 @@ use chains::{
 		AssetHubParaPallet,
 	},
 	pop_network::{
-		genesis::ED as POP_ED, runtime::config::xcm::XcmConfig as PopNetworkXcmConfig, PopNetwork,
-		PopNetworkParaPallet,
+		runtime::config::xcm::XcmConfig as PopNetworkXcmConfig, PopNetwork, PopNetworkParaPallet,
 	},
 	relay::{
 		genesis::ED as RELAY_ED, runtime::xcm_config::XcmConfig as RelayXcmConfig, Relay,


### PR DESCRIPTION
The tests need to be improved in general but refactored it so that there is no mainnet specific code to a runtime generic test.