### PR TITLE
refactor(testnet): use genesis presets for testnet runtime.

### DIFF
--- a/networks/mainnet.toml
+++ b/networks/mainnet.toml
@@ -20,7 +20,7 @@ validator = true
 
 [[parachains]]
 id = 4001
-chain = "mainnet"
+chain = "pop-dev" # mainnet runtime with development config.
 default_command = "./target/release/pop-node"
 
 [parachains.genesis_overrides.balances]
@@ -32,15 +32,6 @@ balances = [
     ["5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy", 10000000000000000],
     ["5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw", 10000000000000000],
     ["5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL", 10000000000000000],
-]
-
-[parachains.genesis_overrides.council]
-members = [
-    # Dev accounts
-    "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-    "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-    "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
-    "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
 ]
 
 [[parachains.collators]]

--- a/networks/testnet.toml
+++ b/networks/testnet.toml
@@ -20,7 +20,7 @@ validator = true
 
 [[parachains]]
 id = 4001
-chain = "testnet"
+chain = "pop-testnet-dev" # pop testnet runtime with development config.
 default_command = "./target/release/pop-node"
 
 [parachains.genesis_overrides.balances]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -146,7 +146,7 @@ pub mod testnet {
 		}
 	}
 
-	/// Configures a development chain running on a single node, using the devnet runtime.
+	/// Configures a development chain running on a single node, using the testnet runtime.
 	pub fn development_chain_spec() -> ChainSpec {
 		const ID: &str = TESTNET_DEV;
 		Runtime::build(
@@ -159,15 +159,14 @@ pub mod testnet {
 		)
 	}
 
-	/// Configures a local chain running on multiple nodes for testing purposes, using the devnet
+	/// Configures a local chain running on multiple nodes for testing purposes, using the testnet
 	/// runtime.
 	pub fn local_chain_spec() -> ChainSpec {
 		const ID: &str = TESTNET_LOCAL;
 		Runtime::build(ID, "POP Testnet (Local)", ChainType::Local, ID, ID, "paseo-local")
 	}
 
-	/// Configures a live chain running on multiple nodes on private devnet, using the devnet
-	/// runtime.
+	/// Configures a live chain running on multiple nodes, using the testnet runtime.
 	pub fn live_chain_spec() -> ChainSpec {
 		const ID: &str = TESTNET;
 		Runtime::build(ID, "POP Testnet", ChainType::Live, ID, ID, "paseo")

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -151,7 +151,7 @@ pub mod testnet {
 		const ID: &str = TESTNET_DEV;
 		Runtime::build(
 			ID,
-			"POP Testnet (Development)",
+			"Pop Testnet (Development)",
 			ChainType::Development,
 			ID,
 			ID,
@@ -163,13 +163,13 @@ pub mod testnet {
 	/// runtime.
 	pub fn local_chain_spec() -> ChainSpec {
 		const ID: &str = TESTNET_LOCAL;
-		Runtime::build(ID, "POP Testnet (Local)", ChainType::Local, ID, ID, "paseo-local")
+		Runtime::build(ID, "Pop Testnet (Local)", ChainType::Local, ID, ID, "paseo-local")
 	}
 
 	/// Configures a live chain running on multiple nodes, using the testnet runtime.
 	pub fn live_chain_spec() -> ChainSpec {
 		const ID: &str = TESTNET;
-		Runtime::build(ID, "POP Testnet", ChainType::Live, ID, ID, "paseo")
+		Runtime::build(ID, "Pop Testnet", ChainType::Live, ID, ID, "paseo")
 	}
 }
 

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,25 +1,9 @@
-use cumulus_primitives_core::ParaId;
-use pop_runtime_common::{AccountId, AuraId};
-use pop_runtime_mainnet::config::governance::SudoAddress;
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::{ChainType, GenericChainSpec};
 use serde::{Deserialize, Serialize};
-use sp_core::crypto::Ss58Codec;
 
 /// Generic `ChainSpec` for a parachain runtime.
 pub type ChainSpec = GenericChainSpec<Extensions>;
-
-/// Specialized `ChainSpec` for the mainnet parachain runtime.
-pub type MainnetChainSpec = sc_service::GenericChainSpec<Extensions>;
-
-/// The default XCM version to set in genesis config.
-const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
-
-pub(crate) enum Relay {
-	Paseo,
-	PaseoLocal,
-	Polkadot,
-}
 
 /// Chainspec builder trait: to be implemented for the different runtimes (i.e. `devnet`, `testnet`
 /// & `mainnet`) to ease building.
@@ -173,163 +157,137 @@ pub mod testnet {
 	}
 }
 
-/// Generate the session keys from individual elements.
-///
-/// The input must be a tuple of individual keys (a single arg for now since we have just one key).
-pub fn pop_mainnet_session_keys(keys: AuraId) -> pop_runtime_mainnet::SessionKeys {
-	pop_runtime_mainnet::SessionKeys { aura: keys }
-}
+pub mod mainnet {
+	use pop_runtime_mainnet as runtime;
+	use pop_runtime_mainnet::Runtime;
+	pub use runtime::genesis::{MAINNET, MAINNET_DEV, MAINNET_LOCAL};
 
-fn configure_for_relay(
-	relay: Relay,
-	properties: &mut sc_chain_spec::Properties,
-) -> (Extensions, u32) {
-	let para_id;
+	use super::*;
 
-	match relay {
-		Relay::Paseo | Relay::PaseoLocal => {
-			para_id = 4001;
-			properties.insert("tokenSymbol".into(), "PAS".into());
-			properties.insert("tokenDecimals".into(), 10.into());
+	impl ChainSpecBuilder for Runtime {
+		fn para_id() -> u32 {
+			runtime::genesis::PARA_ID.into()
+		}
 
-			let relay_chain = if let Relay::Paseo = relay {
-				properties.insert("ss58Format".into(), 0.into());
-				"paseo".into()
-			} else {
-				properties.insert("ss58Format".into(), 42.into());
-				"paseo-local".into()
-			};
-			(Extensions { relay_chain, para_id }, para_id)
-		},
-		Relay::Polkadot => {
-			para_id = 3395;
-			properties.insert("ss58Format".into(), 0.into());
+		fn properties() -> sc_chain_spec::Properties {
+			let mut properties = sc_chain_spec::Properties::new();
 			properties.insert("tokenSymbol".into(), "DOT".into());
 			properties.insert("tokenDecimals".into(), 10.into());
-			(Extensions { relay_chain: "polkadot".into(), para_id }, para_id)
-		},
-	}
-}
-
-pub fn mainnet_chain_spec(relay: Relay) -> MainnetChainSpec {
-	let mut properties = sc_chain_spec::Properties::new();
-	let (extensions, para_id) = configure_for_relay(relay, &mut properties);
-
-	let collator_0_account_id: AccountId =
-		AccountId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
-	let collator_0_aura_id: AuraId =
-		AuraId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
-
-	// Multisig account for sudo, generated from the following signatories:
-	// - 15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg
-	// - 142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z
-	// - 15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz
-	// - 14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4
-	// - Threshold 2
-	let sudo_account_id: AccountId = SudoAddress::get();
-
-	#[allow(deprecated)]
-	MainnetChainSpec::builder(
-		pop_runtime_mainnet::WASM_BINARY.expect("WASM binary was not built, please build it!"),
-		extensions,
-	)
-	.with_name("Pop Network")
-	.with_id("pop")
-	.with_chain_type(ChainType::Live)
-	.with_genesis_config_patch(mainnet_genesis(
-		// initial collators.
-		vec![
-			// POP COLLATOR 0
-			(collator_0_account_id, collator_0_aura_id),
-		],
-		sudo_account_id,
-		para_id.into(),
-		// councillors
-		vec![],
-	))
-	.with_protocol_id("pop")
-	.with_properties(properties)
-	.build()
-}
-
-fn mainnet_genesis(
-	invulnerables: Vec<(AccountId, AuraId)>,
-	root: AccountId,
-	id: ParaId,
-	councillors: Vec<AccountId>,
-) -> serde_json::Value {
-	use pop_runtime_mainnet::EXISTENTIAL_DEPOSIT;
-
-	serde_json::json!({
-		"balances": {
-			"balances": [],
-		},
-		"parachainInfo": {
-			"parachainId": id,
-		},
-		"collatorSelection": {
-			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
-			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
-			"desiredCandidates": 0,
-		},
-		"session": {
-			"keys": invulnerables
-				.into_iter()
-				.map(|(acc, aura)| {
-					(
-						acc.clone(),                 // account id
-						acc,                         // validator id
-						pop_mainnet_session_keys(aura),      // session keys
-					)
-				})
-			.collect::<Vec<_>>(),
-		},
-		"polkadotXcm": {
-			"safeXcmVersion": Some(SAFE_XCM_VERSION),
-		},
-		"sudo": { "key": Some(root) },
-		"council": {
-			"members": councillors,
+			properties.insert("ss58Format".into(), 0.into());
+			properties
 		}
-	})
-}
 
-#[test]
-fn sudo_key_valid() {
-	// Source: https://github.com/paritytech/extended-parachain-template/blob/d08cec37117731953119ecaed79522a0812b46f5/node/src/chain_spec.rs#L79
-	fn get_multisig_sudo_key(mut authority_set: Vec<AccountId>, threshold: u16) -> AccountId {
-		assert!(threshold > 0, "Threshold for sudo multisig cannot be 0");
-		assert!(!authority_set.is_empty(), "Sudo authority set cannot be empty");
-		assert!(
-			authority_set.len() >= threshold.into(),
-			"Threshold must be less than or equal to authority set members"
-		);
-		// Sorting is done to deterministically order the multisig set
-		// So that a single authority set (A, B, C) may generate only a single unique multisig key
-		// Otherwise, (B, A, C) or (C, A, B) could produce different keys and cause chaos
-		authority_set.sort();
-
-		// Define a multisig threshold for `threshold / authority_set.len()` members
-		pallet_multisig::Pallet::<pop_runtime_mainnet::Runtime>::multi_account_id(
-			&authority_set[..],
-			threshold,
-		)
+		fn wasm_binary() -> &'static [u8] {
+			runtime::WASM_BINARY.expect("WASM binary was not built, please build it!")
+		}
 	}
 
-	assert_eq!(
-		get_multisig_sudo_key(
-			vec![
-				AccountId::from_ss58check("15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg")
-					.unwrap(),
-				AccountId::from_ss58check("142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z")
-					.unwrap(),
-				AccountId::from_ss58check("15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz")
-					.unwrap(),
-				AccountId::from_ss58check("14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4")
-					.unwrap(),
-			],
-			2
-		),
-		SudoAddress::get()
-	)
+	/// Configures a development chain running on a single node, using the mainnet runtime.
+	pub fn development_chain_spec() -> ChainSpec {
+		const ID: &str = MAINNET_DEV;
+		Runtime::build(ID, "Pop (Development)", ChainType::Development, ID, ID, "paseo-local")
+	}
+
+	/// Configures a local chain running on multiple nodes for testing purposes, using the mainnet
+	/// runtime.
+	pub fn local_chain_spec() -> ChainSpec {
+		const ID: &str = MAINNET_LOCAL;
+		Runtime::build(ID, "Pop (Local)", ChainType::Local, ID, ID, "paseo-local")
+	}
+
+	/// Configures a live chain running on multiple nodes publicly, using the mainnet
+	/// runtime.
+	pub fn live_chain_spec() -> ChainSpec {
+		const ID: &str = MAINNET;
+		Runtime::build(ID, "Pop", ChainType::Live, ID, ID, "polkadot")
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use sc_chain_spec::ChainSpec;
+		use serde_json::json;
+
+		use super::*;
+
+		#[test]
+		fn dev_configuration_is_correct() {
+			let chain_spec = development_chain_spec();
+			assert!(chain_spec.boot_nodes().is_empty());
+			assert_eq!(chain_spec.name(), "Pop (Development)");
+			assert_eq!(chain_spec.id(), "pop-dev");
+			assert_eq!(chain_spec.chain_type(), ChainType::Development);
+			assert!(chain_spec.telemetry_endpoints().is_none());
+			assert_eq!(chain_spec.protocol_id().unwrap(), "pop-dev");
+			assert!(chain_spec.fork_id().is_none());
+			assert_eq!(
+				&chain_spec.properties(),
+				json!({
+					"ss58Format": 0, // Paseo uses Polkadot's SS58.
+					"tokenDecimals": 10,
+					"tokenSymbol": "DOT",
+				})
+				.as_object()
+				.unwrap()
+			);
+			assert_eq!(
+				chain_spec.extensions(),
+				&Extensions { relay_chain: "paseo-local".to_string(), para_id: 3395 }
+			);
+			assert!(chain_spec.code_substitutes().is_empty());
+		}
+
+		#[test]
+		fn local_configuration_is_correct() {
+			let chain_spec = local_chain_spec();
+			assert!(chain_spec.boot_nodes().is_empty());
+			assert_eq!(chain_spec.name(), "Pop (Local)");
+			assert_eq!(chain_spec.id(), "pop-local");
+			assert_eq!(chain_spec.chain_type(), ChainType::Local);
+			assert!(chain_spec.telemetry_endpoints().is_none());
+			assert_eq!(chain_spec.protocol_id().unwrap(), "pop-local");
+			assert!(chain_spec.fork_id().is_none());
+			assert_eq!(
+				&chain_spec.properties(),
+				json!({
+					"ss58Format": 0, // Paseo uses Polkadot's SS58.
+					"tokenDecimals": 10,
+					"tokenSymbol": "DOT",
+				})
+				.as_object()
+				.unwrap()
+			);
+			assert_eq!(
+				chain_spec.extensions(),
+				&Extensions { relay_chain: "paseo-local".to_string(), para_id: 3395 }
+			);
+			assert!(chain_spec.code_substitutes().is_empty());
+		}
+
+		#[test]
+		fn live_configuration_is_correct() {
+			let chain_spec = live_chain_spec();
+			assert!(chain_spec.boot_nodes().is_empty());
+			assert_eq!(chain_spec.name(), "Pop");
+			assert_eq!(chain_spec.id(), "pop");
+			assert_eq!(chain_spec.chain_type(), ChainType::Live);
+			assert!(chain_spec.telemetry_endpoints().is_none());
+			assert_eq!(chain_spec.protocol_id().unwrap(), "pop");
+			assert!(chain_spec.fork_id().is_none());
+			assert_eq!(
+				&chain_spec.properties(),
+				json!({
+					"ss58Format": 0, // Polkadot's SS58.
+					"tokenDecimals": 10,
+					"tokenSymbol": "DOT",
+				})
+				.as_object()
+				.unwrap()
+			);
+			assert_eq!(
+				chain_spec.extensions(),
+				&Extensions { relay_chain: "polkadot".to_string(), para_id: 3395 }
+			);
+			assert!(chain_spec.code_substitutes().is_empty());
+		}
+	}
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -35,7 +35,7 @@ trait RuntimeResolver {
 fn runtime(id: &str) -> Runtime {
 	if [DEVNET_DEV, DEVNET_LOCAL, DEVNET].contains(&id) {
 		Runtime::Devnet
-	} else if id.starts_with("test") || id.ends_with("testnet") {
+	} else if [TESTNET_DEV, TESTNET_LOCAL, TESTNET].contains(&id) {
 		Runtime::Testnet
 	} else if id.eq("pop") || id.ends_with("mainnet") {
 		Runtime::Mainnet

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -13,7 +13,7 @@ use sc_service::config::{BasePath, PrometheusConfig};
 use sp_runtime::traits::HashingFor;
 
 use crate::{
-	chain_spec::{self, devnet::*, Relay},
+	chain_spec::{self, devnet::*, testnet::*, Relay},
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::new_partial,
 };
@@ -78,7 +78,9 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		"local" | DEVNET_LOCAL => Box::new(chain_spec::devnet::local_chain_spec()),
 		DEVNET => Box::new(chain_spec::devnet::live_chain_spec()),
 		// Testnet.
-		"test" | "testnet" | "pop-paseo" => Box::new(chain_spec::testnet_chain_spec(Relay::Paseo)),
+		TESTNET_DEV => Box::new(chain_spec::testnet::development_chain_spec()),
+		TESTNET_LOCAL => Box::new(chain_spec::testnet::local_chain_spec()),
+		TESTNET => Box::new(chain_spec::testnet::live_chain_spec()),
 		// Mainnet.
 		"pop" | "mainnet" | "pop-polkadot" | "pop-network" =>
 			Box::new(chain_spec::mainnet_chain_spec(Relay::Polkadot)),

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -13,7 +13,7 @@ use sc_service::config::{BasePath, PrometheusConfig};
 use sp_runtime::traits::HashingFor;
 
 use crate::{
-	chain_spec::{self, devnet::*, testnet::*, Relay},
+	chain_spec::{self, devnet::*, mainnet::*, testnet::*},
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::new_partial,
 };
@@ -37,7 +37,7 @@ fn runtime(id: &str) -> Runtime {
 		Runtime::Devnet
 	} else if [TESTNET_DEV, TESTNET_LOCAL, TESTNET].contains(&id) {
 		Runtime::Testnet
-	} else if id.eq("pop") || id.ends_with("mainnet") {
+	} else if [MAINNET_DEV, MAINNET_LOCAL, MAINNET].contains(&id) {
 		Runtime::Mainnet
 	} else {
 		log::warn!(
@@ -82,8 +82,9 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		TESTNET_LOCAL => Box::new(chain_spec::testnet::local_chain_spec()),
 		TESTNET => Box::new(chain_spec::testnet::live_chain_spec()),
 		// Mainnet.
-		"pop" | "mainnet" | "pop-polkadot" | "pop-network" =>
-			Box::new(chain_spec::mainnet_chain_spec(Relay::Polkadot)),
+		MAINNET_DEV => Box::new(chain_spec::mainnet::development_chain_spec()),
+		MAINNET_LOCAL => Box::new(chain_spec::mainnet::local_chain_spec()),
+		MAINNET => Box::new(chain_spec::mainnet::live_chain_spec()),
 		// Path.
 		path => Box::new(chain_spec::ChainSpec::from_json_file(path.into())?),
 	})

--- a/runtime/mainnet/src/apis.rs
+++ b/runtime/mainnet/src/apis.rs
@@ -315,11 +315,11 @@ impl_runtime_apis! {
 		}
 
 		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-			get_preset::<RuntimeGenesisConfig>(id, |_| None)
+			get_preset::<RuntimeGenesisConfig>(id, super::genesis::get_preset)
 		}
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
-			Default::default()
+			super::genesis::presets()
 		}
 	}
 

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -16,5 +16,3 @@ mod revive;
 mod utility;
 /// XCM.
 pub mod xcm;
-// Collation.
-mod collation;

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,7 +1,7 @@
 // Assets.
 mod assets;
 // Collation.
-mod collation;
+pub(crate) mod collation;
 /// Governance.
 pub mod governance;
 /// Monetary matters.

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -16,3 +16,5 @@ mod revive;
 mod utility;
 /// XCM.
 pub mod xcm;
+// Collation.
+mod collation;

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -1,0 +1,559 @@
+use alloc::{vec, vec::Vec};
+
+use cumulus_primitives_core::ParaId;
+use parachains_common::{AccountId, AuraId, Balance};
+use pop_runtime_common::genesis::*;
+use sp_core::crypto::Ss58Codec;
+use sp_genesis_builder::PresetId;
+use sp_runtime::traits::AccountIdConversion;
+
+use crate::{
+	config::{
+		collation::PotId,
+		governance::SudoAddress,
+		monetary::{ExistentialDeposit, MaintenanceAccount, TreasuryAccount},
+	},
+	AssetsConfig, BalancesConfig, CouncilConfig, Runtime, SessionKeys, EXISTENTIAL_DEPOSIT, UNIT,
+};
+
+/// A development chain running on a single node, using the `mainnet` runtime.
+pub const MAINNET_DEV: &str = "pop-dev";
+/// Configures a local chain running on multiple nodes for testing purposes, using the `mainnet`
+/// runtime.
+pub const MAINNET_LOCAL: &str = "pop-local";
+/// A live chain running on multiple nodes, using the `mainnet` runtime.
+pub const MAINNET: &str = "pop";
+/// The available genesis config presets;
+const PRESETS: [&str; 3] = [MAINNET_DEV, MAINNET_LOCAL, MAINNET];
+
+/// The parachain identifier to set in genesis config.
+pub const PARA_ID: ParaId = ParaId::new(3395);
+
+/// Initial balance for genesis endowed accounts. Used for local testing only.
+const ENDOWMENT: Balance = 10_000_000 * UNIT;
+
+/// The default XCM version to set in genesis config.
+const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
+
+/// Returns a JSON blob representation of the built-in `RuntimeGenesisConfig` identified by `id`.
+pub(crate) fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
+	let patch = match id.as_str() {
+		MAINNET_DEV => development_config(),
+		MAINNET_LOCAL => local_config(),
+		MAINNET => live_config(),
+		_ => return None,
+	};
+	Some(
+		to_string(&patch)
+			.expect("serialization to json is expected to work. qed.")
+			.into_bytes(),
+	)
+}
+
+/// Returns a list of identifiers for available builtin `RuntimeGenesisConfig` presets.
+pub(crate) fn presets() -> Vec<PresetId> {
+	PRESETS.map(PresetId::from).to_vec()
+}
+
+/// Configures a development chain running on a single node, using the `mainnet` runtime.
+fn development_config() -> Value {
+	let mut endowed_accounts = dev_accounts();
+	endowed_accounts.push(MaintenanceAccount::get());
+	endowed_accounts.push(PotId::get().into_account_truncating());
+	endowed_accounts.push(TreasuryAccount::get());
+
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Single collator for development chain
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+		]),
+		endowed_accounts,
+		Keyring::Alice.to_account_id(),
+		PARA_ID,
+		vec![
+			Keyring::Alice.to_account_id(),
+			Keyring::Bob.to_account_id(),
+			Keyring::Charlie.to_account_id(),
+			Keyring::Dave.to_account_id(),
+			Keyring::Eve.to_account_id(),
+		],
+	)
+}
+
+/// Configures a local chain running on multiple nodes for testing purposes, using the `mainnet`
+/// runtime.
+fn local_config() -> Value {
+	// Like the multisig used for live config, but with dev accounts.
+	let sudo_account = derive_multisig::<Runtime>(
+		vec![
+			Keyring::Alice.to_account_id(),
+			Keyring::Bob.to_account_id(),
+			Keyring::Charlie.to_account_id(),
+			Keyring::Dave.to_account_id(),
+		],
+		2,
+	);
+
+	let mut endowed_accounts = dev_accounts();
+	endowed_accounts.push(MaintenanceAccount::get());
+	endowed_accounts.push(PotId::get().into_account_truncating());
+	endowed_accounts.push(sudo_account.clone());
+	endowed_accounts.push(TreasuryAccount::get());
+
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Multiple collators for local development chain.
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+			(Keyring::Bob.to_account_id(), Keyring::Bob.public().into()),
+		]),
+		endowed_accounts,
+		sudo_account,
+		PARA_ID,
+		vec![
+			Keyring::Alice.to_account_id(),
+			Keyring::Bob.to_account_id(),
+			Keyring::Charlie.to_account_id(),
+			Keyring::Dave.to_account_id(),
+			Keyring::Eve.to_account_id(),
+		],
+	)
+}
+
+/// Configures a live chain running on multiple nodes on private mainnet, using the `mainnet`
+/// runtime.
+fn live_config() -> Value {
+	let collator_0_account_id: AccountId =
+		AccountId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
+	let collator_0_aura_id: AuraId =
+		AuraId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
+
+	genesis(
+		// Initial collators.
+		vec![
+			// POP COLLATOR 0
+			(collator_0_account_id, collator_0_aura_id),
+		],
+		vec![],
+		SudoAddress::get(),
+		PARA_ID,
+		vec![],
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn genesis(
+	invulnerables: Vec<(AccountId, AuraId)>,
+	endowed_accounts: Vec<AccountId>,
+	sudo_key: AccountId,
+	id: ParaId,
+	council_members: Vec<AccountId>,
+) -> Value {
+	json!({
+		"assets": AssetsConfig {
+			assets: vec![],
+			metadata: vec![],
+			..Default::default()
+		},
+		"balances": BalancesConfig { balances: balances(endowed_accounts) },
+		"collatorSelection": {
+			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
+			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
+		},
+		"council": CouncilConfig {
+			members: council_members,
+			..Default::default()
+		},
+		"parachainInfo": { "parachainId": id },
+		"polkadotXcm": { "safeXcmVersion": Some(SAFE_XCM_VERSION) },
+		"session": {
+			"keys": invulnerables
+				.into_iter()
+				.map(|(acc, aura)| {
+					(
+						acc.clone(),        // account id
+						acc,               	// validator id
+						SessionKeys { aura},// session keys
+					)
+				})
+				.collect::<Vec<_>>(),
+		},
+		"sudo" : { "key" : sudo_key },
+	})
+}
+
+// The initial balances at genesis. Used for local testing only.
+fn balances(endowed_accounts: Vec<AccountId>) -> Vec<(AccountId, Balance)> {
+	let balances = endowed_accounts
+		.iter()
+		.cloned()
+		.map(|k| {
+			// Well known keys get an amount equal to `ENDOWMENT`.
+			// Other keys are funded with ED only.
+			if dev_accounts().contains(&k) {
+				(k, ENDOWMENT)
+			} else {
+				(k, ExistentialDeposit::get())
+			}
+		})
+		.collect::<Vec<_>>();
+	balances
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn ensure_sudo_multisig_account() {
+		assert_eq!(
+			derive_multisig::<Runtime>(
+				vec![
+					AccountId::from_ss58check("15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg")
+						.unwrap(),
+					AccountId::from_ss58check("142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z")
+						.unwrap(),
+					AccountId::from_ss58check("15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz")
+						.unwrap(),
+					AccountId::from_ss58check("14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4")
+						.unwrap(),
+				],
+				2
+			),
+			SudoAddress::get()
+		)
+	}
+
+	mod development_config {
+		use super::*;
+
+		#[test]
+		fn ensure_initial_collators() {
+			let genesis = development_config();
+
+			let invulnerables = genesis["collatorSelection"]["invulnerables"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|a| a.as_str().unwrap().to_string())
+				.collect::<Vec<_>>();
+			assert!(invulnerables.contains(&Keyring::Alice.to_account_id().to_string()));
+
+			let session_keys = genesis["session"]["keys"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|k| {
+					let key = k.as_array().unwrap();
+					let session_key = key[0].as_str().unwrap().to_string();
+					session_key
+				})
+				.collect::<Vec<_>>();
+			assert!(session_keys.contains(&Keyring::Alice.to_account_id().to_string()));
+		}
+
+		#[test]
+		fn endows_given_accounts() {
+			let mut endowed_accounts = dev_accounts();
+			endowed_accounts.push(MaintenanceAccount::get());
+			endowed_accounts.push(PotId::get().into_account_truncating());
+			endowed_accounts.push(TreasuryAccount::get());
+
+			let genesis = development_config();
+
+			let balances: Vec<_> = genesis["balances"]["balances"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|e| {
+					let endowment = e.as_array().unwrap();
+					let account = endowment[0].as_str().unwrap().to_string();
+					let balance = endowment[1].as_number().unwrap();
+					(account, balance)
+				})
+				.collect();
+
+			let accounts_in_balances_state: Vec<_> =
+				balances.into_iter().map(|(account, _)| account).collect();
+			assert!(endowed_accounts
+				.iter()
+				.all(|s| accounts_in_balances_state.contains(&s.to_string())));
+		}
+
+		#[test]
+		fn ensure_correct_sudo_key() {
+			let genesis = development_config();
+
+			let sudo_key = genesis["sudo"]["key"].as_str().unwrap();
+			assert_eq!(sudo_key, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+			assert_eq!(
+				AccountId::from_ss58check(sudo_key).unwrap(),
+				Keyring::Alice.to_account_id()
+			);
+		}
+
+		#[test]
+		fn ensure_correct_para_id() {
+			let genesis = development_config();
+
+			let para_id = genesis["parachainInfo"]["parachainId"].as_u64().unwrap();
+			assert_eq!(para_id, 3395);
+		}
+
+		#[test]
+		fn ensure_genesis_assets_are_empty() {
+			let genesis = development_config();
+
+			let assets = genesis["assets"]["assets"].as_array().unwrap();
+			assert!(assets.is_empty());
+		}
+
+		#[test]
+		fn ensure_council_members() {
+			let council_members = vec![
+				Keyring::Alice.to_account_id(),
+				Keyring::Bob.to_account_id(),
+				Keyring::Charlie.to_account_id(),
+				Keyring::Dave.to_account_id(),
+				Keyring::Eve.to_account_id(),
+			];
+
+			let genesis = development_config();
+
+			let council: Vec<_> = genesis["council"]["members"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|e| {
+					let member = e.as_str().unwrap().to_string();
+					member
+				})
+				.collect();
+			assert!(council_members.iter().all(|s| council.contains(&s.to_string())));
+		}
+	}
+
+	mod local_config {
+		use super::*;
+
+		#[test]
+		fn ensure_initial_collators() {
+			let initial_collators =
+				vec![Keyring::Alice.to_account_id(), Keyring::Bob.to_account_id()];
+
+			let genesis = local_config();
+
+			let invulnerables = genesis["collatorSelection"]["invulnerables"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|a| a.as_str().unwrap().to_string())
+				.collect::<Vec<_>>();
+			assert!(initial_collators.iter().all(|c| invulnerables.contains(&c.to_string())));
+
+			let session_keys = genesis["session"]["keys"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|k| {
+					let key = k.as_array().unwrap();
+					let session_key = key[0].as_str().unwrap().to_string();
+					session_key
+				})
+				.collect::<Vec<_>>();
+			assert!(initial_collators.iter().all(|c| session_keys.contains(&c.to_string())));
+		}
+
+		#[test]
+		fn endows_given_accounts() {
+			let sudo_account = derive_multisig::<Runtime>(
+				vec![
+					Keyring::Alice.to_account_id(),
+					Keyring::Bob.to_account_id(),
+					Keyring::Charlie.to_account_id(),
+					Keyring::Dave.to_account_id(),
+				],
+				2,
+			);
+
+			let mut endowed_accounts = dev_accounts();
+			endowed_accounts.push(MaintenanceAccount::get());
+			endowed_accounts.push(PotId::get().into_account_truncating());
+			endowed_accounts.push(sudo_account);
+			endowed_accounts.push(TreasuryAccount::get());
+
+			let genesis = local_config();
+
+			let balances: Vec<_> = genesis["balances"]["balances"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|e| {
+					let endowment = e.as_array().unwrap();
+					let account = endowment[0].as_str().unwrap().to_string();
+					let balance = endowment[1].as_number().unwrap();
+					(account, balance)
+				})
+				.collect();
+
+			let accounts_in_balances_state: Vec<_> =
+				balances.into_iter().map(|(account, _)| account).collect();
+			assert!(endowed_accounts
+				.iter()
+				.all(|s| accounts_in_balances_state.contains(&s.to_string())));
+		}
+
+		#[test]
+		fn ensure_correct_sudo_key() {
+			assert_eq!(
+				"5H9WyMRtMWqkUggSQun4jiDdbzYbsNQhLDH7KooXaihMC7Tp",
+				derive_multisig::<Runtime>(
+					vec![
+						Keyring::Alice.to_account_id(),
+						Keyring::Bob.to_account_id(),
+						Keyring::Charlie.to_account_id(),
+						Keyring::Dave.to_account_id(),
+					],
+					2
+				)
+				.to_ss58check()
+			);
+
+			let genesis = local_config();
+
+			let sudo_key = genesis["sudo"]["key"].as_str().unwrap();
+			assert_eq!(
+				AccountId::from_ss58check(sudo_key).unwrap(),
+				derive_multisig::<Runtime>(
+					vec![
+						Keyring::Alice.to_account_id(),
+						Keyring::Bob.to_account_id(),
+						Keyring::Charlie.to_account_id(),
+						Keyring::Dave.to_account_id(),
+					],
+					2
+				)
+			);
+		}
+
+		#[test]
+		fn ensure_correct_para_id() {
+			let genesis = local_config();
+
+			let para_id = genesis["parachainInfo"]["parachainId"].as_u64().unwrap();
+			assert_eq!(para_id, 3395);
+		}
+
+		#[test]
+		fn ensure_genesis_assets_are_empty() {
+			let genesis = local_config();
+
+			let assets = genesis["assets"]["assets"].as_array().unwrap();
+			assert!(assets.is_empty());
+		}
+
+		#[test]
+		fn ensure_council_members() {
+			let council_members = vec![
+				Keyring::Alice.to_account_id(),
+				Keyring::Bob.to_account_id(),
+				Keyring::Charlie.to_account_id(),
+				Keyring::Dave.to_account_id(),
+				Keyring::Eve.to_account_id(),
+			];
+			let genesis = local_config();
+
+			let council: Vec<_> = genesis["council"]["members"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|e| {
+					let member = e.as_str().unwrap().to_string();
+					member
+				})
+				.collect();
+			assert!(council_members.iter().all(|s| council.contains(&s.to_string())));
+		}
+	}
+
+	mod live_config {
+		use super::*;
+
+		#[test]
+		fn ensure_initial_collators() {
+			let initial_collators = vec![(
+				AccountId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w")
+					.unwrap(),
+				AuraId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap(),
+			)];
+
+			let genesis = live_config();
+
+			let invulnerables = genesis["collatorSelection"]["invulnerables"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|a| a.as_str().unwrap().to_string())
+				.collect::<Vec<_>>();
+			assert!(initial_collators.iter().all(|c| invulnerables.contains(&c.0.to_string())));
+
+			let session_keys = genesis["session"]["keys"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.map(|k| {
+					let key = k.as_array().unwrap();
+					let session_key = key[0].as_str().unwrap().to_string();
+					let aura_key =
+						key[2].as_object().unwrap()["aura"].as_str().unwrap().to_string();
+					(session_key, aura_key)
+				})
+				.collect::<Vec<_>>();
+			assert!(initial_collators
+				.iter()
+				.all(|c| session_keys.contains(&(c.0.to_string(), c.1.to_string()))));
+		}
+
+		#[test]
+		fn endowed_accounts_are_empty() {
+			let genesis = live_config();
+
+			let balances = genesis["balances"]["balances"].as_array().unwrap();
+
+			assert!(balances.is_empty());
+		}
+
+		#[test]
+		fn ensure_correct_sudo_key() {
+			let genesis = live_config();
+
+			let sudo_key = genesis["sudo"]["key"].as_str().unwrap();
+			assert_eq!(AccountId::from_ss58check(sudo_key).unwrap(), SudoAddress::get());
+		}
+
+		#[test]
+		fn ensure_correct_para_id() {
+			let genesis = live_config();
+
+			let para_id = genesis["parachainInfo"]["parachainId"].as_u64().unwrap();
+			assert_eq!(para_id, 3395);
+		}
+
+		#[test]
+		fn ensure_genesis_assets_are_empty() {
+			let genesis = live_config();
+
+			let assets = genesis["assets"]["assets"].as_array().unwrap();
+			assert!(assets.is_empty());
+		}
+
+		#[test]
+		fn ensure_council_members_are_not_set() {
+			let genesis = live_config();
+
+			let council = genesis["council"]["members"].as_array().unwrap();
+			assert!(council.is_empty());
+		}
+	}
+}

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -8,6 +8,9 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod apis;
 pub mod config;
+
+/// The genesis state presets available.
+pub mod genesis;
 mod weights;
 
 extern crate alloc;

--- a/runtime/testnet/src/genesis.rs
+++ b/runtime/testnet/src/genesis.rs
@@ -1,3 +1,5 @@
+use alloc::{vec, vec::Vec};
+
 use cumulus_primitives_core::ParaId;
 use parachains_common::{AccountId, AuraId, Balance};
 use pop_runtime_common::genesis::*;
@@ -26,8 +28,13 @@ const ENDOWMENT: Balance = 10_000_000 * UNIT;
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
 /// SUDO account set at genesis.
-const TESTNET_SUDO_ACCOUNT: AccountId =
-	AccountId::from_ss58check("5FPL3ZLqUk6MyBoZrQZ1Co29WAteX6T6N68TZ6jitHvhpyuD").unwrap();
+const TESTNET_SUDO_ACCOUNT: &str = "5FPL3ZLqUk6MyBoZrQZ1Co29WAteX6T6N68TZ6jitHvhpyuD";
+
+// Returns the SUDO account's address as an `AccountId`.
+// This function will return an error if the SS58 address is invalid.
+fn sudo_account_id() -> AccountId {
+	AccountId::from_ss58check(TESTNET_SUDO_ACCOUNT).expect("sudo address is valid SS58")
+}
 
 /// Returns a JSON blob representation of the built-in `RuntimeGenesisConfig` identified by `id`.
 pub(crate) fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
@@ -67,7 +74,7 @@ fn development_config() -> Value {
 /// runtime.
 fn local_config() -> Value {
 	let mut endowed_accounts = dev_accounts();
-	endowed_accounts.push(TESTNET_SUDO_ACCOUNT);
+	endowed_accounts.push(sudo_account_id());
 
 	genesis(
 		// Initial collators.
@@ -77,7 +84,7 @@ fn local_config() -> Value {
 			(Keyring::Bob.to_account_id(), Keyring::Bob.public().into()),
 		]),
 		endowed_accounts,
-		TESTNET_SUDO_ACCOUNT,
+		sudo_account_id(),
 		PARA_ID,
 	)
 }
@@ -97,8 +104,6 @@ fn live_config() -> Value {
 		AccountId::from_ss58check("5GMqrQuWpyyBBK7LAWXR5psWvKc1QMqtiyasjp23VNKZWgh6").unwrap();
 	let collator_2_aura_id: AuraId =
 		AuraId::from_ss58check("5GMqrQuWpyyBBK7LAWXR5psWvKc1QMqtiyasjp23VNKZWgh6").unwrap();
-	let sudo_account_id: AccountId =
-		AccountId::from_ss58check("5FPL3ZLqUk6MyBoZrQZ1Co29WAteX6T6N68TZ6jitHvhpyuD").unwrap();
 
 	genesis(
 		// Initial collators.
@@ -111,7 +116,7 @@ fn live_config() -> Value {
 			(collator_2_account_id, collator_2_aura_id),
 		],
 		vec![],
-		TESTNET_SUDO_ACCOUNT,
+		sudo_account_id(),
 		PARA_ID,
 	)
 }
@@ -123,7 +128,6 @@ fn genesis(
 	sudo_key: AccountId,
 	id: ParaId,
 ) -> Value {
-	const DECIMALS: u8 = 6;
 	json!({
 		"balances": BalancesConfig { balances: balances(endowed_accounts) },
 		"parachainInfo": { "parachainId": id },
@@ -150,6 +154,6 @@ fn genesis(
 
 // The initial balances at genesis.
 fn balances(endowed_accounts: Vec<AccountId>) -> Vec<(AccountId, Balance)> {
-	let mut balances = endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect::<Vec<_>>();
+	let balances = endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect::<Vec<_>>();
 	balances
 }

--- a/runtime/testnet/src/genesis.rs
+++ b/runtime/testnet/src/genesis.rs
@@ -44,6 +44,11 @@ pub(crate) fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 	)
 }
 
+/// Returns a list of identifiers for available builtin `RuntimeGenesisConfig` presets.
+pub(crate) fn presets() -> Vec<PresetId> {
+	PRESETS.map(PresetId::from).to_vec()
+}
+
 /// Configures a development chain running on a single node, using the `testnet` runtime.
 fn development_config() -> Value {
 	genesis(

--- a/runtime/testnet/src/genesis.rs
+++ b/runtime/testnet/src/genesis.rs
@@ -1,0 +1,150 @@
+use cumulus_primitives_core::ParaId;
+use parachains_common::{AccountId, AuraId, Balance};
+use pop_runtime_common::genesis::*;
+use sp_core::crypto::Ss58Codec;
+use sp_genesis_builder::PresetId;
+
+use crate::{BalancesConfig, SessionKeys, EXISTENTIAL_DEPOSIT, UNIT};
+
+/// A development chain running on a single node, using the `testnet` runtime.
+pub const TESTNET_DEV: &str = "pop-testnet-dev";
+/// Configures a local chain running on multiple nodes for testing purposes, using the `testnet`
+/// runtime.
+pub const TESTNET_LOCAL: &str = "pop-testnet-local";
+/// A live chain running on multiple nodes on private testnet, using the `testnet` runtime.
+pub const TESTNET: &str = "pop-testnet";
+/// The available genesis config presets;
+const PRESETS: [&str; 3] = [TESTNET_DEV, TESTNET_LOCAL, TESTNET];
+
+/// The parachain identifier to set in genesis config.
+pub const PARA_ID: ParaId = ParaId::new(4_001);
+
+/// Initial balance for genesis endowed accounts.
+const ENDOWMENT: Balance = 10_000_000 * UNIT;
+
+/// The default XCM version to set in genesis config.
+const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
+
+/// SUDO account set at genesis.
+const TESTNET_SUDO_ACCOUNT: AccountId =
+	AccountId::from_ss58check("5FPL3ZLqUk6MyBoZrQZ1Co29WAteX6T6N68TZ6jitHvhpyuD").unwrap();
+
+/// Returns a JSON blob representation of the built-in `RuntimeGenesisConfig` identified by `id`.
+pub(crate) fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
+	let patch = match id.as_str() {
+		TESTNET_DEV => development_config(),
+		TESTNET_LOCAL => local_config(),
+		TESTNET => live_config(),
+		_ => return None,
+	};
+	Some(
+		to_string(&patch)
+			.expect("serialization to json is expected to work. qed.")
+			.into_bytes(),
+	)
+}
+
+/// Configures a development chain running on a single node, using the `testnet` runtime.
+fn development_config() -> Value {
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Single collator for development chain
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+		]),
+		dev_accounts(),
+		Keyring::Alice.to_account_id(),
+		PARA_ID,
+	)
+}
+
+/// Configures a local chain running on multiple nodes for testing purposes, using the `testnet`
+/// runtime.
+fn local_config() -> Value {
+	let mut endowed_accounts = dev_accounts();
+	endowed_accounts.push(TESTNET_SUDO_ACCOUNT);
+
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Multiple collators for local development chain.
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+			(Keyring::Bob.to_account_id(), Keyring::Bob.public().into()),
+		]),
+		endowed_accounts,
+		TESTNET_SUDO_ACCOUNT,
+		PARA_ID,
+	)
+}
+
+/// Configures a live chain running on multiple nodes on private testnet, using the `testnet`
+/// runtime.
+fn live_config() -> Value {
+	let collator_0_account_id: AccountId =
+		AccountId::from_ss58check("5Gn9dVgCNUYtC5JVMBheQQv2x6Lpg5sAMcQVRupG1s3tP2gR").unwrap();
+	let collator_0_aura_id: AuraId =
+		AuraId::from_ss58check("5Gn9dVgCNUYtC5JVMBheQQv2x6Lpg5sAMcQVRupG1s3tP2gR").unwrap();
+	let collator_1_account_id: AccountId =
+		AccountId::from_ss58check("5FyVvcSvSXCkBwvBEHkUh1VWGGrwaR3zbYBkU3Rc5DqV75S4").unwrap();
+	let collator_1_aura_id: AuraId =
+		AuraId::from_ss58check("5FyVvcSvSXCkBwvBEHkUh1VWGGrwaR3zbYBkU3Rc5DqV75S4").unwrap();
+	let collator_2_account_id: AccountId =
+		AccountId::from_ss58check("5GMqrQuWpyyBBK7LAWXR5psWvKc1QMqtiyasjp23VNKZWgh6").unwrap();
+	let collator_2_aura_id: AuraId =
+		AuraId::from_ss58check("5GMqrQuWpyyBBK7LAWXR5psWvKc1QMqtiyasjp23VNKZWgh6").unwrap();
+	let sudo_account_id: AccountId =
+		AccountId::from_ss58check("5FPL3ZLqUk6MyBoZrQZ1Co29WAteX6T6N68TZ6jitHvhpyuD").unwrap();
+
+	genesis(
+		// Initial collators.
+		vec![
+			// POP COLLATOR 0
+			(collator_0_account_id, collator_0_aura_id),
+			// POP COLLATOR 1
+			(collator_1_account_id, collator_1_aura_id),
+			// POP COLLATOR 2
+			(collator_2_account_id, collator_2_aura_id),
+		],
+		vec![],
+		TESTNET_SUDO_ACCOUNT,
+		PARA_ID,
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn genesis(
+	invulnerables: Vec<(AccountId, AuraId)>,
+	endowed_accounts: Vec<AccountId>,
+	sudo_key: AccountId,
+	id: ParaId,
+) -> Value {
+	const DECIMALS: u8 = 6;
+	json!({
+		"balances": BalancesConfig { balances: balances(endowed_accounts) },
+		"parachainInfo": { "parachainId": id },
+		"collatorSelection": {
+			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
+			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
+		},
+		"session": {
+			"keys": invulnerables
+				.into_iter()
+				.map(|(acc, aura)| {
+					(
+						acc.clone(),        // account id
+						acc,               	// validator id
+						SessionKeys { aura },// session keys
+					)
+				})
+				.collect::<Vec<_>>(),
+		},
+		"sudo" : { "key" : sudo_key },
+		"polkadotXcm": { "safeXcmVersion": Some(SAFE_XCM_VERSION) },
+	})
+}
+
+// The initial balances at genesis.
+fn balances(endowed_accounts: Vec<AccountId>) -> Vec<(AccountId, Balance)> {
+	let mut balances = endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect::<Vec<_>>();
+	balances
+}

--- a/runtime/testnet/src/genesis.rs
+++ b/runtime/testnet/src/genesis.rs
@@ -13,7 +13,7 @@ pub const TESTNET_DEV: &str = "pop-testnet-dev";
 /// Configures a local chain running on multiple nodes for testing purposes, using the `testnet`
 /// runtime.
 pub const TESTNET_LOCAL: &str = "pop-testnet-local";
-/// A live chain running on multiple nodes on private testnet, using the `testnet` runtime.
+/// A live chain running on multiple nodes, using the `testnet` runtime.
 pub const TESTNET: &str = "pop-testnet";
 /// The available genesis config presets;
 const PRESETS: [&str; 3] = [TESTNET_DEV, TESTNET_LOCAL, TESTNET];
@@ -73,9 +73,6 @@ fn development_config() -> Value {
 /// Configures a local chain running on multiple nodes for testing purposes, using the `testnet`
 /// runtime.
 fn local_config() -> Value {
-	let mut endowed_accounts = dev_accounts();
-	endowed_accounts.push(sudo_account_id());
-
 	genesis(
 		// Initial collators.
 		Vec::from([
@@ -83,8 +80,8 @@ fn local_config() -> Value {
 			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
 			(Keyring::Bob.to_account_id(), Keyring::Bob.public().into()),
 		]),
-		endowed_accounts,
-		sudo_account_id(),
+		dev_accounts(),
+		Keyring::Alice.to_account_id(),
 		PARA_ID,
 	)
 }

--- a/runtime/testnet/src/genesis.rs
+++ b/runtime/testnet/src/genesis.rs
@@ -6,7 +6,7 @@ use pop_runtime_common::genesis::*;
 use sp_core::crypto::Ss58Codec;
 use sp_genesis_builder::PresetId;
 
-use crate::{BalancesConfig, SessionKeys, EXISTENTIAL_DEPOSIT, UNIT};
+use crate::{AssetsConfig, BalancesConfig, SessionKeys, EXISTENTIAL_DEPOSIT, UNIT};
 
 /// A development chain running on a single node, using the `testnet` runtime.
 pub const TESTNET_DEV: &str = "pop-testnet-dev";
@@ -129,12 +129,24 @@ fn genesis(
 	id: ParaId,
 ) -> Value {
 	json!({
+		"assets": AssetsConfig {
+			// Genesis assets: Vec<(id, owner, is_sufficient, min_balance)>
+			assets: Vec::from([
+				(0, asset_hub_sa_on_pop(), false, EXISTENTIAL_DEPOSIT),	// Relay native asset from Asset Hub
+			]),
+			// Genesis metadata: Vec<(id, name, symbol, decimals)>
+			metadata: Vec::from([
+				(0, "Paseo".into(), "PAS".into(), 10),
+			]),
+			..Default::default()
+		},
 		"balances": BalancesConfig { balances: balances(endowed_accounts) },
-		"parachainInfo": { "parachainId": id },
 		"collatorSelection": {
 			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
 			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
 		},
+		"parachainInfo": { "parachainId": id },
+		"polkadotXcm": { "safeXcmVersion": Some(SAFE_XCM_VERSION) },
 		"session": {
 			"keys": invulnerables
 				.into_iter()
@@ -142,13 +154,12 @@ fn genesis(
 					(
 						acc.clone(),        // account id
 						acc,               	// validator id
-						SessionKeys { aura },// session keys
+						SessionKeys { aura},// session keys
 					)
 				})
 				.collect::<Vec<_>>(),
 		},
 		"sudo" : { "key" : sudo_key },
-		"polkadotXcm": { "safeXcmVersion": Some(SAFE_XCM_VERSION) },
 	})
 }
 

--- a/runtime/testnet/src/genesis.rs
+++ b/runtime/testnet/src/genesis.rs
@@ -129,7 +129,7 @@ fn genesis(
 		"assets": AssetsConfig {
 			// Genesis assets: Vec<(id, owner, is_sufficient, min_balance)>
 			assets: Vec::from([
-				(0, asset_hub_sa_on_pop(), false, EXISTENTIAL_DEPOSIT),	// Relay native asset from Asset Hub
+				(0, sudo_key, false, EXISTENTIAL_DEPOSIT),	// Relay native asset from Asset Hub
 			]),
 			// Genesis metadata: Vec<(id, name, symbol, decimals)>
 			metadata: Vec::from([

--- a/runtime/testnet/src/genesis.rs
+++ b/runtime/testnet/src/genesis.rs
@@ -129,7 +129,7 @@ fn genesis(
 		"assets": AssetsConfig {
 			// Genesis assets: Vec<(id, owner, is_sufficient, min_balance)>
 			assets: Vec::from([
-				(0, sudo_key, false, EXISTENTIAL_DEPOSIT),	// Relay native asset from Asset Hub
+				(0, sudo_key.clone(), false, EXISTENTIAL_DEPOSIT),	// Relay native asset from Asset Hub
 			]),
 			// Genesis metadata: Vec<(id, name, symbol, decimals)>
 			metadata: Vec::from([

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -1027,11 +1027,11 @@ impl_runtime_apis! {
 		}
 
 		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-			get_preset::<RuntimeGenesisConfig>(id, |_| None)
+			get_preset::<RuntimeGenesisConfig>(id, super::genesis::get_preset)
 		}
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
-			Default::default()
+			super::genesis::presets()
 		}
 	}
 }

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -1027,11 +1027,11 @@ impl_runtime_apis! {
 		}
 
 		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-			get_preset::<RuntimeGenesisConfig>(id, super::genesis::get_preset)
+			get_preset::<RuntimeGenesisConfig>(id, genesis::get_preset)
 		}
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
-			super::genesis::presets()
+			genesis::presets()
 		}
 	}
 }

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -8,6 +8,9 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 // Public due to integration tests crate.
 pub mod config;
+
+/// The genesis state presets available.
+pub mod genesis;
 mod weights;
 
 extern crate alloc;


### PR DESCRIPTION
Based on #471 

This PR mainly takes the configuration we had in genesis and refactors the code to use presets. Some configs might need to be changed, but those are not included in this PR.

These are the different spec that will use the testnet runtime. These are the ones we can pass to the node via `--chain  <spec>`.

```rust
/// A development chain running on a single node, using the `testnet` runtime.
pub const TESTNET_DEV: &str = "pop-testnet-dev";
/// Configures a local chain running on multiple nodes for testing purposes, using the `testnet`
/// runtime.
pub const TESTNET_LOCAL: &str = "pop-testnet-local";
/// A live chain running on multiple nodes on private testnet, using the `testnet` runtime.
pub const TESTNET: &str = "pop-testnet";
```

---

### Requirements:

- [x] There's an asset reserved for DOT on every config.

[sc-2373]