### PR TITLE
chore(node): `pop-node v0.3.0`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,10 +55,10 @@ jobs:
           fi
           
           # if devnet, build the node with ismp feature
-          if [ "$RUNTIME" == "devnet" ]; then
-            echo "NODE_BUILD_OPTS=--features on-chain-release-build,ismp" >> $GITHUB_ENV
-          else
+          if [ "$RUNTIME" == "mainnet" ]; then
             echo "NODE_BUILD_OPTS=--features on-chain-release-build" >> $GITHUB_ENV
+          else
+            echo "NODE_BUILD_OPTS=--features on-chain-release-build,ismp" >> $GITHUB_ENV
           fi
 
       - name: Cache runtime target dir

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13555,7 +13555,7 @@ dependencies = [
 
 [[package]]
 name = "pop-node"
-version = "0.2.0-alpha"
+version = "0.3.0-alpha"
 dependencies = [
  "clap",
  "color-print",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13555,7 +13555,7 @@ dependencies = [
 
 [[package]]
 name = "pop-node"
-version = "0.3.0-alpha"
+version = "0.3.0"
 dependencies = [
  "clap",
  "color-print",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,7 +8,7 @@ license = "Unlicense"
 name = "pop-node"
 publish = false
 repository.workspace = true
-version = "0.2.0-alpha"
+version = "0.3.0-alpha"
 
 [dependencies]
 clap.workspace = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,7 +8,7 @@ license = "Unlicense"
 name = "pop-node"
 publish = false
 repository.workspace = true
-version = "0.3.0-alpha"
+version = "0.3.0"
 
 [dependencies]
 clap.workspace = true

--- a/node/chain_specs/testnet/paseo.raw.json
+++ b/node/chain_specs/testnet/paseo.raw.json
@@ -23,7 +23,7 @@
   "telemetryEndpoints": null,
   "protocolId": "pas",
   "properties": {
-    "ss58Format": 42,
+    "ss58Format": 0,
     "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },

--- a/runtime/testnet/src/config/mod.rs
+++ b/runtime/testnet/src/config/mod.rs
@@ -7,8 +7,8 @@ pub(crate) mod collation;
 mod contracts;
 /// Governance.
 pub mod governance;
-// Ismp.
 // Public due to pop api integration tests crate.
+/// Ismp.
 pub mod ismp;
 /// Monetary matters.
 pub(crate) mod monetary;
@@ -19,4 +19,5 @@ pub mod system;
 // Utility.
 mod utility;
 // Public due to integration tests crate.
+/// XCM.
 pub mod xcm;


### PR DESCRIPTION
This PR should only be merged after #482 . I've pushed these changes outside of #482 such that we can keep an explicit commit in history about these changes.

-  [x] Needs to be rebased after 482 has been merged.

Changes:

- Bumps node version after having introduced ISMP into testnet runtime in #482.
- Updates the CI release workflow to activate the ISMP feature for testnet releases.
- Pushes a more actual version of paseo relay chain in [e3a72e1](https://github.com/r0gue-io/pop-node/pull/484/commits/e3a72e1859a8fa60d0570d39b9b9e6a516bac28e). The node can sync the relay without problems.
- Removes "alpha" from the node crate version.