### PR TITLE
refactor(genesis): use runtime genesis presets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13631,10 +13631,13 @@ version = "0.0.0"
 dependencies = [
  "docify",
  "frame-support 39.0.0",
+ "pallet-multisig 39.0.0",
  "parachains-common 19.0.0",
  "parity-scale-codec",
  "polkadot-primitives 17.0.0",
  "scale-info",
+ "serde_json",
+ "sp-keyring 40.0.0",
  "sp-runtime 40.1.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13634,6 +13634,7 @@ dependencies = [
  "pallet-multisig 39.0.0",
  "parachains-common 19.0.0",
  "parity-scale-codec",
+ "polkadot-parachain-primitives 15.0.0",
  "polkadot-primitives 17.0.0",
  "scale-info",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 serde = "1.0.209"
-serde_json = "1.0.127"
+serde_json = { version = "1.0.127", default-features = false }
 smallvec = "1.11.2"
 subxt = "0.38.0"
 subxt-signer = "0.38.0"

--- a/networks/devnet.toml
+++ b/networks/devnet.toml
@@ -20,7 +20,7 @@ validator = true
 
 [[parachains]]
 id = 4001
-chain = "pop-devnet-dev" # pop devenet runtime with development config.
+chain = "pop-devnet-dev" # pop devnet runtime with development config.
 default_command = "./target/release/pop-node"
 
 [parachains.genesis_overrides.balances]

--- a/networks/devnet.toml
+++ b/networks/devnet.toml
@@ -20,6 +20,7 @@ validator = true
 
 [[parachains]]
 id = 4001
+chain = "pop-devnet-dev" # pop devenet runtime with development config.
 default_command = "./target/release/pop-node"
 
 [parachains.genesis_overrides.balances]

--- a/networks/mainnet.toml
+++ b/networks/mainnet.toml
@@ -20,7 +20,7 @@ validator = true
 
 [[parachains]]
 id = 4001
-chain = "mainnet"
+chain = "pop-dev" # mainnet runtime with development config.
 default_command = "./target/release/pop-node"
 
 [parachains.genesis_overrides.balances]
@@ -32,15 +32,6 @@ balances = [
     ["5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy", 10000000000000000],
     ["5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw", 10000000000000000],
     ["5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL", 10000000000000000],
-]
-
-[parachains.genesis_overrides.council]
-members = [
-    # Dev accounts
-    "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-    "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-    "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
-    "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
 ]
 
 [[parachains.collators]]

--- a/networks/testnet.toml
+++ b/networks/testnet.toml
@@ -20,7 +20,7 @@ validator = true
 
 [[parachains]]
 id = 4001
-chain = "testnet"
+chain = "pop-testnet-dev" # pop testnet runtime with development config.
 default_command = "./target/release/pop-node"
 
 [parachains.genesis_overrides.balances]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,28 +1,9 @@
-use cumulus_primitives_core::ParaId;
-use pop_runtime_common::{AccountId, AuraId};
-use pop_runtime_mainnet::config::governance::SudoAddress;
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::{ChainType, GenericChainSpec};
 use serde::{Deserialize, Serialize};
-use sp_core::crypto::Ss58Codec;
 
 /// Generic `ChainSpec` for a parachain runtime.
 pub type ChainSpec = GenericChainSpec<Extensions>;
-
-/// Specialized `ChainSpec` for the testnet parachain runtime.
-pub type TestnetChainSpec = sc_service::GenericChainSpec<Extensions>;
-
-/// Specialized `ChainSpec` for the mainnet parachain runtime.
-pub type MainnetChainSpec = sc_service::GenericChainSpec<Extensions>;
-
-/// The default XCM version to set in genesis config.
-const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
-
-pub(crate) enum Relay {
-	Paseo,
-	PaseoLocal,
-	Polkadot,
-}
 
 /// Chainspec builder trait: to be implemented for the different runtimes (i.e. `devnet`, `testnet`
 /// & `mainnet`) to ease building.
@@ -123,252 +104,189 @@ pub mod devnet {
 	}
 }
 
-/// Generate the session keys from individual elements.
-///
-/// The input must be a tuple of individual keys (a single arg for now since we have just one key).
-pub fn pop_testnet_session_keys(keys: AuraId) -> pop_runtime_testnet::SessionKeys {
-	pop_runtime_testnet::SessionKeys { aura: keys }
-}
-/// Generate the session keys from individual elements.
-///
-/// The input must be a tuple of individual keys (a single arg for now since we have just one key).
-pub fn pop_mainnet_session_keys(keys: AuraId) -> pop_runtime_mainnet::SessionKeys {
-	pop_runtime_mainnet::SessionKeys { aura: keys }
-}
+pub mod testnet {
+	use pop_runtime_testnet as runtime;
+	use pop_runtime_testnet::Runtime;
+	pub use runtime::genesis::{TESTNET, TESTNET_DEV, TESTNET_LOCAL};
 
-fn configure_for_relay(
-	relay: Relay,
-	properties: &mut sc_chain_spec::Properties,
-) -> (Extensions, u32) {
-	let para_id;
+	use super::*;
 
-	match relay {
-		Relay::Paseo | Relay::PaseoLocal => {
-			para_id = 4001;
+	impl ChainSpecBuilder for Runtime {
+		fn para_id() -> u32 {
+			runtime::genesis::PARA_ID.into()
+		}
+
+		fn properties() -> sc_chain_spec::Properties {
+			let mut properties = sc_chain_spec::Properties::new();
 			properties.insert("tokenSymbol".into(), "PAS".into());
 			properties.insert("tokenDecimals".into(), 10.into());
-
-			let relay_chain = if let Relay::Paseo = relay {
-				properties.insert("ss58Format".into(), 0.into());
-				"paseo".into()
-			} else {
-				properties.insert("ss58Format".into(), 42.into());
-				"paseo-local".into()
-			};
-			(Extensions { relay_chain, para_id }, para_id)
-		},
-		Relay::Polkadot => {
-			para_id = 3395;
 			properties.insert("ss58Format".into(), 0.into());
-			properties.insert("tokenSymbol".into(), "DOT".into());
-			properties.insert("tokenDecimals".into(), 10.into());
-			(Extensions { relay_chain: "polkadot".into(), para_id }, para_id)
-		},
-	}
-}
-
-pub fn testnet_chain_spec(relay: Relay) -> TestnetChainSpec {
-	// Give your base currency a unit name and decimal places
-	let mut properties = sc_chain_spec::Properties::new();
-	let (extensions, para_id) = configure_for_relay(relay, &mut properties);
-
-	let collator_0_account_id: AccountId =
-		AccountId::from_ss58check("5Gn9dVgCNUYtC5JVMBheQQv2x6Lpg5sAMcQVRupG1s3tP2gR").unwrap();
-	let collator_0_aura_id: AuraId =
-		AuraId::from_ss58check("5Gn9dVgCNUYtC5JVMBheQQv2x6Lpg5sAMcQVRupG1s3tP2gR").unwrap();
-	let collator_1_account_id: AccountId =
-		AccountId::from_ss58check("5FyVvcSvSXCkBwvBEHkUh1VWGGrwaR3zbYBkU3Rc5DqV75S4").unwrap();
-	let collator_1_aura_id: AuraId =
-		AuraId::from_ss58check("5FyVvcSvSXCkBwvBEHkUh1VWGGrwaR3zbYBkU3Rc5DqV75S4").unwrap();
-	let collator_2_account_id: AccountId =
-		AccountId::from_ss58check("5GMqrQuWpyyBBK7LAWXR5psWvKc1QMqtiyasjp23VNKZWgh6").unwrap();
-	let collator_2_aura_id: AuraId =
-		AuraId::from_ss58check("5GMqrQuWpyyBBK7LAWXR5psWvKc1QMqtiyasjp23VNKZWgh6").unwrap();
-	let sudo_account_id: AccountId =
-		AccountId::from_ss58check("5FPL3ZLqUk6MyBoZrQZ1Co29WAteX6T6N68TZ6jitHvhpyuD").unwrap();
-
-	#[allow(deprecated)]
-	TestnetChainSpec::builder(
-		pop_runtime_testnet::WASM_BINARY.expect("WASM binary was not built, please build it!"),
-		extensions,
-	)
-	.with_name("Pop Network Testnet")
-	.with_id("pop-testnet")
-	.with_chain_type(ChainType::Live)
-	.with_genesis_config_patch(testnet_genesis(
-		// initial collators.
-		vec![
-			// POP COLLATOR 0
-			(collator_0_account_id, collator_0_aura_id),
-			// POP COLLATOR 1
-			(collator_1_account_id, collator_1_aura_id),
-			// POP COLLATOR 2
-			(collator_2_account_id, collator_2_aura_id),
-		],
-		sudo_account_id,
-		para_id.into(),
-	))
-	.with_protocol_id("pop-testnet")
-	.with_properties(properties)
-	.build()
-}
-
-pub fn mainnet_chain_spec(relay: Relay) -> MainnetChainSpec {
-	let mut properties = sc_chain_spec::Properties::new();
-	let (extensions, para_id) = configure_for_relay(relay, &mut properties);
-
-	let collator_0_account_id: AccountId =
-		AccountId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
-	let collator_0_aura_id: AuraId =
-		AuraId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
-
-	// Multisig account for sudo, generated from the following signatories:
-	// - 15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg
-	// - 142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z
-	// - 15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz
-	// - 14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4
-	// - Threshold 2
-	let sudo_account_id: AccountId = SudoAddress::get();
-
-	#[allow(deprecated)]
-	MainnetChainSpec::builder(
-		pop_runtime_mainnet::WASM_BINARY.expect("WASM binary was not built, please build it!"),
-		extensions,
-	)
-	.with_name("Pop Network")
-	.with_id("pop")
-	.with_chain_type(ChainType::Live)
-	.with_genesis_config_patch(mainnet_genesis(
-		// initial collators.
-		vec![
-			// POP COLLATOR 0
-			(collator_0_account_id, collator_0_aura_id),
-		],
-		sudo_account_id,
-		para_id.into(),
-		// councillors
-		vec![],
-	))
-	.with_protocol_id("pop")
-	.with_properties(properties)
-	.build()
-}
-
-fn mainnet_genesis(
-	invulnerables: Vec<(AccountId, AuraId)>,
-	root: AccountId,
-	id: ParaId,
-	councillors: Vec<AccountId>,
-) -> serde_json::Value {
-	use pop_runtime_mainnet::EXISTENTIAL_DEPOSIT;
-
-	serde_json::json!({
-		"balances": {
-			"balances": [],
-		},
-		"parachainInfo": {
-			"parachainId": id,
-		},
-		"collatorSelection": {
-			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
-			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
-			"desiredCandidates": 0,
-		},
-		"session": {
-			"keys": invulnerables
-				.into_iter()
-				.map(|(acc, aura)| {
-					(
-						acc.clone(),                 // account id
-						acc,                         // validator id
-						pop_mainnet_session_keys(aura),      // session keys
-					)
-				})
-			.collect::<Vec<_>>(),
-		},
-		"polkadotXcm": {
-			"safeXcmVersion": Some(SAFE_XCM_VERSION),
-		},
-		"sudo": { "key": Some(root) },
-		"council": {
-			"members": councillors,
+			properties
 		}
-	})
-}
 
-fn testnet_genesis(
-	invulnerables: Vec<(AccountId, AuraId)>,
-	root: AccountId,
-	id: ParaId,
-) -> serde_json::Value {
-	use pop_runtime_testnet::EXISTENTIAL_DEPOSIT;
+		fn wasm_binary() -> &'static [u8] {
+			runtime::WASM_BINARY.expect("WASM binary was not built, please build it!")
+		}
+	}
 
-	serde_json::json!({
-		"balances": {
-			"balances": [],
-		},
-		"parachainInfo": {
-			"parachainId": id,
-		},
-		"collatorSelection": {
-			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
-			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
-		},
-		"session": {
-			"keys": invulnerables
-				.into_iter()
-				.map(|(acc, aura)| {
-					(
-						acc.clone(),                 // account id
-						acc,                         // validator id
-						pop_testnet_session_keys(aura),      // session keys
-					)
-				})
-			.collect::<Vec<_>>(),
-		},
-		"polkadotXcm": {
-			"safeXcmVersion": Some(SAFE_XCM_VERSION),
-		},
-		"sudo": { "key": Some(root) }
-	})
-}
-
-#[test]
-fn sudo_key_valid() {
-	// Source: https://github.com/paritytech/extended-parachain-template/blob/d08cec37117731953119ecaed79522a0812b46f5/node/src/chain_spec.rs#L79
-	fn get_multisig_sudo_key(mut authority_set: Vec<AccountId>, threshold: u16) -> AccountId {
-		assert!(threshold > 0, "Threshold for sudo multisig cannot be 0");
-		assert!(!authority_set.is_empty(), "Sudo authority set cannot be empty");
-		assert!(
-			authority_set.len() >= threshold.into(),
-			"Threshold must be less than or equal to authority set members"
-		);
-		// Sorting is done to deterministically order the multisig set
-		// So that a single authority set (A, B, C) may generate only a single unique multisig key
-		// Otherwise, (B, A, C) or (C, A, B) could produce different keys and cause chaos
-		authority_set.sort();
-
-		// Define a multisig threshold for `threshold / authority_set.len()` members
-		pallet_multisig::Pallet::<pop_runtime_mainnet::Runtime>::multi_account_id(
-			&authority_set[..],
-			threshold,
+	/// Configures a development chain running on a single node, using the testnet runtime.
+	pub fn development_chain_spec() -> ChainSpec {
+		const ID: &str = TESTNET_DEV;
+		Runtime::build(
+			ID,
+			"Pop Testnet (Development)",
+			ChainType::Development,
+			ID,
+			ID,
+			"paseo-local",
 		)
 	}
 
-	assert_eq!(
-		get_multisig_sudo_key(
-			vec![
-				AccountId::from_ss58check("15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg")
-					.unwrap(),
-				AccountId::from_ss58check("142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z")
-					.unwrap(),
-				AccountId::from_ss58check("15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz")
-					.unwrap(),
-				AccountId::from_ss58check("14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4")
-					.unwrap(),
-			],
-			2
-		),
-		SudoAddress::get()
-	)
+	/// Configures a local chain running on multiple nodes for testing purposes, using the testnet
+	/// runtime.
+	pub fn local_chain_spec() -> ChainSpec {
+		const ID: &str = TESTNET_LOCAL;
+		Runtime::build(ID, "Pop Testnet (Local)", ChainType::Local, ID, ID, "paseo-local")
+	}
+
+	/// Configures a live chain running on multiple nodes, using the testnet runtime.
+	pub fn live_chain_spec() -> ChainSpec {
+		const ID: &str = TESTNET;
+		Runtime::build(ID, "Pop Testnet", ChainType::Live, ID, ID, "paseo")
+	}
+}
+
+pub mod mainnet {
+	use pop_runtime_mainnet as runtime;
+	use pop_runtime_mainnet::Runtime;
+	pub use runtime::genesis::{MAINNET, MAINNET_DEV, MAINNET_LOCAL};
+
+	use super::*;
+
+	impl ChainSpecBuilder for Runtime {
+		fn para_id() -> u32 {
+			runtime::genesis::PARA_ID.into()
+		}
+
+		fn properties() -> sc_chain_spec::Properties {
+			let mut properties = sc_chain_spec::Properties::new();
+			properties.insert("tokenSymbol".into(), "DOT".into());
+			properties.insert("tokenDecimals".into(), 10.into());
+			properties.insert("ss58Format".into(), 0.into());
+			properties
+		}
+
+		fn wasm_binary() -> &'static [u8] {
+			runtime::WASM_BINARY.expect("WASM binary was not built, please build it!")
+		}
+	}
+
+	/// Configures a development chain running on a single node, using the mainnet runtime.
+	pub fn development_chain_spec() -> ChainSpec {
+		const ID: &str = MAINNET_DEV;
+		Runtime::build(ID, "Pop (Development)", ChainType::Development, ID, ID, "paseo-local")
+	}
+
+	/// Configures a local chain running on multiple nodes for testing purposes, using the mainnet
+	/// runtime.
+	pub fn local_chain_spec() -> ChainSpec {
+		const ID: &str = MAINNET_LOCAL;
+		Runtime::build(ID, "Pop (Local)", ChainType::Local, ID, ID, "paseo-local")
+	}
+
+	/// Configures a live chain running on multiple nodes publicly, using the mainnet
+	/// runtime.
+	pub fn live_chain_spec() -> ChainSpec {
+		const ID: &str = MAINNET;
+		Runtime::build(ID, "Pop", ChainType::Live, ID, ID, "polkadot")
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use sc_chain_spec::ChainSpec;
+		use serde_json::json;
+
+		use super::*;
+
+		#[test]
+		fn dev_configuration_is_correct() {
+			let chain_spec = development_chain_spec();
+			assert!(chain_spec.boot_nodes().is_empty());
+			assert_eq!(chain_spec.name(), "Pop (Development)");
+			assert_eq!(chain_spec.id(), "pop-dev");
+			assert_eq!(chain_spec.chain_type(), ChainType::Development);
+			assert!(chain_spec.telemetry_endpoints().is_none());
+			assert_eq!(chain_spec.protocol_id().unwrap(), "pop-dev");
+			assert!(chain_spec.fork_id().is_none());
+			assert_eq!(
+				&chain_spec.properties(),
+				json!({
+					"ss58Format": 0, // Paseo uses Polkadot's SS58.
+					"tokenDecimals": 10,
+					"tokenSymbol": "DOT",
+				})
+				.as_object()
+				.unwrap()
+			);
+			assert_eq!(
+				chain_spec.extensions(),
+				&Extensions { relay_chain: "paseo-local".to_string(), para_id: 3395 }
+			);
+			assert!(chain_spec.code_substitutes().is_empty());
+		}
+
+		#[test]
+		fn local_configuration_is_correct() {
+			let chain_spec = local_chain_spec();
+			assert!(chain_spec.boot_nodes().is_empty());
+			assert_eq!(chain_spec.name(), "Pop (Local)");
+			assert_eq!(chain_spec.id(), "pop-local");
+			assert_eq!(chain_spec.chain_type(), ChainType::Local);
+			assert!(chain_spec.telemetry_endpoints().is_none());
+			assert_eq!(chain_spec.protocol_id().unwrap(), "pop-local");
+			assert!(chain_spec.fork_id().is_none());
+			assert_eq!(
+				&chain_spec.properties(),
+				json!({
+					"ss58Format": 0, // Paseo uses Polkadot's SS58.
+					"tokenDecimals": 10,
+					"tokenSymbol": "DOT",
+				})
+				.as_object()
+				.unwrap()
+			);
+			assert_eq!(
+				chain_spec.extensions(),
+				&Extensions { relay_chain: "paseo-local".to_string(), para_id: 3395 }
+			);
+			assert!(chain_spec.code_substitutes().is_empty());
+		}
+
+		#[test]
+		fn live_configuration_is_correct() {
+			let chain_spec = live_chain_spec();
+			assert!(chain_spec.boot_nodes().is_empty());
+			assert_eq!(chain_spec.name(), "Pop");
+			assert_eq!(chain_spec.id(), "pop");
+			assert_eq!(chain_spec.chain_type(), ChainType::Live);
+			assert!(chain_spec.telemetry_endpoints().is_none());
+			assert_eq!(chain_spec.protocol_id().unwrap(), "pop");
+			assert!(chain_spec.fork_id().is_none());
+			assert_eq!(
+				&chain_spec.properties(),
+				json!({
+					"ss58Format": 0, // Polkadot's SS58.
+					"tokenDecimals": 10,
+					"tokenSymbol": "DOT",
+				})
+				.as_object()
+				.unwrap()
+			);
+			assert_eq!(
+				chain_spec.extensions(),
+				&Extensions { relay_chain: "polkadot".to_string(), para_id: 3395 }
+			);
+			assert!(chain_spec.code_substitutes().is_empty());
+		}
+	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -101,7 +101,7 @@ pub mod devnet {
 		const ID: &str = DEVNET_DEV;
 		Runtime::build(
 			ID,
-			"POP Devnet (Development)",
+			"Pop Devnet (Development)",
 			ChainType::Development,
 			ID,
 			ID,
@@ -113,14 +113,14 @@ pub mod devnet {
 	/// runtime.
 	pub fn local_chain_spec() -> ChainSpec {
 		const ID: &str = DEVNET_LOCAL;
-		Runtime::build(ID, "POP Devnet (Local)", ChainType::Local, ID, ID, "paseo-local")
+		Runtime::build(ID, "Pop Devnet (Local)", ChainType::Local, ID, ID, "paseo-local")
 	}
 
 	/// Configures a live chain running on multiple nodes on private devnet, using the devnet
 	/// runtime.
 	pub fn live_chain_spec() -> ChainSpec {
 		const ID: &str = DEVNET;
-		Runtime::build(ID, "POP Devnet", ChainType::Live, ID, ID, "paseo")
+		Runtime::build(ID, "Pop Devnet", ChainType::Live, ID, ID, "paseo")
 	}
 }
 

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -5,7 +5,6 @@ use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::{ChainType, GenericChainSpec};
 use serde::{Deserialize, Serialize};
 use sp_core::crypto::Ss58Codec;
-pub use sp_keyring::sr25519::Keyring;
 
 /// Generic `ChainSpec` for a parachain runtime.
 pub type ChainSpec = GenericChainSpec<Extensions>;

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -116,8 +116,7 @@ pub mod devnet {
 		Runtime::build(ID, "Pop Devnet (Local)", ChainType::Local, ID, ID, "paseo-local")
 	}
 
-	/// Configures a live chain running on multiple nodes on private devnet, using the devnet
-	/// runtime.
+	/// Configures a live chain running on multiple nodes, using the devnet runtime.
 	pub fn live_chain_spec() -> ChainSpec {
 		const ID: &str = DEVNET;
 		Runtime::build(ID, "Pop Devnet", ChainType::Live, ID, ID, "paseo")

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -13,7 +13,7 @@ use sc_service::config::{BasePath, PrometheusConfig};
 use sp_runtime::traits::HashingFor;
 
 use crate::{
-	chain_spec::{self, devnet::*, Relay},
+	chain_spec::{self, devnet::*, mainnet::*, testnet::*},
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::new_partial,
 };
@@ -35,9 +35,9 @@ trait RuntimeResolver {
 fn runtime(id: &str) -> Runtime {
 	if [DEVNET_DEV, DEVNET_LOCAL, DEVNET].contains(&id) {
 		Runtime::Devnet
-	} else if id.starts_with("test") || id.ends_with("testnet") {
+	} else if [TESTNET_DEV, TESTNET_LOCAL, TESTNET].contains(&id) {
 		Runtime::Testnet
-	} else if id.eq("pop") || id.ends_with("mainnet") {
+	} else if [MAINNET_DEV, MAINNET_LOCAL, MAINNET].contains(&id) {
 		Runtime::Mainnet
 	} else {
 		log::warn!(
@@ -78,10 +78,13 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		"local" | DEVNET_LOCAL => Box::new(chain_spec::devnet::local_chain_spec()),
 		DEVNET => Box::new(chain_spec::devnet::live_chain_spec()),
 		// Testnet.
-		"test" | "testnet" | "pop-paseo" => Box::new(chain_spec::testnet_chain_spec(Relay::Paseo)),
+		TESTNET_DEV => Box::new(chain_spec::testnet::development_chain_spec()),
+		TESTNET_LOCAL => Box::new(chain_spec::testnet::local_chain_spec()),
+		TESTNET => Box::new(chain_spec::testnet::live_chain_spec()),
 		// Mainnet.
-		"pop" | "mainnet" | "pop-polkadot" | "pop-network" =>
-			Box::new(chain_spec::mainnet_chain_spec(Relay::Polkadot)),
+		MAINNET_DEV => Box::new(chain_spec::mainnet::development_chain_spec()),
+		MAINNET_LOCAL => Box::new(chain_spec::mainnet::local_chain_spec()),
+		MAINNET => Box::new(chain_spec::mainnet::live_chain_spec()),
 		// Path.
 		path => Box::new(chain_spec::ChainSpec::from_json_file(path.into())?),
 	})

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -26,6 +26,7 @@ sp-runtime.workspace = true
 # Cumulus
 parachains-common.workspace = true
 polkadot-primitives.workspace = true
+polkadot-parachain-primitives.workspace = true
 
 [features]
 default = [ "std" ]
@@ -40,6 +41,7 @@ std = [
 	"frame-support/std",
 	"parachains-common/std",
 	"polkadot-primitives/std",
+	"polkadot-parachain-primitives/std",
 	"scale-info/std",
 	"serde_json/std",
 	"sp-runtime/std",

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -15,11 +15,15 @@ targets = [ "x86_64-unknown-linux-gnu" ]
 codec = { workspace = true, features = [ "derive" ] }
 docify.workspace = true
 scale-info = { workspace = true, features = [ "derive" ] }
+serde_json = { features = ["alloc"], workspace = true }
 
 # Substrate
 frame-support.workspace = true
+sp-keyring.workspace = true
 sp-runtime.workspace = true
+pallet-multisig.workspace = true
 
+# Cumulus
 parachains-common.workspace = true
 polkadot-primitives.workspace = true
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -25,8 +25,8 @@ sp-runtime.workspace = true
 
 # Cumulus
 parachains-common.workspace = true
-polkadot-primitives.workspace = true
 polkadot-parachain-primitives.workspace = true
+polkadot-primitives.workspace = true
 
 [features]
 default = [ "std" ]
@@ -40,8 +40,8 @@ std = [
 	"codec/std",
 	"frame-support/std",
 	"parachains-common/std",
-	"polkadot-primitives/std",
 	"polkadot-parachain-primitives/std",
+	"polkadot-primitives/std",
 	"scale-info/std",
 	"serde_json/std",
 	"sp-runtime/std",

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -41,5 +41,6 @@ std = [
 	"parachains-common/std",
 	"polkadot-primitives/std",
 	"scale-info/std",
+	"serde_json/std",
 	"sp-runtime/std",
 ]

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -15,13 +15,13 @@ targets = [ "x86_64-unknown-linux-gnu" ]
 codec = { workspace = true, features = [ "derive" ] }
 docify.workspace = true
 scale-info = { workspace = true, features = [ "derive" ] }
-serde_json = { features = ["alloc"], workspace = true }
+serde_json = { features = [ "alloc" ], workspace = true }
 
 # Substrate
 frame-support.workspace = true
+pallet-multisig.workspace = true
 sp-keyring.workspace = true
 sp-runtime.workspace = true
-pallet-multisig.workspace = true
 
 # Cumulus
 parachains-common.workspace = true

--- a/runtime/common/src/genesis.rs
+++ b/runtime/common/src/genesis.rs
@@ -1,0 +1,32 @@
+use parachains_common::AccountId;
+pub use serde_json::{json, to_string, Value};
+pub use sp_keyring::sr25519::Keyring;
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::format;
+use alloc::vec::Vec;
+
+/// A set of dev accounts, typically used for endowments at genesis for development chains.
+pub fn dev_accounts() -> Vec<AccountId> {
+	Keyring::well_known().map(|k| k.to_account_id()).collect()
+}
+
+/// Derive a multisig key from a given set of `accounts` and a `threshold`.
+pub fn derive_multisig<T: pallet_multisig::Config>(
+	mut signatories: Vec<T::AccountId>,
+	threshold: u16,
+) -> T::AccountId {
+	assert!(!signatories.is_empty(), "Signatories set cannot be empty");
+	assert!(threshold > 0, "Threshold for multisig cannot be 0");
+	assert!(
+		signatories.len() >= threshold.into(),
+		"Threshold must be less than or equal to the number of signatories"
+	);
+	// Sorting is done to deterministically order the multisig set
+	// So that a single authority set (A, B, C) may generate only a single unique multisig key
+	// Otherwise, (B, A, C) or (C, A, B) could produce different keys and cause chaos
+	signatories.sort();
+
+	// Derive a multisig with `threshold / signatories.len()` threshold
+	pallet_multisig::Pallet::<T>::multi_account_id(&signatories[..], threshold)
+}

--- a/runtime/common/src/genesis.rs
+++ b/runtime/common/src/genesis.rs
@@ -1,10 +1,10 @@
-use parachains_common::AccountId;
-pub use serde_json::{json, to_string, Value};
-pub use sp_keyring::sr25519::Keyring;
-extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::format;
 use alloc::vec::Vec;
+
+use parachains_common::AccountId;
+pub use serde_json::{json, to_string, Value};
+pub use sp_keyring::sr25519::Keyring;
 
 /// A set of dev accounts, typically used for endowments at genesis for development chains.
 pub fn dev_accounts() -> Vec<AccountId> {

--- a/runtime/common/src/genesis.rs
+++ b/runtime/common/src/genesis.rs
@@ -3,8 +3,15 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use parachains_common::AccountId;
+use polkadot_parachain_primitives::primitives::Sibling;
 pub use serde_json::{json, to_string, Value};
 pub use sp_keyring::sr25519::Keyring;
+use sp_runtime::traits::AccountIdConversion;
+
+/// Sovereign account of AssetHub on Pop.
+pub fn asset_hub_sa_on_pop() -> AccountId {
+	Sibling::from(1_000).into_account_truncating()
+}
 
 /// A set of dev accounts, typically used for endowments at genesis for development chains.
 pub fn dev_accounts() -> Vec<AccountId> {

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -6,6 +6,11 @@ pub use parachains_common::{AccountId, AuraId, Balance, Block, BlockNumber, Hash
 pub use polkadot_primitives::MAX_POV_SIZE;
 use sp_runtime::Perbill;
 
+extern crate alloc;
+
+/// Functions used for defining the genesis state of a chain.
+pub mod genesis;
+
 /// Nonce for an account
 pub type Nonce = u32;
 

--- a/runtime/devnet/src/genesis.rs
+++ b/runtime/devnet/src/genesis.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use cumulus_primitives_core::ParaId;
 use ismp_parachain::ParachainData;
 use parachains_common::{AccountId, AuraId, Balance};
@@ -101,7 +103,6 @@ fn genesis(
 	id: ParaId,
 	ismp_parachains: Vec<ParachainData>,
 ) -> Value {
-	const DECIMALS: u8 = 6;
 	json!({
 		"balances": BalancesConfig { balances: balances(endowed_accounts) },
 		"parachainInfo": { "parachainId": id },
@@ -133,6 +134,6 @@ fn genesis(
 
 // The initial balances at genesis.
 fn balances(endowed_accounts: Vec<AccountId>) -> Vec<(AccountId, Balance)> {
-	let mut balances = endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect::<Vec<_>>();
+	let balances = endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect::<Vec<_>>();
 	balances
 }

--- a/runtime/devnet/src/genesis.rs
+++ b/runtime/devnet/src/genesis.rs
@@ -39,6 +39,11 @@ pub(crate) fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 	)
 }
 
+/// Returns a list of identifiers for available builtin `RuntimeGenesisConfig` presets.
+pub(crate) fn presets() -> Vec<PresetId> {
+	PRESETS.map(PresetId::from).to_vec()
+}
+
 /// Configures a development chain running on a single node, using the `devnet` runtime.
 fn development_config() -> Value {
 	genesis(

--- a/runtime/devnet/src/genesis.rs
+++ b/runtime/devnet/src/genesis.rs
@@ -90,7 +90,7 @@ fn live_config() -> Value {
 			(Keyring::Bob.to_account_id(), Keyring::Bob.public().into()),
 			(Keyring::Charlie.to_account_id(), Keyring::Charlie.public().into()),
 		]),
-		dev_accounts(),
+		vec![],
 		Keyring::Alice.to_account_id(),
 		PARA_ID,
 		Vec::from([ParachainData { id: 1000, slot_duration: 6000 }]),

--- a/runtime/devnet/src/genesis.rs
+++ b/runtime/devnet/src/genesis.rs
@@ -109,7 +109,7 @@ fn genesis(
 		"assets": AssetsConfig {
 			// Genesis assets: Vec<(id, owner, is_sufficient, min_balance)>
 			assets: Vec::from([
-				(0, asset_hub_sa_on_pop(), true, EXISTENTIAL_DEPOSIT),	// Relay native asset from Asset Hub
+				(0, asset_hub_sa_on_pop(), false, EXISTENTIAL_DEPOSIT),	// Relay native asset from Asset Hub
 			]),
 			// Genesis metadata: Vec<(id, name, symbol, decimals)>
 			metadata: Vec::from([

--- a/runtime/devnet/src/genesis.rs
+++ b/runtime/devnet/src/genesis.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 
 use cumulus_primitives_core::ParaId;
 use ismp_parachain::ParachainData;

--- a/runtime/devnet/src/genesis.rs
+++ b/runtime/devnet/src/genesis.rs
@@ -15,7 +15,7 @@ pub const DEVNET_DEV: &str = "pop-devnet-dev";
 /// Configures a local chain running on multiple nodes for testing purposes, using the `devnet`
 /// runtime.
 pub const DEVNET_LOCAL: &str = "pop-devnet-local";
-/// A live chain running on multiple nodes on private devnet, using the `devnet` runtime.
+/// A live chain running on multiple nodes, using the `devnet` runtime.
 pub const DEVNET: &str = "pop-devnet";
 /// The available genesis config presets;
 const PRESETS: [&str; 3] = [DEVNET_DEV, DEVNET_LOCAL, DEVNET];
@@ -109,7 +109,7 @@ fn genesis(
 		"assets": AssetsConfig {
 			// Genesis assets: Vec<(id, owner, is_sufficient, min_balance)>
 			assets: Vec::from([
-				(0, asset_hub_sa_on_pop(), false, EXISTENTIAL_DEPOSIT),	// Relay native asset from Asset Hub
+				(0, sudo_key.clone(), false, EXISTENTIAL_DEPOSIT),	// Relay native asset from Asset Hub
 			]),
 			// Genesis metadata: Vec<(id, name, symbol, decimals)>
 			metadata: Vec::from([

--- a/runtime/devnet/src/genesis.rs
+++ b/runtime/devnet/src/genesis.rs
@@ -1,0 +1,123 @@
+use cumulus_primitives_core::ParaId;
+use ismp_parachain::ParachainData;
+use parachains_common::{AccountId, AuraId, Balance};
+use pop_runtime_common::genesis::*;
+use sp_genesis_builder::PresetId;
+
+use crate::{BalancesConfig, IsmpParachainConfig, SessionKeys, EXISTENTIAL_DEPOSIT};
+
+/// A development chain running on a single node, using the `devnet` runtime.
+pub const DEVNET_DEV: &str = "pop-devnet-dev";
+/// Configures a local chain running on multiple nodes for testing purposes, using the `devnet`
+/// runtime.
+pub const DEVNET_LOCAL: &str = "pop-devnet-local";
+/// A live chain running on multiple nodes on private devnet, using the `devnet` runtime.
+pub const DEVNET: &str = "pop-devnet";
+/// The available genesis config presets;
+const PRESETS: [&str; 3] = [DEVNET_DEV, DEVNET_LOCAL, DEVNET];
+
+/// The parachain identifier to set in genesis config.
+pub const PARA_ID: ParaId = ParaId::new(4_001);
+/// The default XCM version to set in genesis config.
+const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
+
+/// Returns a JSON blob representation of the built-in `RuntimeGenesisConfig` identified by `id`.
+pub(crate) fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
+	let patch = match id.as_str() {
+		DEVNET_DEV => development_config(),
+		DEVNET_LOCAL => local_config(),
+		DEVNET => live_config(),
+		_ => return None,
+	};
+	Some(
+		to_string(&patch)
+			.expect("serialization to json is expected to work. qed.")
+			.into_bytes(),
+	)
+}
+
+/// Configures a development chain running on a single node, using the `devnet` runtime.
+fn development_config() -> Value {
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Single collator for development chain
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+		]),
+		dev_accounts(),
+		Keyring::Alice.to_account_id(),
+		PARA_ID,
+		Vec::from([ParachainData { id: 1000, slot_duration: 6000 }]),
+	)
+}
+
+/// Configures a local chain running on multiple nodes for testing purposes, using the `devnet`
+/// runtime.
+fn local_config() -> Value {
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Multiple collators for local development chain.
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+			(Keyring::Bob.to_account_id(), Keyring::Bob.public().into()),
+		]),
+		dev_accounts(),
+		Keyring::Alice.to_account_id(),
+		PARA_ID,
+		Vec::from([ParachainData { id: 1000, slot_duration: 6000 }]),
+	)
+}
+
+/// Configures a live chain running on multiple nodes on private devnet, using the `devnet` runtime.
+fn live_config() -> Value {
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Multiple collators for live development chain.
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+			(Keyring::Bob.to_account_id(), Keyring::Bob.public().into()),
+		]),
+		dev_accounts(),
+		Keyring::Alice.to_account_id(),
+		PARA_ID,
+		Vec::from([ParachainData { id: 1000, slot_duration: 6000 }]),
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn genesis(
+	invulnerables: Vec<(AccountId, AuraId)>,
+	_endowed_accounts: Vec<AccountId>,
+	sudo_key: AccountId,
+	id: ParaId,
+	ismp_parachains: Vec<ParachainData>,
+) -> Value {
+	const DECIMALS: u8 = 6;
+	json!({
+		"balances": BalancesConfig { balances: vec![] },
+		"parachainInfo": { "parachainId": id },
+		"collatorSelection": {
+			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
+			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
+		},
+		"session": {
+			"keys": invulnerables
+				.into_iter()
+				.map(|(acc, aura)| {
+					(
+						acc.clone(),        // account id
+						acc,               	// validator id
+						SessionKeys { aura},// session keys
+					)
+				})
+				.collect::<Vec<_>>(),
+		},
+		"sudo" : { "key" : sudo_key },
+		"polkadotXcm": { "safeXcmVersion": Some(SAFE_XCM_VERSION) },
+		// The following parachains are tracked via ISMP.
+		"ismpParachain": IsmpParachainConfig {
+			parachains: ismp_parachains,
+			..Default::default()
+		},
+	})
+}

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -1032,11 +1032,11 @@ impl_runtime_apis! {
 		}
 
 		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-			get_preset::<RuntimeGenesisConfig>(id, super::genesis::get_preset)
+			get_preset::<RuntimeGenesisConfig>(id, genesis::get_preset)
 		}
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
-			super::genesis::presets()
+			genesis::presets()
 		}
 	}
 

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -8,6 +8,8 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 // Public due to integration tests crate.
 pub mod config;
+/// The genesis state presets available.
+pub mod genesis;
 mod weights;
 
 extern crate alloc;

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -481,9 +481,9 @@ impl pallet_collator_selection::Config for Runtime {
 	type Currency = Balances;
 	// should be a multiple of session or things will get inconsistent
 	type KickThreshold = Period;
-	type MaxCandidates = ConstU32<100>;
+	type MaxCandidates = ConstU32<0>;
 	type MaxInvulnerables = ConstU32<20>;
-	type MinEligibleCollators = ConstU32<4>;
+	type MinEligibleCollators = ConstU32<3>;
 	type PotId = PotId;
 	type RuntimeEvent = RuntimeEvent;
 	type UpdateOrigin = CollatorSelectionUpdateOrigin;

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -1032,11 +1032,11 @@ impl_runtime_apis! {
 		}
 
 		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-			get_preset::<RuntimeGenesisConfig>(id, |_| None)
+			get_preset::<RuntimeGenesisConfig>(id, super::genesis::get_preset)
 		}
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
-			Default::default()
+			super::genesis::presets()
 		}
 	}
 

--- a/runtime/mainnet/src/apis.rs
+++ b/runtime/mainnet/src/apis.rs
@@ -315,11 +315,11 @@ impl_runtime_apis! {
 		}
 
 		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-			get_preset::<RuntimeGenesisConfig>(id, |_| None)
+			get_preset::<RuntimeGenesisConfig>(id, super::genesis::get_preset)
 		}
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
-			Default::default()
+			super::genesis::presets()
 		}
 	}
 

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,7 +1,7 @@
 // Assets.
 mod assets;
 // Collation.
-mod collation;
+pub(crate) mod collation;
 /// Governance.
 pub mod governance;
 /// Monetary matters.

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -1,0 +1,559 @@
+use alloc::{vec, vec::Vec};
+
+use cumulus_primitives_core::ParaId;
+use parachains_common::{AccountId, AuraId, Balance};
+use pop_runtime_common::genesis::*;
+use sp_core::crypto::Ss58Codec;
+use sp_genesis_builder::PresetId;
+use sp_runtime::traits::AccountIdConversion;
+
+use crate::{
+	config::{
+		collation::PotId,
+		governance::SudoAddress,
+		monetary::{ExistentialDeposit, MaintenanceAccount, TreasuryAccount},
+	},
+	AssetsConfig, BalancesConfig, CouncilConfig, Runtime, SessionKeys, EXISTENTIAL_DEPOSIT, UNIT,
+};
+
+/// A development chain running on a single node, using the `mainnet` runtime.
+pub const MAINNET_DEV: &str = "pop-dev";
+/// Configures a local chain running on multiple nodes for testing purposes, using the `mainnet`
+/// runtime.
+pub const MAINNET_LOCAL: &str = "pop-local";
+/// A live chain running on multiple nodes, using the `mainnet` runtime.
+pub const MAINNET: &str = "pop";
+/// The available genesis config presets;
+const PRESETS: [&str; 3] = [MAINNET_DEV, MAINNET_LOCAL, MAINNET];
+
+/// The parachain identifier to set in genesis config.
+pub const PARA_ID: ParaId = ParaId::new(3395);
+
+/// Initial balance for genesis endowed accounts. Used for local testing only.
+const ENDOWMENT: Balance = 10_000_000 * UNIT;
+
+/// The default XCM version to set in genesis config.
+const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
+
+/// Returns a JSON blob representation of the built-in `RuntimeGenesisConfig` identified by `id`.
+pub(crate) fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
+	let patch = match id.as_str() {
+		MAINNET_DEV => development_config(),
+		MAINNET_LOCAL => local_config(),
+		MAINNET => live_config(),
+		_ => return None,
+	};
+	Some(
+		to_string(&patch)
+			.expect("serialization to json is expected to work. qed.")
+			.into_bytes(),
+	)
+}
+
+/// Returns a list of identifiers for available builtin `RuntimeGenesisConfig` presets.
+pub(crate) fn presets() -> Vec<PresetId> {
+	PRESETS.map(PresetId::from).to_vec()
+}
+
+/// Configures a development chain running on a single node, using the `mainnet` runtime.
+fn development_config() -> Value {
+	let mut endowed_accounts = dev_accounts();
+	endowed_accounts.push(MaintenanceAccount::get());
+	endowed_accounts.push(PotId::get().into_account_truncating());
+	endowed_accounts.push(TreasuryAccount::get());
+
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Single collator for development chain
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+		]),
+		endowed_accounts,
+		Keyring::Alice.to_account_id(),
+		PARA_ID,
+		vec![
+			Keyring::Alice.to_account_id(),
+			Keyring::Bob.to_account_id(),
+			Keyring::Charlie.to_account_id(),
+			Keyring::Dave.to_account_id(),
+			Keyring::Eve.to_account_id(),
+		],
+	)
+}
+
+/// Configures a local chain running on multiple nodes for testing purposes, using the `mainnet`
+/// runtime.
+fn local_config() -> Value {
+	// Like the multisig used for live config, but with dev accounts.
+	let sudo_account = derive_multisig::<Runtime>(
+		vec![
+			Keyring::Alice.to_account_id(),
+			Keyring::Bob.to_account_id(),
+			Keyring::Charlie.to_account_id(),
+			Keyring::Dave.to_account_id(),
+		],
+		2,
+	);
+
+	let mut endowed_accounts = dev_accounts();
+	endowed_accounts.push(MaintenanceAccount::get());
+	endowed_accounts.push(PotId::get().into_account_truncating());
+	endowed_accounts.push(sudo_account.clone());
+	endowed_accounts.push(TreasuryAccount::get());
+
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Multiple collators for local development chain.
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+			(Keyring::Bob.to_account_id(), Keyring::Bob.public().into()),
+		]),
+		endowed_accounts,
+		sudo_account,
+		PARA_ID,
+		vec![
+			Keyring::Alice.to_account_id(),
+			Keyring::Bob.to_account_id(),
+			Keyring::Charlie.to_account_id(),
+			Keyring::Dave.to_account_id(),
+			Keyring::Eve.to_account_id(),
+		],
+	)
+}
+
+/// Configures a live chain running on multiple nodes on private mainnet, using the `mainnet`
+/// runtime.
+fn live_config() -> Value {
+	let collator_0_account_id: AccountId =
+		AccountId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
+	let collator_0_aura_id: AuraId =
+		AuraId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
+
+	genesis(
+		// Initial collators.
+		vec![
+			// POP COLLATOR 0
+			(collator_0_account_id, collator_0_aura_id),
+		],
+		vec![],
+		SudoAddress::get(),
+		PARA_ID,
+		vec![],
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn genesis(
+	invulnerables: Vec<(AccountId, AuraId)>,
+	endowed_accounts: Vec<AccountId>,
+	sudo_key: AccountId,
+	id: ParaId,
+	council_members: Vec<AccountId>,
+) -> Value {
+	json!({
+		"assets": AssetsConfig {
+			assets: vec![],
+			metadata: vec![],
+			..Default::default()
+		},
+		"balances": BalancesConfig { balances: balances(endowed_accounts) },
+		"collatorSelection": {
+			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
+			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
+		},
+		"council": CouncilConfig {
+			members: council_members,
+			..Default::default()
+		},
+		"parachainInfo": { "parachainId": id },
+		"polkadotXcm": { "safeXcmVersion": Some(SAFE_XCM_VERSION) },
+		"session": {
+			"keys": invulnerables
+				.into_iter()
+				.map(|(acc, aura)| {
+					(
+						acc.clone(),        // account id
+						acc,               	// validator id
+						SessionKeys { aura},// session keys
+					)
+				})
+				.collect::<Vec<_>>(),
+		},
+		"sudo" : { "key" : sudo_key },
+	})
+}
+
+// The initial balances at genesis. Used for local testing only.
+fn balances(endowed_accounts: Vec<AccountId>) -> Vec<(AccountId, Balance)> {
+	let balances = endowed_accounts
+		.iter()
+		.cloned()
+		.map(|k| {
+			// Well known keys get an amount equal to `ENDOWMENT`.
+			// Other keys are funded with ED only.
+			if dev_accounts().contains(&k) {
+				(k, ENDOWMENT)
+			} else {
+				(k, ExistentialDeposit::get())
+			}
+		})
+		.collect::<Vec<_>>();
+	balances
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn ensure_sudo_multisig_account() {
+		assert_eq!(
+			derive_multisig::<Runtime>(
+				vec![
+					AccountId::from_ss58check("15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg")
+						.unwrap(),
+					AccountId::from_ss58check("142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z")
+						.unwrap(),
+					AccountId::from_ss58check("15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz")
+						.unwrap(),
+					AccountId::from_ss58check("14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4")
+						.unwrap(),
+				],
+				2
+			),
+			SudoAddress::get()
+		)
+	}
+
+	mod development_config {
+		use super::*;
+
+		#[test]
+		fn ensure_initial_collators() {
+			let genesis = development_config();
+
+			let invulnerables = genesis["collatorSelection"]["invulnerables"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|a| a.as_str().unwrap().to_string())
+				.collect::<Vec<_>>();
+			assert!(invulnerables.contains(&Keyring::Alice.to_account_id().to_string()));
+
+			let session_keys = genesis["session"]["keys"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|k| {
+					let key = k.as_array().unwrap();
+					let session_key = key[0].as_str().unwrap().to_string();
+					session_key
+				})
+				.collect::<Vec<_>>();
+			assert!(session_keys.contains(&Keyring::Alice.to_account_id().to_string()));
+		}
+
+		#[test]
+		fn endows_given_accounts() {
+			let mut endowed_accounts = dev_accounts();
+			endowed_accounts.push(MaintenanceAccount::get());
+			endowed_accounts.push(PotId::get().into_account_truncating());
+			endowed_accounts.push(TreasuryAccount::get());
+
+			let genesis = development_config();
+
+			let balances: Vec<_> = genesis["balances"]["balances"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|e| {
+					let endowment = e.as_array().unwrap();
+					let account = endowment[0].as_str().unwrap().to_string();
+					let balance = endowment[1].as_number().unwrap();
+					(account, balance)
+				})
+				.collect();
+
+			let accounts_in_balances_state: Vec<_> =
+				balances.into_iter().map(|(account, _)| account).collect();
+			assert!(endowed_accounts
+				.iter()
+				.all(|s| accounts_in_balances_state.contains(&s.to_string())));
+		}
+
+		#[test]
+		fn ensure_correct_sudo_key() {
+			let genesis = development_config();
+
+			let sudo_key = genesis["sudo"]["key"].as_str().unwrap();
+			assert_eq!(sudo_key, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+			assert_eq!(
+				AccountId::from_ss58check(sudo_key).unwrap(),
+				Keyring::Alice.to_account_id()
+			);
+		}
+
+		#[test]
+		fn ensure_correct_para_id() {
+			let genesis = development_config();
+
+			let para_id = genesis["parachainInfo"]["parachainId"].as_u64().unwrap();
+			assert_eq!(para_id, 3395);
+		}
+
+		#[test]
+		fn ensure_genesis_assets_are_empty() {
+			let genesis = development_config();
+
+			let assets = genesis["assets"]["assets"].as_array().unwrap();
+			assert!(assets.is_empty());
+		}
+
+		#[test]
+		fn ensure_council_members() {
+			let council_members = vec![
+				Keyring::Alice.to_account_id(),
+				Keyring::Bob.to_account_id(),
+				Keyring::Charlie.to_account_id(),
+				Keyring::Dave.to_account_id(),
+				Keyring::Eve.to_account_id(),
+			];
+
+			let genesis = development_config();
+
+			let council: Vec<_> = genesis["council"]["members"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|e| {
+					let member = e.as_str().unwrap().to_string();
+					member
+				})
+				.collect();
+			assert!(council_members.iter().all(|s| council.contains(&s.to_string())));
+		}
+	}
+
+	mod local_config {
+		use super::*;
+
+		#[test]
+		fn ensure_initial_collators() {
+			let initial_collators =
+				vec![Keyring::Alice.to_account_id(), Keyring::Bob.to_account_id()];
+
+			let genesis = local_config();
+
+			let invulnerables = genesis["collatorSelection"]["invulnerables"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|a| a.as_str().unwrap().to_string())
+				.collect::<Vec<_>>();
+			assert!(initial_collators.iter().all(|c| invulnerables.contains(&c.to_string())));
+
+			let session_keys = genesis["session"]["keys"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|k| {
+					let key = k.as_array().unwrap();
+					let session_key = key[0].as_str().unwrap().to_string();
+					session_key
+				})
+				.collect::<Vec<_>>();
+			assert!(initial_collators.iter().all(|c| session_keys.contains(&c.to_string())));
+		}
+
+		#[test]
+		fn endows_given_accounts() {
+			let sudo_account = derive_multisig::<Runtime>(
+				vec![
+					Keyring::Alice.to_account_id(),
+					Keyring::Bob.to_account_id(),
+					Keyring::Charlie.to_account_id(),
+					Keyring::Dave.to_account_id(),
+				],
+				2,
+			);
+
+			let mut endowed_accounts = dev_accounts();
+			endowed_accounts.push(MaintenanceAccount::get());
+			endowed_accounts.push(PotId::get().into_account_truncating());
+			endowed_accounts.push(sudo_account);
+			endowed_accounts.push(TreasuryAccount::get());
+
+			let genesis = local_config();
+
+			let balances: Vec<_> = genesis["balances"]["balances"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|e| {
+					let endowment = e.as_array().unwrap();
+					let account = endowment[0].as_str().unwrap().to_string();
+					let balance = endowment[1].as_number().unwrap();
+					(account, balance)
+				})
+				.collect();
+
+			let accounts_in_balances_state: Vec<_> =
+				balances.into_iter().map(|(account, _)| account).collect();
+			assert!(endowed_accounts
+				.iter()
+				.all(|s| accounts_in_balances_state.contains(&s.to_string())));
+		}
+
+		#[test]
+		fn ensure_correct_sudo_key() {
+			assert_eq!(
+				"5H9WyMRtMWqkUggSQun4jiDdbzYbsNQhLDH7KooXaihMC7Tp",
+				derive_multisig::<Runtime>(
+					vec![
+						Keyring::Alice.to_account_id(),
+						Keyring::Bob.to_account_id(),
+						Keyring::Charlie.to_account_id(),
+						Keyring::Dave.to_account_id(),
+					],
+					2
+				)
+				.to_ss58check()
+			);
+
+			let genesis = local_config();
+
+			let sudo_key = genesis["sudo"]["key"].as_str().unwrap();
+			assert_eq!(
+				AccountId::from_ss58check(sudo_key).unwrap(),
+				derive_multisig::<Runtime>(
+					vec![
+						Keyring::Alice.to_account_id(),
+						Keyring::Bob.to_account_id(),
+						Keyring::Charlie.to_account_id(),
+						Keyring::Dave.to_account_id(),
+					],
+					2
+				)
+			);
+		}
+
+		#[test]
+		fn ensure_correct_para_id() {
+			let genesis = local_config();
+
+			let para_id = genesis["parachainInfo"]["parachainId"].as_u64().unwrap();
+			assert_eq!(para_id, 3395);
+		}
+
+		#[test]
+		fn ensure_genesis_assets_are_empty() {
+			let genesis = local_config();
+
+			let assets = genesis["assets"]["assets"].as_array().unwrap();
+			assert!(assets.is_empty());
+		}
+
+		#[test]
+		fn ensure_council_members() {
+			let council_members = vec![
+				Keyring::Alice.to_account_id(),
+				Keyring::Bob.to_account_id(),
+				Keyring::Charlie.to_account_id(),
+				Keyring::Dave.to_account_id(),
+				Keyring::Eve.to_account_id(),
+			];
+			let genesis = local_config();
+
+			let council: Vec<_> = genesis["council"]["members"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|e| {
+					let member = e.as_str().unwrap().to_string();
+					member
+				})
+				.collect();
+			assert!(council_members.iter().all(|s| council.contains(&s.to_string())));
+		}
+	}
+
+	mod live_config {
+		use super::*;
+
+		#[test]
+		fn ensure_initial_collators() {
+			let initial_collators = vec![(
+				AccountId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w")
+					.unwrap(),
+				AuraId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap(),
+			)];
+
+			let genesis = live_config();
+
+			let invulnerables = genesis["collatorSelection"]["invulnerables"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|a| a.as_str().unwrap().to_string())
+				.collect::<Vec<_>>();
+			assert!(initial_collators.iter().all(|c| invulnerables.contains(&c.0.to_string())));
+
+			let session_keys = genesis["session"]["keys"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|k| {
+					let key = k.as_array().unwrap();
+					let session_key = key[0].as_str().unwrap().to_string();
+					let aura_key =
+						key[2].as_object().unwrap()["aura"].as_str().unwrap().to_string();
+					(session_key, aura_key)
+				})
+				.collect::<Vec<_>>();
+			assert!(initial_collators
+				.iter()
+				.all(|c| session_keys.contains(&(c.0.to_string(), c.1.to_string()))));
+		}
+
+		#[test]
+		fn endowed_accounts_are_empty() {
+			let genesis = live_config();
+
+			let balances = genesis["balances"]["balances"].as_array().unwrap();
+
+			assert!(balances.is_empty());
+		}
+
+		#[test]
+		fn ensure_correct_sudo_key() {
+			let genesis = live_config();
+
+			let sudo_key = genesis["sudo"]["key"].as_str().unwrap();
+			assert_eq!(AccountId::from_ss58check(sudo_key).unwrap(), SudoAddress::get());
+		}
+
+		#[test]
+		fn ensure_correct_para_id() {
+			let genesis = live_config();
+
+			let para_id = genesis["parachainInfo"]["parachainId"].as_u64().unwrap();
+			assert_eq!(para_id, 3395);
+		}
+
+		#[test]
+		fn ensure_genesis_assets_are_empty() {
+			let genesis = live_config();
+
+			let assets = genesis["assets"]["assets"].as_array().unwrap();
+			assert!(assets.is_empty());
+		}
+
+		#[test]
+		fn ensure_council_members_are_not_set() {
+			let genesis = live_config();
+
+			let council = genesis["council"]["members"].as_array().unwrap();
+			assert!(council.is_empty());
+		}
+	}
+}

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -8,6 +8,9 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod apis;
 pub mod config;
+
+/// The genesis state presets available.
+pub mod genesis;
 mod weights;
 
 extern crate alloc;

--- a/runtime/testnet/src/genesis.rs
+++ b/runtime/testnet/src/genesis.rs
@@ -1,0 +1,167 @@
+use alloc::{vec, vec::Vec};
+
+use cumulus_primitives_core::ParaId;
+use parachains_common::{AccountId, AuraId, Balance};
+use pop_runtime_common::genesis::*;
+use sp_core::crypto::Ss58Codec;
+use sp_genesis_builder::PresetId;
+
+use crate::{AssetsConfig, BalancesConfig, SessionKeys, EXISTENTIAL_DEPOSIT, UNIT};
+
+/// A development chain running on a single node, using the `testnet` runtime.
+pub const TESTNET_DEV: &str = "pop-testnet-dev";
+/// Configures a local chain running on multiple nodes for testing purposes, using the `testnet`
+/// runtime.
+pub const TESTNET_LOCAL: &str = "pop-testnet-local";
+/// A live chain running on multiple nodes, using the `testnet` runtime.
+pub const TESTNET: &str = "pop-testnet";
+/// The available genesis config presets;
+const PRESETS: [&str; 3] = [TESTNET_DEV, TESTNET_LOCAL, TESTNET];
+
+/// The parachain identifier to set in genesis config.
+pub const PARA_ID: ParaId = ParaId::new(4_001);
+
+/// Initial balance for genesis endowed accounts.
+const ENDOWMENT: Balance = 10_000_000 * UNIT;
+
+/// The default XCM version to set in genesis config.
+const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
+
+/// SUDO account set at genesis.
+const TESTNET_SUDO_ACCOUNT: &str = "5FPL3ZLqUk6MyBoZrQZ1Co29WAteX6T6N68TZ6jitHvhpyuD";
+
+// Returns the SUDO account's address as an `AccountId`.
+// This function will return an error if the SS58 address is invalid.
+fn sudo_account_id() -> AccountId {
+	AccountId::from_ss58check(TESTNET_SUDO_ACCOUNT).expect("sudo address is valid SS58")
+}
+
+/// Returns a JSON blob representation of the built-in `RuntimeGenesisConfig` identified by `id`.
+pub(crate) fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
+	let patch = match id.as_str() {
+		TESTNET_DEV => development_config(),
+		TESTNET_LOCAL => local_config(),
+		TESTNET => live_config(),
+		_ => return None,
+	};
+	Some(
+		to_string(&patch)
+			.expect("serialization to json is expected to work. qed.")
+			.into_bytes(),
+	)
+}
+
+/// Returns a list of identifiers for available builtin `RuntimeGenesisConfig` presets.
+pub(crate) fn presets() -> Vec<PresetId> {
+	PRESETS.map(PresetId::from).to_vec()
+}
+
+/// Configures a development chain running on a single node, using the `testnet` runtime.
+fn development_config() -> Value {
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Single collator for development chain
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+		]),
+		dev_accounts(),
+		Keyring::Alice.to_account_id(),
+		PARA_ID,
+	)
+}
+
+/// Configures a local chain running on multiple nodes for testing purposes, using the `testnet`
+/// runtime.
+fn local_config() -> Value {
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Multiple collators for local development chain.
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+			(Keyring::Bob.to_account_id(), Keyring::Bob.public().into()),
+		]),
+		dev_accounts(),
+		Keyring::Alice.to_account_id(),
+		PARA_ID,
+	)
+}
+
+/// Configures a live chain running on multiple nodes on private testnet, using the `testnet`
+/// runtime.
+fn live_config() -> Value {
+	let collator_0_account_id: AccountId =
+		AccountId::from_ss58check("5Gn9dVgCNUYtC5JVMBheQQv2x6Lpg5sAMcQVRupG1s3tP2gR").unwrap();
+	let collator_0_aura_id: AuraId =
+		AuraId::from_ss58check("5Gn9dVgCNUYtC5JVMBheQQv2x6Lpg5sAMcQVRupG1s3tP2gR").unwrap();
+	let collator_1_account_id: AccountId =
+		AccountId::from_ss58check("5FyVvcSvSXCkBwvBEHkUh1VWGGrwaR3zbYBkU3Rc5DqV75S4").unwrap();
+	let collator_1_aura_id: AuraId =
+		AuraId::from_ss58check("5FyVvcSvSXCkBwvBEHkUh1VWGGrwaR3zbYBkU3Rc5DqV75S4").unwrap();
+	let collator_2_account_id: AccountId =
+		AccountId::from_ss58check("5GMqrQuWpyyBBK7LAWXR5psWvKc1QMqtiyasjp23VNKZWgh6").unwrap();
+	let collator_2_aura_id: AuraId =
+		AuraId::from_ss58check("5GMqrQuWpyyBBK7LAWXR5psWvKc1QMqtiyasjp23VNKZWgh6").unwrap();
+
+	genesis(
+		// Initial collators.
+		vec![
+			// POP COLLATOR 0
+			(collator_0_account_id, collator_0_aura_id),
+			// POP COLLATOR 1
+			(collator_1_account_id, collator_1_aura_id),
+			// POP COLLATOR 2
+			(collator_2_account_id, collator_2_aura_id),
+		],
+		vec![],
+		sudo_account_id(),
+		PARA_ID,
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn genesis(
+	invulnerables: Vec<(AccountId, AuraId)>,
+	endowed_accounts: Vec<AccountId>,
+	sudo_key: AccountId,
+	id: ParaId,
+) -> Value {
+	json!({
+		"assets": AssetsConfig {
+			// Genesis assets: Vec<(id, owner, is_sufficient, min_balance)>
+			assets: Vec::from([
+				(0, sudo_key.clone(), false, EXISTENTIAL_DEPOSIT),	// Relay native asset from Asset Hub
+			]),
+			// Genesis metadata: Vec<(id, name, symbol, decimals)>
+			metadata: Vec::from([
+				(0, "Paseo".into(), "PAS".into(), 10),
+			]),
+			..Default::default()
+		},
+		"balances": BalancesConfig { balances: balances(endowed_accounts) },
+		"collatorSelection": {
+			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
+			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
+		},
+		"parachainInfo": { "parachainId": id },
+		"polkadotXcm": { "safeXcmVersion": Some(SAFE_XCM_VERSION) },
+		"session": {
+			"keys": invulnerables
+				.into_iter()
+				.map(|(acc, aura)| {
+					(
+						acc.clone(),        // account id
+						acc,               	// validator id
+						SessionKeys { aura},// session keys
+					)
+				})
+				.collect::<Vec<_>>(),
+		},
+		"sudo" : { "key" : sudo_key },
+	})
+}
+
+// The initial balances at genesis.
+fn balances(endowed_accounts: Vec<AccountId>) -> Vec<(AccountId, Balance)> {
+	let balances = endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect::<Vec<_>>();
+	balances
+}

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -8,6 +8,9 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 // Public due to integration tests crate.
 pub mod config;
+
+/// The genesis state presets available.
+pub mod genesis;
 mod weights;
 
 extern crate alloc;
@@ -1024,11 +1027,11 @@ impl_runtime_apis! {
 		}
 
 		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-			get_preset::<RuntimeGenesisConfig>(id, |_| None)
+			get_preset::<RuntimeGenesisConfig>(id, genesis::get_preset)
 		}
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
-			Default::default()
+			genesis::presets()
 		}
 	}
 }


### PR DESCRIPTION
Closes: #246

Refactor genesis config to use presets for all runtimes:

- [x] Use genesis presets for devnet runtime: this PR
- [x] Use genesis presets for testnet runtime: #472 
- [x] Use genesis presets for mainnet runtime: #473

Each PR is been based on the one above as per this list. Merging should be easier if we waterfall starting from #473  and continue with #472 then this PR. Reviews should still be easier in order devnet -> mainnet as the changes are incremental.

These are the different spec that will use the devnet runtime. These are the ones we can pass to the node via `--chain <spec>`.

```rust
/// A development chain running on a single node, using the `devnet` runtime.
pub const DEVNET_DEV: &str = "pop-devnet-dev";
/// Configures a local chain running on multiple nodes for testing purposes, using the `devnet`
/// runtime.
pub const DEVNET_LOCAL: &str = "pop-devnet-local";
/// A live chain running on multiple nodes on private devnet, using the `devnet` runtime.
pub const DEVNET: &str = "pop-devnet";
```

Each of these use a different genesis configuration.

---

### Requirements:

- [x] There's an asset reserved for DOT on every config.

[sc-2373]