### PR TITLE
fix(ci): different fixes for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build ${{ env.RUNTIME }} runtime
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.9.2
+        uses: chevdor/srtool-actions@v0.8.0
         env:
           # runtimes do not have ismp feature
           BUILD_OPTS: '--features on-chain-release-build'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,7 @@ jobs:
       - name: Install packages (Linux)
         if: contains(matrix.platform.target, 'linux')
         run: |
+          sudo apt-get update
           sudo apt-get install -y protobuf-compiler ${{ contains(matrix.platform.target, 'aarch64') && 'crossbuild-essential-arm64' || '' }}
           protoc --version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ env:
 
 on:
   release:
-    types: [ published ]
+    types: [published]
   workflow_dispatch:
     inputs:
       ref:
@@ -16,7 +16,7 @@ on:
         description: Build node
         default: true
       runtime:
-        description: 'Runtime to build (none, devnet, testnet, mainnet)'
+        description: "Runtime to build (none, devnet, testnet, mainnet)"
         default: none
         type: choice
         options:
@@ -53,7 +53,7 @@ jobs:
           else
             echo "RUNTIME=devnet" >> $GITHUB_ENV  # Default to devnet if no tag matches
           fi
-          
+
           # if devnet, build the node with ismp feature
           if [ "$RUNTIME" == "mainnet" ]; then
             echo "NODE_BUILD_OPTS=--features on-chain-release-build" >> $GITHUB_ENV
@@ -75,7 +75,7 @@ jobs:
         uses: chevdor/srtool-actions@v0.8.0
         env:
           # runtimes do not have ismp feature
-          BUILD_OPTS: '--features on-chain-release-build'
+          BUILD_OPTS: "--features on-chain-release-build"
         with:
           chain: ${{ env.RUNTIME }}
           package: "pop-runtime-${{ env.RUNTIME }}"
@@ -174,7 +174,7 @@ jobs:
     env:
       RUSTFLAGS: "${{ matrix.platform.cpu != '' && format('-C target-cpu={0}', matrix.platform.cpu) || '' }} ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && '-C linker=aarch64-linux-gnu-gcc' || '' }}"
       path: "target/${{ matrix.platform.target }}/production"
-      package: "pop-node-${{ matrix.platform.target }}${{ matrix.platform.cpu != '' && format('-{0}', matrix.platform.cpu) || '' }}.tar.gz"
+      package: "pop-node-${{ matrix.platform.target }}${{ matrix.platform.cpu != '' && format('-{0}', matrix.platform.cpu) || '' }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -200,7 +200,7 @@ jobs:
 
       - name: Set Node Build Opts
         run: |
-          if [[ "${{ github.event.release.tag_name }}" == "mainnet"* ]]; then
+          if [[ "${{ github.event.release.tag_name }}" == "mainnet"* || "${{ github.event.inputs.runtime }}" == "mainnet"* ]]; then
             echo "NODE_BUILD_OPTS=--features on-chain-release-build" >> $GITHUB_ENV
           else
             echo "NODE_BUILD_OPTS=--features on-chain-release-build,ismp" >> $GITHUB_ENV
@@ -214,6 +214,8 @@ jobs:
         run: |
           cd ${{ env.path }}
           sha256sum pop-node > pop-node.sha256
+          SHA256_SUM=$(cat pop-node.sha256 | awk '{print $1}')
+          echo "SHA256_SUM=$SHA256_SUM" >> $GITHUB_ENV
           tar -czf ${{ env.package }} pop-node pop-node.sha256
 
       - name: Package binary (macOS)
@@ -221,12 +223,14 @@ jobs:
         run: |
           cd ${{ env.path }}
           shasum -a 256 pop-node > pop-node.sha256
+          SHA256_SUM=$(cat pop-node.sha256 | awk '{print $1}')
+          echo "SHA256_SUM=$SHA256_SUM" >> $GITHUB_ENV
           tar -czf ${{ env.package }} pop-node pop-node.sha256
 
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: ${{ env.package }}-${{ env.SHA256_SUM }}.tar.gz
           path: ${{ env.path }}/${{ env.package }}
 
       - name: Add binary to release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
           tar -czf ${{ env.package }} pop-node pop-node.sha256
 
       - name: Upload binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: ${{ env.path }}/${{ env.package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,14 @@ jobs:
       - name: Add target
         run: rustup target add ${{ matrix.platform.target }}
 
+      - name: Set Node Build Opts
+        run: |
+          if [[ "${{ github.event.release.tag_name }}" == "mainnet"* ]]; then
+            echo "NODE_BUILD_OPTS=--features on-chain-release-build" >> $GITHUB_ENV
+          else
+            echo "NODE_BUILD_OPTS=--features on-chain-release-build,ismp" >> $GITHUB_ENV
+          fi
+
       - name: Build node
         run: cargo build --profile=production -p pop-node $NODE_BUILD_OPTS --target ${{ matrix.platform.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
           sha256sum pop-node > pop-node.sha256
           SHA256_SUM=$(cat pop-node.sha256 | awk '{print $1}')
           echo "SHA256_SUM=$SHA256_SUM" >> $GITHUB_ENV
-          tar -czf ${{ env.package }} pop-node pop-node.sha256
+          tar -czf "${{ env.package }}.tar.gz" pop-node pop-node.sha256
 
       - name: Package binary (macOS)
         if: contains(matrix.platform.target, 'apple')
@@ -225,7 +225,7 @@ jobs:
           shasum -a 256 pop-node > pop-node.sha256
           SHA256_SUM=$(cat pop-node.sha256 | awk '{print $1}')
           echo "SHA256_SUM=$SHA256_SUM" >> $GITHUB_ENV
-          tar -czf ${{ env.package }} pop-node pop-node.sha256
+          tar -czf "${{ env.package }}.tar.gz" pop-node pop-node.sha256
 
       - name: Upload binary
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Moves away from using `upload-artifact@v3` as it is [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). Uses v4 instead.

- Adds `NODE_BUILD_OPTS` to build-node task: https://github.com/r0gue-io/pop-node/pull/488/commits/c1e0ee03680cf88591f4afea7145db6157ab5461

- `Install packages` runs `apt-get update` https://github.com/r0gue-io/pop-node/pull/488/commits/b7b30f49fd6aa3277aa909f59a2ddbc3696ae6d9

- Downgrades srtool to 0.8.0 https://github.com/r0gue-io/pop-node/pull/488/commits/0a1c92eda04c487f0d6992e057800ea871648985

- Provides unique names for the artifacts being used on upload-artifact@v4 by appending the sha256 of the binary. [073885c](https://github.com/r0gue-io/pop-node/pull/488/commits/073885c7fa2df68c7a69ab75a0cf44a3ed9c2ff8). This change was a result of the version update for this action, which brought in some special requirements when it comes to working with multiple elements. [Issue for reference](https://github.com/actions/upload-artifact/issues/478#issuecomment-1872945805). It seemed that the matrix we define to use as compilation targets has, as understood by the action behavior and results, on `x86_64-unknown-linux-gnu`, although both our cases for this arch are clearly different. As a result and to protect the time dedicated to this I added the digests.