### PR TITLE
chore(governance): initiate council migration for mainnet runtime

### DIFF
--- a/runtime/mainnet/src/config/governance.rs
+++ b/runtime/mainnet/src/config/governance.rs
@@ -113,7 +113,7 @@ pub(crate) mod initiate_council_migration {
 			}
 
 			let members: Vec<AccountId> = Members::get();
-			pallet_collective::Members::<Runtime, CouncilCollective>::put(members.clone());
+			pallet_collective::Members::<Runtime, CouncilCollective>::put(members);
 			<Runtime as frame_system::Config>::DbWeight::get().reads_writes(1, 1)
 		}
 

--- a/runtime/mainnet/src/config/governance.rs
+++ b/runtime/mainnet/src/config/governance.rs
@@ -131,10 +131,14 @@ pub(crate) mod initiate_council_migration {
 
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+			let expected_members: Vec<AccountId> = Members::get();
 			let members_in_storage: Vec<AccountId> =
 				pallet_collective::Members::<Runtime, CouncilCollective>::get();
-			let expected_members: Vec<AccountId> = Members::get();
 
+			// Err if there are not 5 members in storage after the migration.
+			if members_in_storage.len() != 5 {
+				return Err(TryRuntimeError::Other("Migration didn't execute successfully."));
+			}
 			// Iterate over expected members and check if they are in storage.
 			for m in expected_members.iter() {
 				if !members_in_storage.contains(m) {

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -133,7 +133,10 @@ pub type UncheckedExtrinsic =
 ///
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
 #[allow(unused_parens)]
-type Migrations = ();
+type Migrations = (
+	// Unreleased.
+	config::governance::initiate_council_migration::SetCouncilors,
+);
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<


### PR DESCRIPTION
Introduces `OnRuntimeUpgrade` impl for `SetCouncilors`, initiating the council with some given members.
The migration is included in the runtime as unreleased, and can be removed once it has been executed on chain.

Tests are provide to demonstrate:
- the the migration does nothing if Members is already populated.
- the weight of `on_runtime_upgrade` is smaller than the maximum allowed in a block. (Can be fine tuned)

`pre_upgrade` and `post_upgrade` checks are provided for `try-runtime` feature.
- `post_upgrade` ensures that the members in storage after the upgrade contain the expected ones.
- `pre_upgrade` is implemented, but wasn't sure what to do with it as the council doesn't exist previous to the upgrade executing this migration. [Seems pre and post checks can only be executed together](https://github.com/paritytech/polkadot-sdk/blob/bcc272a1058f5b7cf9688a23b27d45349b66cb6a/substrate/frame/support/src/traits/try_runtime/mod.rs#L104-L105).

---

[sc-3216]