### PR TITLE
Messaging - General

### DIFF
--- a/pallets/api/src/messaging/deposits.rs
+++ b/pallets/api/src/messaging/deposits.rs
@@ -1,7 +1,7 @@
 use sp_runtime::SaturatedConversion;
+use sp_std::ops::Mul;
 
 use super::*;
-use sp_std::ops::Mul;
 
 #[derive(Clone, Debug, Encode, Eq, Decode, MaxEncodedLen, PartialEq, TypeInfo)]
 pub enum ProtocolStorageDeposit {
@@ -10,7 +10,9 @@ pub enum ProtocolStorageDeposit {
 }
 
 /// Calculate the deposit required for the space used for a specific protocol.
-pub fn calculate_protocol_deposit<T: Config, ByteFee: Get<BalanceOf<T>>>(p: ProtocolStorageDeposit) -> BalanceOf<T> {
+pub fn calculate_protocol_deposit<T: Config, ByteFee: Get<BalanceOf<T>>>(
+	p: ProtocolStorageDeposit,
+) -> BalanceOf<T> {
 	let base: usize = match p {
 		ProtocolStorageDeposit::XcmQueries =>
 			KeyLenOf::<XcmQueries<T>>::get() as usize +
@@ -33,7 +35,7 @@ pub fn calculate_message_deposit<T: Config, ByteFee: Get<BalanceOf<T>>>() -> Bal
 }
 
 /// Blanket implementation of generating the deposit for a type that implements MaxEncodedLen.
-pub fn calculate_deposit_of<T: Config, ByteFee: Get<BalanceOf<T>>, U: MaxEncodedLen>() -> BalanceOf<T> {
+pub fn calculate_deposit_of<T: Config, ByteFee: Get<BalanceOf<T>>, U: MaxEncodedLen>(
+) -> BalanceOf<T> {
 	ByteFee::get() * U::max_encoded_len().saturated_into()
 }
-

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -262,9 +262,9 @@ pub mod pallet {
 			let origin = ensure_signed(origin)?;
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = 
-				calculate_protocol_deposit::<T, T::OnChainByteFee>(ProtocolStorageDeposit::IsmpRequests) +
-				calculate_message_deposit::<T, T::OnChainByteFee>() + 
+			let deposit = calculate_protocol_deposit::<T, T::OnChainByteFee>(
+				ProtocolStorageDeposit::IsmpRequests,
+			) + calculate_message_deposit::<T, T::OnChainByteFee>() +
 				calculate_deposit_of::<T, T::OffChainByteFee, ismp::Get<T>>();
 
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
@@ -326,9 +326,9 @@ pub mod pallet {
 			let origin = ensure_signed(origin)?;
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = 
-				calculate_protocol_deposit::<T, T::OnChainByteFee>(ProtocolStorageDeposit::IsmpRequests) +
-				calculate_message_deposit::<T, T::OnChainByteFee>() +
+			let deposit = calculate_protocol_deposit::<T, T::OnChainByteFee>(
+				ProtocolStorageDeposit::IsmpRequests,
+			) + calculate_message_deposit::<T, T::OnChainByteFee>() +
 				calculate_deposit_of::<T, T::OffChainByteFee, ismp::Post<T>>();
 
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
@@ -392,9 +392,9 @@ pub mod pallet {
 
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = 
-				calculate_protocol_deposit::<T, T::OnChainByteFee>(ProtocolStorageDeposit::IsmpRequests) +
-				calculate_message_deposit::<T, T::OnChainByteFee>();
+			let deposit = calculate_protocol_deposit::<T, T::OnChainByteFee>(
+				ProtocolStorageDeposit::IsmpRequests,
+			) + calculate_message_deposit::<T, T::OnChainByteFee>();
 
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
 

--- a/pallets/api/src/mock.rs
+++ b/pallets/api/src/mock.rs
@@ -240,10 +240,10 @@ impl<T: crate::messaging::Config> NotifyQueryHandler<T> for MockNotifyQuery<T> {
 }
 
 impl crate::messaging::Config for Test {
-	type ByteFee = TransactionByteFee;
+	type OnChainByteFee = TransactionByteFee;
 	type CallbackExecutor = MockCallbackExecutor<Test>;
 	type Deposit = Balances;
-	type IsmpByteFee = ();
+	type OffChainByteFee = ();
 	type IsmpDispatcher = MockIsmpDispatcher;
 	type MaxContextLen = ConstU32<64>;
 	type MaxDataLen = ConstU32<1024>;

--- a/pallets/api/src/mock.rs
+++ b/pallets/api/src/mock.rs
@@ -240,10 +240,8 @@ impl<T: crate::messaging::Config> NotifyQueryHandler<T> for MockNotifyQuery<T> {
 }
 
 impl crate::messaging::Config for Test {
-	type OnChainByteFee = TransactionByteFee;
 	type CallbackExecutor = MockCallbackExecutor<Test>;
 	type Deposit = Balances;
-	type OffChainByteFee = ();
 	type IsmpDispatcher = MockIsmpDispatcher;
 	type MaxContextLen = ConstU32<64>;
 	type MaxDataLen = ConstU32<1024>;
@@ -251,6 +249,8 @@ impl crate::messaging::Config for Test {
 	type MaxKeys = ConstU32<10>;
 	type MaxRemovals = ConstU32<1024>;
 	type MaxResponseLen = ConstU32<1024>;
+	type OffChainByteFee = ();
+	type OnChainByteFee = TransactionByteFee;
 	type OriginConverter = ();
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;

--- a/runtime/devnet/src/config/api/mod.rs
+++ b/runtime/devnet/src/config/api/mod.rs
@@ -112,12 +112,8 @@ impl nonfungibles::Config for Runtime {
 }
 
 impl messaging::Config for Runtime {
-	type OnChainByteFee = TransactionByteFee;
 	type CallbackExecutor = CallbackExecutor;
 	type Deposit = Balances;
-	// TODO: ISMP state written to offchain indexing, require some protection but perhaps not as
-	// much as onchain cost.
-	type OffChainByteFee = 	();
 	type IsmpDispatcher = Ismp;
 	type MaxContextLen = ConstU32<64>;
 	type MaxDataLen = ConstU32<1024>;
@@ -127,6 +123,10 @@ impl messaging::Config for Runtime {
 	type MaxRemovals = ConstU32<1024>;
 	// TODO: ensure within the contract buffer bounds
 	type MaxResponseLen = ConstU32<1024>;
+	// TODO: ISMP state written to offchain indexing, require some protection but perhaps not as
+	// much as onchain cost.
+	type OffChainByteFee = ();
+	type OnChainByteFee = TransactionByteFee;
 	type OriginConverter = LocalOriginToLocation;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;

--- a/runtime/devnet/src/config/api/mod.rs
+++ b/runtime/devnet/src/config/api/mod.rs
@@ -112,12 +112,12 @@ impl nonfungibles::Config for Runtime {
 }
 
 impl messaging::Config for Runtime {
-	type ByteFee = TransactionByteFee;
+	type OnChainByteFee = TransactionByteFee;
 	type CallbackExecutor = CallbackExecutor;
 	type Deposit = Balances;
 	// TODO: ISMP state written to offchain indexing, require some protection but perhaps not as
 	// much as onchain cost.
-	type IsmpByteFee = ();
+	type OffChainByteFee = 	();
 	type IsmpDispatcher = Ismp;
 	type MaxContextLen = ConstU32<64>;
 	type MaxDataLen = ConstU32<1024>;


### PR DESCRIPTION
This goes over most of the General section of the messaging pallet's tasks. 

## Losing ones deposit
Previously, in the extrinsics that take a message deposit, there was a possibility that the extrinsic would error before the message is stored and therefore when one tried to removed the message, it did not exist and therefore, the deposit could not be claimed. This has been fixed by moving much of the validation code before taking the deposit and then handling the fallible code after taking deposit more appropriately.

## Remove extrinsic
Notably the `remove` extrinsic has had a makeover so that it can be more comfortably unit tested.
I have moved much of the logic into the impl of `Message`, encapsulating the logic like this allowed me to cut down the complexity of the tests and the code.
Many tests have been written and cover all bases as far as im concerned.

The extrinsic has also been made transactional this is because we deposit an event at the end of the extrinsic that emits the messages removed, The previous implementation would remove messages without emitting an event which will be a pain for app devs . We could build it so it ignores erroneous messages and emits only the ones that pass but i thought this was a quick fix and i have lots to do thats of higher priority.

## MessageStatus
The `MessageStatus` has been introduced and ive moved away from combination of message status and message type.

Previously a message would be of type `IsmpTimedOut` now it is an `IsmpMessage` with the status of `TimedOut`.
This was done to differentiate between what a message is and what status it is in. I think this will allow more flexibility for messages in the future.  The downside is that one must handle all message statuses for a message and the previous version uses Rust's type system to enforce a messages status. This is the change im least confident about.

## Storage Deposits
Previously the deposit implementations were scattered around the codebase and there was a trait called `CalculateDeposits`. Following this code was more difficult than it had to be. I have made `deposits.rs` to contain all the deposit calculation code, and used a blanket implementation instead of the specific impls of the `CalculateDeposits`. This has improved readability nicely.
The `IsmpByteFee` is intended for Offchain storage costs hence it has been replaced with OffchainByteFee.
ByteFee has subsequently been changed to OnChainByteFee.

## Other
`CallbackT` has been renamed to CallbackExecutor for better semantics.
MessageId has been changed to a [u8; 32] from an unsigned integer. 



[sc-3066]