### PR TITLE
chore(runtime): include assetid migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13846,7 +13846,7 @@ dependencies = [
 
 [[package]]
 name = "pop-runtime-testnet"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "cumulus-pallet-aura-ext 0.18.0",

--- a/runtime/devnet/src/config/assets.rs
+++ b/runtime/devnet/src/config/assets.rs
@@ -132,7 +132,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type Balance = Balance;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
-	type CallbackHandle = ();
+	type CallbackHandle = pallet_assets::AutoIncAssetId<Runtime, TrustBackedAssetsInstance>;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type Currency = Balances;
 	type Extra = ();

--- a/runtime/devnet/src/genesis.rs
+++ b/runtime/devnet/src/genesis.rs
@@ -115,6 +115,7 @@ fn genesis(
 			metadata: Vec::from([
 				(0, "Paseo".into(), "PAS".into(), 10),
 			]),
+			next_asset_id: Some(1),
 			..Default::default()
 		},
 		"balances": BalancesConfig { balances: balances(endowed_accounts) },

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -154,6 +154,7 @@ fn genesis(
 		"assets": AssetsConfig {
 			assets: vec![],
 			metadata: vec![],
+			next_asset_id: Some(1),
 			..Default::default()
 		},
 		"balances": BalancesConfig { balances: balances(endowed_accounts) },
@@ -310,6 +311,14 @@ mod tests {
 		}
 
 		#[test]
+		fn ensure_genesis_next_assets_id_is_1() {
+			let genesis = development_config();
+
+			let next_asset_id = genesis["assets"]["nextAssetId"].as_u64().unwrap();
+			assert_eq!(next_asset_id, 1);
+		}
+
+		#[test]
 		fn ensure_council_members() {
 			let council_members = vec![
 				Keyring::Alice.to_account_id(),
@@ -454,6 +463,14 @@ mod tests {
 		}
 
 		#[test]
+		fn ensure_genesis_next_assets_id_is_1() {
+			let genesis = local_config();
+
+			let next_asset_id = genesis["assets"]["nextAssetId"].as_u64().unwrap();
+			assert_eq!(next_asset_id, 1);
+		}
+
+		#[test]
 		fn ensure_council_members() {
 			let council_members = vec![
 				Keyring::Alice.to_account_id(),
@@ -546,6 +563,14 @@ mod tests {
 
 			let assets = genesis["assets"]["assets"].as_array().unwrap();
 			assert!(assets.is_empty());
+		}
+
+		#[test]
+		fn ensure_genesis_next_assets_id_is_1() {
+			let genesis = live_config();
+
+			let next_asset_id = genesis["assets"]["nextAssetId"].as_u64().unwrap();
+			assert_eq!(next_asset_id, 1);
 		}
 
 		#[test]

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -62,6 +62,8 @@ pub use sp_runtime::{ExtrinsicInclusionMode, MultiAddress, Perbill, Permill};
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
+use crate::config::assets::TrustBackedAssetsInstance;
+
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
@@ -136,6 +138,11 @@ pub type UncheckedExtrinsic =
 type Migrations = (
 	// Unreleased.
 	config::governance::initiate_council_migration::SetCouncilors,
+	pallet_assets::migration::next_asset_id::SetNextAssetId<
+		ConstU32<1>,
+		Runtime,
+		TrustBackedAssetsInstance,
+	>,
 );
 
 /// Executive: handles dispatch to the various modules.

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -6,7 +6,7 @@ homepage.workspace = true
 license = "Unlicense"
 name = "pop-runtime-testnet"
 repository.workspace = true
-version = "0.5.0"
+version = "0.5.2"
 
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]

--- a/runtime/testnet/src/config/assets.rs
+++ b/runtime/testnet/src/config/assets.rs
@@ -39,7 +39,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type Balance = Balance;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
-	type CallbackHandle = pallet_assets::AutoIncAssetId<Runtime>;
+	type CallbackHandle = pallet_assets::AutoIncAssetId<Runtime, TrustBackedAssetsInstance>;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type Currency = Balances;
 	type Extra = ();

--- a/runtime/testnet/src/config/assets.rs
+++ b/runtime/testnet/src/config/assets.rs
@@ -39,7 +39,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type Balance = Balance;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
-	type CallbackHandle = ();
+	type CallbackHandle = pallet_assets::AutoIncAssetId<Runtime>;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type Currency = Balances;
 	type Extra = ();
@@ -62,7 +62,6 @@ parameter_types! {
 	pub const NftsDepositPerByte: Balance = deposit(0, 1);
 	pub const NftsMaxDeadlineDuration: BlockNumber = 12 * 30 * DAYS;
 }
-
 impl pallet_nfts::Config for Runtime {
 	// TODO: source from primitives
 	type ApprovalsLimit = ConstU32<20>;

--- a/runtime/testnet/src/genesis.rs
+++ b/runtime/testnet/src/genesis.rs
@@ -129,6 +129,7 @@ fn genesis(
 			metadata: Vec::from([
 				(0, "Paseo".into(), "PAS".into(), 10),
 			]),
+			next_asset_id: Some(1),
 			..Default::default()
 		},
 		"balances": BalancesConfig { balances: balances(endowed_accounts) },

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -71,6 +71,8 @@ use weights::{BlockExecutionWeight, ExtrinsicBaseWeight};
 // XCM Imports
 use xcm::latest::prelude::BodyId;
 
+use crate::config::assets::TrustBackedAssetsInstance;
+
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
@@ -143,6 +145,14 @@ pub type UncheckedExtrinsic =
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
 pub type Migrations = (
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
+	// Unreleased.
+	pallet_assets::migration::next_asset_id::SetNextAssetId<
+		// Higher AssetId on testnet live is `7_045`,
+		// rounded up to 10_000.
+		ConstU32<10_000>,
+		Runtime,
+		TrustBackedAssetsInstance,
+	>,
 	// Permanent.
 	pallet_contracts::Migration<Runtime>,
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
@@ -220,7 +230,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: Cow::Borrowed("pop"),
 	authoring_version: 1,
 	#[allow(clippy::zero_prefixed_literal)]
-	spec_version: 00_05_00,
+	spec_version: 00_05_02,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
- Includes a new migration to populate `NextAssetId` for pallet_assets. Sets the next id to `10_000` as the biggest id existing on testnet live right now is > `7_000` so I've rounded up to `10_000`.
- Configures `CallbackHandle` for `pallet_assets` such that asset id is automatically incremented after new assets creation.
- Adds similar state population for testnet genesis state.
- Bumps the spec version to `00_05_02`.
- Bump the runtime crate version to `0.5.2`.

--- 

- [x] Changes for mainnet runtime can be found in: https://github.com/r0gue-io/pop-node/pull/497
- [x] Changes for devnet runtime can be found in: https://github.com/r0gue-io/pop-node/pull/498

---

[sc-3216]