### PR TITLE
chore(mainnet): include assetid migration

### DIFF
--- a/runtime/mainnet/src/config/assets.rs
+++ b/runtime/mainnet/src/config/assets.rs
@@ -42,7 +42,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type Balance = Balance;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
-	type CallbackHandle = ();
+	type CallbackHandle = pallet_assets::AutoIncAssetId<Runtime, TrustBackedAssetsInstance>;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type Currency = Balances;
 	type Extra = ();
@@ -200,12 +200,12 @@ mod tests {
 		}
 
 		#[test]
-		fn callback_handle_is_default() {
+		fn callback_handle_is_auto_inc_asset_id() {
 			assert_eq!(
 				TypeId::of::<
 					<Runtime as pallet_assets::Config<TrustBackedAssetsInstance>>::CallbackHandle,
 				>(),
-				TypeId::of::<()>(),
+				TypeId::of::<pallet_assets::AutoIncAssetId<Runtime, TrustBackedAssetsInstance>>(),
 			);
 		}
 

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -154,6 +154,7 @@ fn genesis(
 		"assets": AssetsConfig {
 			assets: vec![],
 			metadata: vec![],
+			next_asset_id: Some(1),
 			..Default::default()
 		},
 		"balances": BalancesConfig { balances: balances(endowed_accounts) },
@@ -310,6 +311,14 @@ mod tests {
 		}
 
 		#[test]
+		fn ensure_genesis_next_assets_id_is_1() {
+			let genesis = development_config();
+
+			let next_asset_id = genesis["assets"]["nextAssetId"].as_u64().unwrap();
+			assert_eq!(next_asset_id, 1);
+		}
+
+		#[test]
 		fn ensure_council_members() {
 			let council_members = vec![
 				Keyring::Alice.to_account_id(),
@@ -454,6 +463,14 @@ mod tests {
 		}
 
 		#[test]
+		fn ensure_genesis_next_assets_id_is_1() {
+			let genesis = local_config();
+
+			let next_asset_id = genesis["assets"]["nextAssetId"].as_u64().unwrap();
+			assert_eq!(next_asset_id, 1);
+		}
+
+		#[test]
 		fn ensure_council_members() {
 			let council_members = vec![
 				Keyring::Alice.to_account_id(),
@@ -546,6 +563,14 @@ mod tests {
 
 			let assets = genesis["assets"]["assets"].as_array().unwrap();
 			assert!(assets.is_empty());
+		}
+
+		#[test]
+		fn ensure_genesis_next_assets_id_is_1() {
+			let genesis = live_config();
+
+			let next_asset_id = genesis["assets"]["nextAssetId"].as_u64().unwrap();
+			assert_eq!(next_asset_id, 1);
 		}
 
 		#[test]

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -62,6 +62,8 @@ pub use sp_runtime::{ExtrinsicInclusionMode, MultiAddress, Perbill, Permill};
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
+use crate::config::assets::TrustBackedAssetsInstance;
+
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
@@ -133,7 +135,14 @@ pub type UncheckedExtrinsic =
 ///
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
 #[allow(unused_parens)]
-type Migrations = ();
+type Migrations = (
+	// Unreleased.
+	pallet_assets::migration::next_asset_id::SetNextAssetId<
+		ConstU32<1>,
+		Runtime,
+		TrustBackedAssetsInstance,
+	>,
+);
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<


### PR DESCRIPTION
- Includes a new migration to populate `NextAssetId` for pallet_assets. Sets the next id to `1`.
- Adds similar state population for testnet genesis state.
- Configures `CallbackHandle` for `pallet_assets` such that the asset id is increased after the creation of a new asset.
- Includes tests for the runtime config as well as for the genesis config.