### PR TITLE
refactor(mainnet): use genesis presets for mainnet runtime.

### DIFF
--- a/networks/mainnet.toml
+++ b/networks/mainnet.toml
@@ -34,15 +34,6 @@ balances = [
     ["5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL", 10000000000000000],
 ]
 
-[parachains.genesis_overrides.council]
-members = [
-    # Dev accounts
-    "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-    "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-    "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
-    "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
-]
-
 [[parachains.collators]]
 name = "pop"
 rpc_port = 9944

--- a/networks/mainnet.toml
+++ b/networks/mainnet.toml
@@ -20,7 +20,7 @@ validator = true
 
 [[parachains]]
 id = 4001
-chain = "mainnet"
+chain = "pop-dev" # mainnet runtime with development config.
 default_command = "./target/release/pop-node"
 
 [parachains.genesis_overrides.balances]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -213,7 +213,7 @@ pub mod mainnet {
 		fn dev_configuration_is_correct() {
 			let chain_spec = development_chain_spec();
 			assert!(chain_spec.boot_nodes().is_empty());
-			assert_eq!(chain_spec.name(), "POP (Development)");
+			assert_eq!(chain_spec.name(), "Pop (Development)");
 			assert_eq!(chain_spec.id(), "pop-dev");
 			assert_eq!(chain_spec.chain_type(), ChainType::Development);
 			assert!(chain_spec.telemetry_endpoints().is_none());
@@ -240,7 +240,7 @@ pub mod mainnet {
 		fn local_configuration_is_correct() {
 			let chain_spec = local_chain_spec();
 			assert!(chain_spec.boot_nodes().is_empty());
-			assert_eq!(chain_spec.name(), "POP (Local)");
+			assert_eq!(chain_spec.name(), "Pop (Local)");
 			assert_eq!(chain_spec.id(), "pop-local");
 			assert_eq!(chain_spec.chain_type(), ChainType::Local);
 			assert!(chain_spec.telemetry_endpoints().is_none());
@@ -267,7 +267,7 @@ pub mod mainnet {
 		fn live_configuration_is_correct() {
 			let chain_spec = live_chain_spec();
 			assert!(chain_spec.boot_nodes().is_empty());
-			assert_eq!(chain_spec.name(), "POP");
+			assert_eq!(chain_spec.name(), "Pop");
 			assert_eq!(chain_spec.id(), "pop");
 			assert_eq!(chain_spec.chain_type(), ChainType::Live);
 			assert!(chain_spec.telemetry_endpoints().is_none());

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,16 +1,9 @@
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::{ChainType, GenericChainSpec};
 use serde::{Deserialize, Serialize};
-use sp_core::crypto::Ss58Codec;
 
 /// Generic `ChainSpec` for a parachain runtime.
 pub type ChainSpec = GenericChainSpec<Extensions>;
-
-/// Specialized `ChainSpec` for the mainnet parachain runtime.
-pub type MainnetChainSpec = sc_service::GenericChainSpec<Extensions>;
-
-/// The default XCM version to set in genesis config.
-const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
 /// Chainspec builder trait: to be implemented for the different runtimes (i.e. `devnet`, `testnet`
 /// & `mainnet`) to ease building.

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -12,12 +12,6 @@ pub type MainnetChainSpec = sc_service::GenericChainSpec<Extensions>;
 /// The default XCM version to set in genesis config.
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
-pub(crate) enum Relay {
-	Paseo,
-	PaseoLocal,
-	Polkadot,
-}
-
 /// Chainspec builder trait: to be implemented for the different runtimes (i.e. `devnet`, `testnet`
 /// & `mainnet`) to ease building.
 trait ChainSpecBuilder {

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -199,6 +199,95 @@ pub mod mainnet {
 	/// runtime.
 	pub fn live_chain_spec() -> ChainSpec {
 		const ID: &str = MAINNET;
-		Runtime::build(ID, "POP", ChainType::Live, ID, ID, "paseo")
+		Runtime::build(ID, "POP", ChainType::Live, ID, ID, "polkadot")
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use sc_chain_spec::ChainSpec;
+		use serde_json::json;
+
+		use super::*;
+
+		#[test]
+		fn dev_configuration_is_correct() {
+			let chain_spec = development_chain_spec();
+			assert!(chain_spec.boot_nodes().is_empty());
+			assert_eq!(chain_spec.name(), "POP (Development)");
+			assert_eq!(chain_spec.id(), "pop-dev");
+			assert_eq!(chain_spec.chain_type(), ChainType::Development);
+			assert!(chain_spec.telemetry_endpoints().is_none());
+			assert_eq!(chain_spec.protocol_id().unwrap(), "pop-dev");
+			assert!(chain_spec.fork_id().is_none());
+			assert_eq!(
+				&chain_spec.properties(),
+				json!({
+					"ss58Format": 0, // Paseo uses Polkadot's SS58.
+					"tokenDecimals": 10,
+					"tokenSymbol": "DOT",
+				})
+				.as_object()
+				.unwrap()
+			);
+			assert_eq!(
+				chain_spec.extensions(),
+				&Extensions { relay_chain: "paseo-local".to_string(), para_id: 3395 }
+			);
+			assert!(chain_spec.code_substitutes().is_empty());
+		}
+
+		#[test]
+		fn local_configuration_is_correct() {
+			let chain_spec = local_chain_spec();
+			assert!(chain_spec.boot_nodes().is_empty());
+			assert_eq!(chain_spec.name(), "POP (Local)");
+			assert_eq!(chain_spec.id(), "pop-local");
+			assert_eq!(chain_spec.chain_type(), ChainType::Local);
+			assert!(chain_spec.telemetry_endpoints().is_none());
+			assert_eq!(chain_spec.protocol_id().unwrap(), "pop-local");
+			assert!(chain_spec.fork_id().is_none());
+			assert_eq!(
+				&chain_spec.properties(),
+				json!({
+					"ss58Format": 0, // Paseo uses Polkadot's SS58.
+					"tokenDecimals": 10,
+					"tokenSymbol": "DOT",
+				})
+				.as_object()
+				.unwrap()
+			);
+			assert_eq!(
+				chain_spec.extensions(),
+				&Extensions { relay_chain: "paseo-local".to_string(), para_id: 3395 }
+			);
+			assert!(chain_spec.code_substitutes().is_empty());
+		}
+
+		#[test]
+		fn live_configuration_is_correct() {
+			let chain_spec = live_chain_spec();
+			assert!(chain_spec.boot_nodes().is_empty());
+			assert_eq!(chain_spec.name(), "POP");
+			assert_eq!(chain_spec.id(), "pop");
+			assert_eq!(chain_spec.chain_type(), ChainType::Live);
+			assert!(chain_spec.telemetry_endpoints().is_none());
+			assert_eq!(chain_spec.protocol_id().unwrap(), "pop");
+			assert!(chain_spec.fork_id().is_none());
+			assert_eq!(
+				&chain_spec.properties(),
+				json!({
+					"ss58Format": 0, // Polkadot's SS58.
+					"tokenDecimals": 10,
+					"tokenSymbol": "DOT",
+				})
+				.as_object()
+				.unwrap()
+			);
+			assert_eq!(
+				chain_spec.extensions(),
+				&Extensions { relay_chain: "polkadot".to_string(), para_id: 3395 }
+			);
+			assert!(chain_spec.code_substitutes().is_empty());
+		}
 	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,6 +1,3 @@
-use cumulus_primitives_core::ParaId;
-use pop_runtime_common::{AccountId, AuraId};
-use pop_runtime_mainnet::config::governance::SudoAddress;
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::{ChainType, GenericChainSpec};
 use serde::{Deserialize, Serialize};
@@ -173,163 +170,48 @@ pub mod testnet {
 	}
 }
 
-/// Generate the session keys from individual elements.
-///
-/// The input must be a tuple of individual keys (a single arg for now since we have just one key).
-pub fn pop_mainnet_session_keys(keys: AuraId) -> pop_runtime_mainnet::SessionKeys {
-	pop_runtime_mainnet::SessionKeys { aura: keys }
-}
+pub mod mainnet {
+	use pop_runtime_mainnet as runtime;
+	use pop_runtime_mainnet::Runtime;
+	pub use runtime::genesis::{MAINNET, MAINNET_DEV, MAINNET_LOCAL};
 
-fn configure_for_relay(
-	relay: Relay,
-	properties: &mut sc_chain_spec::Properties,
-) -> (Extensions, u32) {
-	let para_id;
+	use super::*;
 
-	match relay {
-		Relay::Paseo | Relay::PaseoLocal => {
-			para_id = 4001;
-			properties.insert("tokenSymbol".into(), "PAS".into());
-			properties.insert("tokenDecimals".into(), 10.into());
+	impl ChainSpecBuilder for Runtime {
+		fn para_id() -> u32 {
+			runtime::genesis::PARA_ID.into()
+		}
 
-			let relay_chain = if let Relay::Paseo = relay {
-				properties.insert("ss58Format".into(), 0.into());
-				"paseo".into()
-			} else {
-				properties.insert("ss58Format".into(), 42.into());
-				"paseo-local".into()
-			};
-			(Extensions { relay_chain, para_id }, para_id)
-		},
-		Relay::Polkadot => {
-			para_id = 3395;
-			properties.insert("ss58Format".into(), 0.into());
+		fn properties() -> sc_chain_spec::Properties {
+			let mut properties = sc_chain_spec::Properties::new();
 			properties.insert("tokenSymbol".into(), "DOT".into());
 			properties.insert("tokenDecimals".into(), 10.into());
-			(Extensions { relay_chain: "polkadot".into(), para_id }, para_id)
-		},
-	}
-}
-
-pub fn mainnet_chain_spec(relay: Relay) -> MainnetChainSpec {
-	let mut properties = sc_chain_spec::Properties::new();
-	let (extensions, para_id) = configure_for_relay(relay, &mut properties);
-
-	let collator_0_account_id: AccountId =
-		AccountId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
-	let collator_0_aura_id: AuraId =
-		AuraId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
-
-	// Multisig account for sudo, generated from the following signatories:
-	// - 15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg
-	// - 142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z
-	// - 15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz
-	// - 14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4
-	// - Threshold 2
-	let sudo_account_id: AccountId = SudoAddress::get();
-
-	#[allow(deprecated)]
-	MainnetChainSpec::builder(
-		pop_runtime_mainnet::WASM_BINARY.expect("WASM binary was not built, please build it!"),
-		extensions,
-	)
-	.with_name("Pop Network")
-	.with_id("pop")
-	.with_chain_type(ChainType::Live)
-	.with_genesis_config_patch(mainnet_genesis(
-		// initial collators.
-		vec![
-			// POP COLLATOR 0
-			(collator_0_account_id, collator_0_aura_id),
-		],
-		sudo_account_id,
-		para_id.into(),
-		// councillors
-		vec![],
-	))
-	.with_protocol_id("pop")
-	.with_properties(properties)
-	.build()
-}
-
-fn mainnet_genesis(
-	invulnerables: Vec<(AccountId, AuraId)>,
-	root: AccountId,
-	id: ParaId,
-	councillors: Vec<AccountId>,
-) -> serde_json::Value {
-	use pop_runtime_mainnet::EXISTENTIAL_DEPOSIT;
-
-	serde_json::json!({
-		"balances": {
-			"balances": [],
-		},
-		"parachainInfo": {
-			"parachainId": id,
-		},
-		"collatorSelection": {
-			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
-			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
-			"desiredCandidates": 0,
-		},
-		"session": {
-			"keys": invulnerables
-				.into_iter()
-				.map(|(acc, aura)| {
-					(
-						acc.clone(),                 // account id
-						acc,                         // validator id
-						pop_mainnet_session_keys(aura),      // session keys
-					)
-				})
-			.collect::<Vec<_>>(),
-		},
-		"polkadotXcm": {
-			"safeXcmVersion": Some(SAFE_XCM_VERSION),
-		},
-		"sudo": { "key": Some(root) },
-		"council": {
-			"members": councillors,
+			properties.insert("ss58Format".into(), 0.into());
+			properties
 		}
-	})
-}
 
-#[test]
-fn sudo_key_valid() {
-	// Source: https://github.com/paritytech/extended-parachain-template/blob/d08cec37117731953119ecaed79522a0812b46f5/node/src/chain_spec.rs#L79
-	fn get_multisig_sudo_key(mut authority_set: Vec<AccountId>, threshold: u16) -> AccountId {
-		assert!(threshold > 0, "Threshold for sudo multisig cannot be 0");
-		assert!(!authority_set.is_empty(), "Sudo authority set cannot be empty");
-		assert!(
-			authority_set.len() >= threshold.into(),
-			"Threshold must be less than or equal to authority set members"
-		);
-		// Sorting is done to deterministically order the multisig set
-		// So that a single authority set (A, B, C) may generate only a single unique multisig key
-		// Otherwise, (B, A, C) or (C, A, B) could produce different keys and cause chaos
-		authority_set.sort();
-
-		// Define a multisig threshold for `threshold / authority_set.len()` members
-		pallet_multisig::Pallet::<pop_runtime_mainnet::Runtime>::multi_account_id(
-			&authority_set[..],
-			threshold,
-		)
+		fn wasm_binary() -> &'static [u8] {
+			runtime::WASM_BINARY.expect("WASM binary was not built, please build it!")
+		}
 	}
 
-	assert_eq!(
-		get_multisig_sudo_key(
-			vec![
-				AccountId::from_ss58check("15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg")
-					.unwrap(),
-				AccountId::from_ss58check("142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z")
-					.unwrap(),
-				AccountId::from_ss58check("15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz")
-					.unwrap(),
-				AccountId::from_ss58check("14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4")
-					.unwrap(),
-			],
-			2
-		),
-		SudoAddress::get()
-	)
+	/// Configures a development chain running on a single node, using the mainnet runtime.
+	pub fn development_chain_spec() -> ChainSpec {
+		const ID: &str = MAINNET_DEV;
+		Runtime::build(ID, "POP (Development)", ChainType::Development, ID, ID, "paseo-local")
+	}
+
+	/// Configures a local chain running on multiple nodes for testing purposes, using the mainnet
+	/// runtime.
+	pub fn local_chain_spec() -> ChainSpec {
+		const ID: &str = MAINNET_LOCAL;
+		Runtime::build(ID, "POP (Local)", ChainType::Local, ID, ID, "paseo-local")
+	}
+
+	/// Configures a live chain running on multiple nodes publicly, using the mainnet
+	/// runtime.
+	pub fn live_chain_spec() -> ChainSpec {
+		const ID: &str = MAINNET;
+		Runtime::build(ID, "POP", ChainType::Live, ID, ID, "paseo")
+	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -185,21 +185,21 @@ pub mod mainnet {
 	/// Configures a development chain running on a single node, using the mainnet runtime.
 	pub fn development_chain_spec() -> ChainSpec {
 		const ID: &str = MAINNET_DEV;
-		Runtime::build(ID, "POP (Development)", ChainType::Development, ID, ID, "paseo-local")
+		Runtime::build(ID, "Pop (Development)", ChainType::Development, ID, ID, "paseo-local")
 	}
 
 	/// Configures a local chain running on multiple nodes for testing purposes, using the mainnet
 	/// runtime.
 	pub fn local_chain_spec() -> ChainSpec {
 		const ID: &str = MAINNET_LOCAL;
-		Runtime::build(ID, "POP (Local)", ChainType::Local, ID, ID, "paseo-local")
+		Runtime::build(ID, "Pop (Local)", ChainType::Local, ID, ID, "paseo-local")
 	}
 
 	/// Configures a live chain running on multiple nodes publicly, using the mainnet
 	/// runtime.
 	pub fn live_chain_spec() -> ChainSpec {
 		const ID: &str = MAINNET;
-		Runtime::build(ID, "POP", ChainType::Live, ID, ID, "polkadot")
+		Runtime::build(ID, "Pop", ChainType::Live, ID, ID, "polkadot")
 	}
 
 	#[cfg(test)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -13,7 +13,7 @@ use sc_service::config::{BasePath, PrometheusConfig};
 use sp_runtime::traits::HashingFor;
 
 use crate::{
-	chain_spec::{self, devnet::*, testnet::*, Relay},
+	chain_spec::{self, devnet::*, mainnet::*, testnet::*, Relay},
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::new_partial,
 };
@@ -82,8 +82,9 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		TESTNET_LOCAL => Box::new(chain_spec::testnet::local_chain_spec()),
 		TESTNET => Box::new(chain_spec::testnet::live_chain_spec()),
 		// Mainnet.
-		"pop" | "mainnet" | "pop-polkadot" | "pop-network" =>
-			Box::new(chain_spec::mainnet_chain_spec(Relay::Polkadot)),
+		MAINNET_DEV => Box::new(chain_spec::mainnet::development_chain_spec()),
+		MAINNET_LOCAL => Box::new(chain_spec::mainnet::local_chain_spec()),
+		MAINNET => Box::new(chain_spec::mainnet::live_chain_spec()),
 		// Path.
 		path => Box::new(chain_spec::ChainSpec::from_json_file(path.into())?),
 	})

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -13,7 +13,7 @@ use sc_service::config::{BasePath, PrometheusConfig};
 use sp_runtime::traits::HashingFor;
 
 use crate::{
-	chain_spec::{self, devnet::*, mainnet::*, testnet::*, Relay},
+	chain_spec::{self, devnet::*, mainnet::*, testnet::*},
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::new_partial,
 };

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -37,7 +37,7 @@ fn runtime(id: &str) -> Runtime {
 		Runtime::Devnet
 	} else if [TESTNET_DEV, TESTNET_LOCAL, TESTNET].contains(&id) {
 		Runtime::Testnet
-	} else if id.eq("pop") || id.ends_with("mainnet") {
+	} else if [MAINNET_DEV, MAINNET_LOCAL, MAINNET].contains(&id) {
 		Runtime::Mainnet
 	} else {
 		log::warn!(

--- a/runtime/mainnet/src/apis.rs
+++ b/runtime/mainnet/src/apis.rs
@@ -315,11 +315,11 @@ impl_runtime_apis! {
 		}
 
 		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-			get_preset::<RuntimeGenesisConfig>(id, |_| None)
+			get_preset::<RuntimeGenesisConfig>(id, super::genesis::get_preset)
 		}
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
-			Default::default()
+			super::genesis::presets()
 		}
 	}
 

--- a/runtime/mainnet/src/config/mod.rs
+++ b/runtime/mainnet/src/config/mod.rs
@@ -1,7 +1,7 @@
 // Assets.
 mod assets;
 // Collation.
-mod collation;
+pub(crate) mod collation;
 /// Governance.
 pub mod governance;
 /// Monetary matters.

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -86,7 +86,7 @@ fn development_config() -> Value {
 		// AssetId reserved for DOT from AH.
 		vec![GenesisAsset {
 			id: 0,
-			owner: asset_hub_sa_on_pop(),
+			owner: Keyring::Alice.to_account_id(),
 			is_sufficient: false,
 			min_balance: ExistentialDeposit::get(),
 			name: "DOT".into(),
@@ -134,7 +134,7 @@ fn local_config() -> Value {
 		// AssetId reserved for DOT from AH.
 		vec![GenesisAsset {
 			id: 0,
-			owner: asset_hub_sa_on_pop(),
+			owner: SudoAddress::get(),
 			is_sufficient: false,
 			min_balance: ExistentialDeposit::get(),
 			name: "DOT".into(),
@@ -299,6 +299,10 @@ mod tests {
 
 			let sudo_key = genesis["sudo"]["key"].as_str().unwrap();
 			assert_eq!(sudo_key, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+			assert_eq!(
+				AccountId::from_ss58check(sudo_key).unwrap(),
+				Keyring::Alice.to_account_id()
+			);
 		}
 
 		#[test]
@@ -329,12 +333,10 @@ mod tests {
 
 			// AssetId is 0.
 			assert_eq!(assets[0].0, 0);
-			// Owner is ah_sa_on_pop
-			assert_eq!(assets[0].1, "5Eg2fntNprdN3FgH4sfEaaZhYtddZQSQUqvYJ1f2mLtinVhV");
+			// Owner is SudoAccount
 			assert_eq!(
-				asset_hub_sa_on_pop(),
-				AccountId::from_ss58check("5Eg2fntNprdN3FgH4sfEaaZhYtddZQSQUqvYJ1f2mLtinVhV")
-					.unwrap()
+				AccountId::from_ss58check(assets[0].1.as_str()).unwrap(),
+				Keyring::Alice.to_account_id()
 			);
 			// Asset is not sufficient
 			assert_eq!(assets[0].2, false);
@@ -449,12 +451,10 @@ mod tests {
 
 			// AssetId is 0.
 			assert_eq!(assets[0].0, 0);
-			// Owner is ah_sa_on_pop
-			assert_eq!(assets[0].1, "5Eg2fntNprdN3FgH4sfEaaZhYtddZQSQUqvYJ1f2mLtinVhV");
+			// Owner is SudoAddress
 			assert_eq!(
-				asset_hub_sa_on_pop(),
-				AccountId::from_ss58check("5Eg2fntNprdN3FgH4sfEaaZhYtddZQSQUqvYJ1f2mLtinVhV")
-					.unwrap()
+				AccountId::from_ss58check(assets[0].1.as_str()).unwrap(),
+				SudoAddress::get()
 			);
 			// Asset is not sufficient
 			assert_eq!(assets[0].2, false);

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -1,0 +1,164 @@
+use cumulus_primitives_core::ParaId;
+use parachains_common::{AccountId, AuraId, Balance};
+use pop_runtime_common::genesis::*;
+use sp_core::crypto::Ss58Codec;
+use sp_genesis_builder::PresetId;
+
+use crate::{
+	config::governance::SudoAddress, BalancesConfig, RuntimeError::Sudo, SessionKeys,
+	EXISTENTIAL_DEPOSIT, UNIT,
+};
+
+/// A development chain running on a single node, using the `mainnet` runtime.
+pub const MAINNET_DEV: &str = "pop-dev";
+/// Configures a local chain running on multiple nodes for testing purposes, using the `mainnet`
+/// runtime.
+pub const MAINNET_LOCAL: &str = "pop-local";
+/// A live chain running on multiple nodes, using the `mainnet` runtime.
+pub const MAINNET: &str = "pop";
+/// The available genesis config presets;
+const PRESETS: [&str; 3] = [MAINNET_DEV, MAINNET_LOCAL, MAINNET];
+
+/// The parachain identifier to set in genesis config.
+pub const PARA_ID: ParaId = ParaId::new(3395);
+
+/// Initial balance for genesis endowed accounts.
+const ENDOWMENT: Balance = 10_000_000 * UNIT;
+
+/// The default XCM version to set in genesis config.
+const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
+
+/// Returns a JSON blob representation of the built-in `RuntimeGenesisConfig` identified by `id`.
+pub(crate) fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
+	let patch = match id.as_str() {
+		MAINNET_DEV => development_config(),
+		MAINNET_LOCAL => local_config(),
+		MAINNET => live_config(),
+		_ => return None,
+	};
+	Some(
+		to_string(&patch)
+			.expect("serialization to json is expected to work. qed.")
+			.into_bytes(),
+	)
+}
+
+/// Returns a list of identifiers for available builtin `RuntimeGenesisConfig` presets.
+pub(crate) fn presets() -> Vec<PresetId> {
+	PRESETS.map(PresetId::from).to_vec()
+}
+
+/// Configures a development chain running on a single node, using the `mainnet` runtime.
+fn development_config() -> Value {
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Single collator for development chain
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+		]),
+		dev_accounts(),
+		Keyring::Alice.to_account_id(),
+		PARA_ID,
+	)
+}
+
+/// Configures a local chain running on multiple nodes for testing purposes, using the `mainnet`
+/// runtime.
+fn local_config() -> Value {
+	let mut endowed_accounts = dev_accounts();
+	endowed_accounts.push(SudoAddress::get());
+
+	genesis(
+		// Initial collators.
+		Vec::from([
+			// Multiple collators for local development chain.
+			(Keyring::Alice.to_account_id(), Keyring::Alice.public().into()),
+			(Keyring::Bob.to_account_id(), Keyring::Bob.public().into()),
+		]),
+		endowed_accounts,
+		SudoAddress::get(),
+		PARA_ID,
+	)
+}
+
+/// Configures a live chain running on multiple nodes on private mainnet, using the `mainnet`
+/// runtime.
+fn live_config() -> Value {
+	let collator_0_account_id: AccountId =
+		AccountId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
+	let collator_0_aura_id: AuraId =
+		AuraId::from_ss58check("15B6eUkXgoLA3dWruCRYWeBGNC8SCwuqiMtMTM1Zh2auSg3w").unwrap();
+
+	genesis(
+		// Initial collators.
+		vec![
+			// POP COLLATOR 0
+			(collator_0_account_id, collator_0_aura_id),
+		],
+		vec![],
+		SudoAddress::get(),
+		PARA_ID,
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn genesis(
+	invulnerables: Vec<(AccountId, AuraId)>,
+	endowed_accounts: Vec<AccountId>,
+	sudo_key: AccountId,
+	id: ParaId,
+) -> Value {
+	json!({
+		"balances": BalancesConfig { balances: balances(endowed_accounts) },
+		"parachainInfo": { "parachainId": id },
+		"collatorSelection": {
+			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
+			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
+		},
+		"session": {
+			"keys": invulnerables
+				.into_iter()
+				.map(|(acc, aura)| {
+					(
+						acc.clone(),        // account id
+						acc,               	// validator id
+						SessionKeys { aura },// session keys
+					)
+				})
+				.collect::<Vec<_>>(),
+		},
+		"sudo" : { "key" : sudo_key },
+		"polkadotXcm": { "safeXcmVersion": Some(SAFE_XCM_VERSION) },
+	})
+}
+
+// The initial balances at genesis.
+fn balances(endowed_accounts: Vec<AccountId>) -> Vec<(AccountId, Balance)> {
+	let mut balances = endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect::<Vec<_>>();
+	balances
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn ensure_sudo_account() {
+		assert_eq!(
+			derive_multisig(
+				vec![
+					AccountId::from_ss58check("15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg")
+						.unwrap(),
+					AccountId::from_ss58check("142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z")
+						.unwrap(),
+					AccountId::from_ss58check("15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz")
+						.unwrap(),
+					AccountId::from_ss58check("14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4")
+						.unwrap(),
+				],
+				2
+			),
+			SudoAddress::get()
+		)
+	}
+}

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -211,11 +211,12 @@ fn balances(endowed_accounts: Vec<AccountId>) -> Vec<(AccountId, Balance)> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::Runtime;
 
 	#[test]
 	fn ensure_sudo_account() {
 		assert_eq!(
-			derive_multisig(
+			derive_multisig::<Runtime>(
 				vec![
 					AccountId::from_ss58check("15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg")
 						.unwrap(),

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -1,3 +1,5 @@
+use alloc::{vec, vec::Vec};
+
 use cumulus_primitives_core::ParaId;
 use parachains_common::{AccountId, AuraId, Balance};
 use pop_runtime_common::genesis::*;
@@ -5,8 +7,7 @@ use sp_core::crypto::Ss58Codec;
 use sp_genesis_builder::PresetId;
 
 use crate::{
-	config::governance::SudoAddress, BalancesConfig, RuntimeError::Sudo, SessionKeys,
-	EXISTENTIAL_DEPOSIT, UNIT,
+	config::governance::SudoAddress, BalancesConfig, SessionKeys, EXISTENTIAL_DEPOSIT, UNIT,
 };
 
 /// A development chain running on a single node, using the `mainnet` runtime.
@@ -134,7 +135,7 @@ fn genesis(
 
 // The initial balances at genesis.
 fn balances(endowed_accounts: Vec<AccountId>) -> Vec<(AccountId, Balance)> {
-	let mut balances = endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect::<Vec<_>>();
+	let balances = endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect::<Vec<_>>();
 	balances
 }
 

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -183,7 +183,7 @@ fn genesis(
 	})
 }
 
-// The initial balances at genesis; Used for local testing only.
+// The initial balances at genesis. Used for local testing only.
 fn balances(endowed_accounts: Vec<AccountId>) -> Vec<(AccountId, Balance)> {
 	let balances = endowed_accounts
 		.iter()

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -8,7 +8,7 @@ use sp_genesis_builder::PresetId;
 
 use crate::{
 	config::{governance::SudoAddress, monetary::ExistentialDeposit},
-	AssetsConfig, BalancesConfig, SessionKeys, EXISTENTIAL_DEPOSIT, UNIT,
+	AssetsConfig, BalancesConfig, CouncilConfig, SessionKeys, EXISTENTIAL_DEPOSIT, UNIT,
 };
 
 /// A development chain running on a single node, using the `mainnet` runtime.
@@ -82,6 +82,13 @@ fn development_config() -> Value {
 			symbol: "DOT".into(),
 			decimals: 10,
 		}],
+		vec![
+			Keyring::Alice.to_account_id(),
+			Keyring::Bob.to_account_id(),
+			Keyring::Charlie.to_account_id(),
+			Keyring::Dave.to_account_id(),
+			Keyring::Eve.to_account_id(),
+		],
 	)
 }
 
@@ -111,6 +118,13 @@ fn local_config() -> Value {
 			symbol: "DOT".into(),
 			decimals: 10,
 		}],
+		vec![
+			AccountId::from_ss58check("142zako1kfvrpQ7pJKYR8iGUD58i4wjb78FUsmJ9WcXmkM5z").unwrap(),
+			AccountId::from_ss58check("15VPagCVayS6XvT5RogPYop3BJTJzwqR2mCGR1kVn3w58ygg").unwrap(),
+			AccountId::from_ss58check("14G3CUFnZUBnHZUhahexSZ6AgemaW9zMHBnGccy3df7actf4").unwrap(),
+			AccountId::from_ss58check("15k9niqckMg338cFBoz9vWFGwnCtwPBquKvqJEfHApijZkDz").unwrap(),
+			AccountId::from_ss58check("13BL7T6bTgeEdfEdZqLCKJZPN8ncyFNxxHRKFb2YMATvyfH4").unwrap(),
+		],
 	)
 }
 
@@ -132,6 +146,7 @@ fn live_config() -> Value {
 		SudoAddress::get(),
 		PARA_ID,
 		vec![],
+		vec![],
 	)
 }
 
@@ -142,6 +157,7 @@ fn genesis(
 	sudo_key: AccountId,
 	id: ParaId,
 	genesis_assets: Vec<GenesisAsset>,
+	council_members: Vec<AccountId>,
 ) -> Value {
 	// Collect genesis assets.
 	// Genesis assets: Vec<(id, owner, is_sufficient, min_balance)>
@@ -163,6 +179,10 @@ fn genesis(
 		"collatorSelection": {
 			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
 			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
+		},
+		"council": CouncilConfig {
+			members: council_members,
+			..Default::default()
 		},
 		"parachainInfo": { "parachainId": id },
 		"polkadotXcm": { "safeXcmVersion": Some(SAFE_XCM_VERSION) },

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -29,7 +29,7 @@ const PRESETS: [&str; 3] = [MAINNET_DEV, MAINNET_LOCAL, MAINNET];
 /// The parachain identifier to set in genesis config.
 pub const PARA_ID: ParaId = ParaId::new(3395);
 
-/// Initial balance for genesis endowed accounts; Used for local testing only.
+/// Initial balance for genesis endowed accounts. Used for local testing only.
 const ENDOWMENT: Balance = 10_000_000 * UNIT;
 
 /// The default XCM version to set in genesis config.

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -8,6 +8,9 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod apis;
 pub mod config;
+
+/// The genesis state presets available.
+pub mod genesis;
 mod weights;
 
 extern crate alloc;


### PR DESCRIPTION
Based on #472 

Moves genesis configuration for mainnet into the runtime.

These are the different spec that will use the mainnet runtime. These are the ones we can pass to the node via `--chain  <spec>`.

```rust
/// A development chain running on a single node, using the `mainnet` runtime.
pub const MAINNET_DEV: &str = "pop-dev";
/// Configures a local chain running on multiple nodes for testing purposes, using the `mainnet`
/// runtime.
pub const MAINNET_LOCAL: &str = "pop-local";
/// A live chain running on multiple nodes, using the `mainnet` runtime.
pub const MAINNET: &str = "pop";
```

---

### Requirements:

- [x] There's an asset reserved for DOT on development and local configuration.
- [x] Council seats are populated in genesis state

[sc-2373]
