### PR TITLE
fix(testnet): bump testnet tx version

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_tracking.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking.md
@@ -19,6 +19,8 @@ assignees: ''
 - [ ] All changes have passed peer-review. < link PR >
 - [ ] Update runtime crate version. Note that `pop-runtime-devnet` is usually not updated.
 - [ ] Runtime spec version is updated.
+- [ ] If needed, the `transaction_version` has been updated. This can be checked with
+  `subwasm`(https://github.com/chevdor/subwasm).
 - [ ] If needed, new benchmarks have been run. A diff between the new weights and the current ones has been reviewed.
     - [`substrate-weight-compare`](https://github.com/ggwpez/substrate-weight-compare) can be used for this purpose.
 - [ ] Execution of [`try-runtime`](https://github.com/paritytech/try-runtime-cli) doesn't point out any missing migrations or other items requiring action.
@@ -76,6 +78,27 @@ _More instructions around using chopsticks for this can be found in [.chopsticks
     {"jsonrpc":"2.0","id":2,"method":"dev_newBlock","params":[{"count":20}]}
 ```
 
+- [ ] Verify if `transaction_version` needs to be updated:
+
+1. Build the new runtime. No concrete features need to be active, it's not a problem if there `runtime-benchmarks` or
+   `try-runtime` are included.
+
+```shell
+    cargo build --release -p <runtime-crate>
+```
+
+2. Fetch the runtime that is on chain at the moment. This can be fetched from the corresponding github release, or a
+   node connected to the network via `subwasm`.
+
+```shell
+    subwasm get <node-endpoint> -o ./output/path
+```
+
+3. Use `subwasm` to create a diff between the runtimes and verify if `transaction_version` is compatible between them.
+
+```shell
+    subwasm diff <old-runtime> <new-runtime>
+```
 
 ## Release
 

--- a/.github/ISSUE_TEMPLATE/release_tracking.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking.md
@@ -93,7 +93,7 @@ _More instructions around using chopsticks for this can be found in [.chopsticks
     subwasm get <node-endpoint> -o ./output/path
 ```
 
-3. Use `subwasm` to create a diff between the runtimes and verify if `transaction_version` is compatible between them.
+3. Use `subwasm` to create a diff between the runtimes and verify if the `transaction_version` is compatible.
 
 ```shell
     subwasm diff <old-runtime> <new-runtime>

--- a/.github/ISSUE_TEMPLATE/release_tracking.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking.md
@@ -80,8 +80,7 @@ _More instructions around using chopsticks for this can be found in [.chopsticks
 
 - [ ] Verify if `transaction_version` needs to be updated:
 
-1. Build the new runtime. No concrete features need to be active, it's not a problem if there `runtime-benchmarks` or
-   `try-runtime` are included.
+1. Build the new runtime. No concrete features need to be active, and it's not a problem if `runtime-benchmarks` or `try-runtime` is enabled.
 
 ```shell
     cargo build --release -p <runtime-crate>

--- a/.github/ISSUE_TEMPLATE/release_tracking.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking.md
@@ -96,7 +96,7 @@ _More instructions around using chopsticks for this can be found in [.chopsticks
 3. Use `subwasm` to create a diff between the runtimes and verify if the `transaction_version` is compatible.
 
 ```shell
-    subwasm diff <old-runtime> <new-runtime>
+    subwasm diff <current-runtime-wasm> <new-runtime-wasm>
 ```
 
 ## Release

--- a/.github/ISSUE_TEMPLATE/release_tracking.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking.md
@@ -86,7 +86,7 @@ _More instructions around using chopsticks for this can be found in [.chopsticks
     cargo build --release -p <runtime-crate>
 ```
 
-2. Fetch the runtime that is on chain at the moment. This can be fetched from the corresponding github release, or a
+2. Fetch the on chain runtime. This can be fetched from the corresponding github release, or a
    node connected to the network via `subwasm`.
 
 ```shell

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6568,7 +6568,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 [[package]]
 name = "ismp"
 version = "0.2.2"
-source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
+source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
  "anyhow",
  "derive_more 1.0.0",
@@ -6585,7 +6585,7 @@ dependencies = [
 [[package]]
 name = "ismp-parachain"
 version = "1.15.3"
-source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
+source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
  "cumulus-pallet-parachain-system 0.18.0",
  "cumulus-primitives-core 0.17.0",
@@ -6610,7 +6610,7 @@ dependencies = [
 [[package]]
 name = "ismp-parachain-inherent"
 version = "1.15.3"
-source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
+source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6631,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "ismp-parachain-runtime-api"
 version = "1.15.1"
-source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
+source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
  "cumulus-pallet-parachain-system 0.18.0",
  "sp-api 35.0.0",
@@ -9923,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "pallet-ismp"
 version = "1.15.3"
-source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
+source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
  "anyhow",
  "fortuples",
@@ -9946,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "pallet-ismp-rpc"
 version = "1.15.3"
-source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
+source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
  "anyhow",
  "frame-system 39.1.0",
@@ -9976,7 +9976,7 @@ dependencies = [
 [[package]]
 name = "pallet-ismp-runtime-api"
 version = "1.15.3"
-source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
+source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
  "ismp",
  "pallet-ismp",
@@ -16825,7 +16825,7 @@ dependencies = [
 [[package]]
 name = "serde-hex-utils"
 version = "0.1.0"
-source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
+source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
  "anyhow",
  "hex",
@@ -19524,7 +19524,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-machine"
 version = "1.15.3"
-source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
+source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
  "frame-support 39.0.0",
  "hash-db",

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -223,7 +223,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 00_05_00,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 1,
+	transaction_version: 2,
 	system_version: 1,
 };
 


### PR DESCRIPTION
On the last testing done prior to testnet runtime v0.5.0 I've noticed that we forgot to bump the transaction_version.
This PR solves that.

This was noticed by comparing the running wasm vs the one we had built with `subwasm`.
Instructions have been included to our release tracking template to account for the above check - commit [0f541e6](https://github.com/r0gue-io/pop-node/pull/491/commits/0f541e6a2a7989d047658f25f6117ee998144d78)