### PR TITLE
feat(messaging): callback gas topup

### DIFF
--- a/pallets/api/src/messaging/benchmarking.rs
+++ b/pallets/api/src/messaging/benchmarking.rs
@@ -406,7 +406,6 @@ mod messaging_benchmarks {
 		Pallet::<T>::ismp_post(RawOrigin::Signed(origin.clone()), message_id.into(), get, callback);
 	}
 
-
 	/// Tops up callback weight for callback execution of pending messages.
 	#[benchmark]
 	fn top_up_callback_weight() {

--- a/pallets/api/src/messaging/benchmarking.rs
+++ b/pallets/api/src/messaging/benchmarking.rs
@@ -406,6 +406,8 @@ mod messaging_benchmarks {
 		Pallet::<T>::ismp_post(RawOrigin::Signed(origin.clone()), message_id.into(), get, callback);
 	}
 
+
+	/// Tops up callback weight for callback execution of pending messages.
 	#[benchmark]
 	fn top_up_callback_weight() {
 		let origin: T::AccountId = account("alice", 0, SEED);

--- a/pallets/api/src/messaging/benchmarking.rs
+++ b/pallets/api/src/messaging/benchmarking.rs
@@ -47,7 +47,7 @@ mod messaging_benchmarks {
 		pallet_balances::Pallet::<T>::make_free_balance_be(&owner, u32::MAX.into());
 
 		for i in 0..x {
-			<T as crate::messaging::Config>::Deposit::hold(
+			<T as crate::messaging::Config>::Fungibles::hold(
 				&HoldReason::Messaging.into(),
 				&owner,
 				deposit,
@@ -184,7 +184,7 @@ mod messaging_benchmarks {
 
 		let weight = Weight::from_parts(100_000, 100_000);
 		let cb_gas_deposit = T::WeightToFee::weight_to_fee(&weight);
-		T::Deposit::hold(&HoldReason::CallbackGas.into(), &origin, cb_gas_deposit).unwrap();
+		T::Fungibles::hold(&HoldReason::CallbackGas.into(), &origin, cb_gas_deposit).unwrap();
 		// also hold for message deposit
 		let message_deposit = calculate_protocol_deposit::<T, T::OnChainByteFee>(
 			ProtocolStorageDeposit::IsmpRequests,
@@ -192,7 +192,7 @@ mod messaging_benchmarks {
 			calculate_deposit_of::<T, T::OffChainByteFee, ismp::Get<T>>();
 
 		// Take some extra so we dont need to complicate the benchmark further.
-		T::Deposit::hold(&HoldReason::Messaging.into(), &origin, message_deposit * 2u32.into())
+		T::Fungibles::hold(&HoldReason::Messaging.into(), &origin, message_deposit * 2u32.into())
 			.unwrap();
 
 		let callback = Some(Callback { selector: [0; 4], weight, abi: Abi::Scale });
@@ -404,6 +404,40 @@ mod messaging_benchmarks {
 
 		#[extrinsic_call]
 		Pallet::<T>::ismp_post(RawOrigin::Signed(origin.clone()), message_id.into(), get, callback);
+	}
+
+	#[benchmark]
+	fn top_up_callback_weight() {
+		let origin: T::AccountId = account("alice", 0, SEED);
+		let message_id = [0u8; 32];
+		let initial_weight = Weight::from_parts(100_000, 100_000);
+		let additional_weight = Weight::from_parts(150_000, 150_000);
+		let callback = Callback {
+			abi: Abi::Scale,
+			weight: initial_weight,
+			selector: [0u8; 4],
+		};
+
+		let message: Message<T> = Message::Ismp {
+			commitment: [10u8; 32].into(),
+			deposit: 100_000u32.into(),
+			callback: Some(callback),
+		};
+
+		Messages::<T>::insert(&origin, message_id, &message);
+
+		pallet_balances::Pallet::<T>::make_free_balance_be(
+			&origin,
+			pallet_balances::Pallet::<T>::total_issuance() / 2u32.into(),
+		);
+
+		#[extrinsic_call]
+		Pallet::<T>::top_up_callback_weight(RawOrigin::Signed(origin.clone()), message_id, additional_weight);
+
+		assert_has_event::<T>(Event::<T>::CallbackGasIncreased { 
+			message_id,
+			total_weight: initial_weight + additional_weight
+		}.into());
 	}
 
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/api/src/messaging/benchmarking.rs
+++ b/pallets/api/src/messaging/benchmarking.rs
@@ -412,11 +412,7 @@ mod messaging_benchmarks {
 		let message_id = [0u8; 32];
 		let initial_weight = Weight::from_parts(100_000, 100_000);
 		let additional_weight = Weight::from_parts(150_000, 150_000);
-		let callback = Callback {
-			abi: Abi::Scale,
-			weight: initial_weight,
-			selector: [0u8; 4],
-		};
+		let callback = Callback { abi: Abi::Scale, weight: initial_weight, selector: [0u8; 4] };
 
 		let message: Message<T> = Message::Ismp {
 			commitment: [10u8; 32].into(),
@@ -432,12 +428,19 @@ mod messaging_benchmarks {
 		);
 
 		#[extrinsic_call]
-		Pallet::<T>::top_up_callback_weight(RawOrigin::Signed(origin.clone()), message_id, additional_weight);
-
-		assert_has_event::<T>(Event::<T>::CallbackGasIncreased { 
+		Pallet::<T>::top_up_callback_weight(
+			RawOrigin::Signed(origin.clone()),
 			message_id,
-			total_weight: initial_weight + additional_weight
-		}.into());
+			additional_weight,
+		);
+
+		assert_has_event::<T>(
+			Event::<T>::CallbackGasIncreased {
+				message_id,
+				total_weight: initial_weight + additional_weight,
+			}
+			.into(),
+		);
 	}
 
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -697,10 +697,11 @@ pub mod pallet {
 		/// Top up the callback weight for a pending message.
 		///
 		/// This extrinsic allows users to increase the gas (weight) budget allocated for a callback
-		/// associated with an in-flight message. This is useful when the initially allocated weight is
-		/// insufficient to complete the callback.
+		/// associated with an in-flight message. This is useful when the initially allocated weight
+		/// is insufficient to complete the callback.
 		///
-		/// The additional fee for the new weight is held from the user's balance using the `HoldReason::CallbackGas`.
+		/// The additional fee for the new weight is held from the user's balance using the
+		/// `HoldReason::CallbackGas`.
 		///
 		/// Only pending requests can have their weight increased.
 		///
@@ -708,7 +709,8 @@ pub mod pallet {
 		///
 		/// - `origin`: Must be a signed account.
 		/// - `message_id`: The identifier of the message to be topped up.
-		/// - `additional_weight`: The additional weight to be appended to the message's existing callback weight.
+		/// - `additional_weight`: The additional weight to be appended to the message's existing
+		///   callback weight.
 		#[pallet::call_index(6)]
 		#[pallet::weight(Weight::zero())]
 		pub fn top_up_callback_weight(
@@ -728,39 +730,27 @@ pub mod pallet {
 				T::WeightToFee::weight_to_fee(&additional_weight),
 			)?;
 
-			Messages::<T>::try_mutate(&who, message_id, |maybe_message|{
+			Messages::<T>::try_mutate(&who, message_id, |maybe_message| {
 				if let Some(message) = maybe_message {
 					// Mutate to accrue new weight.
-					let total_weight  = match message {
-						Message::Ismp { callback, .. } => {
-							callback.as_mut().map_or_else(
-								|| Err(Error::<T>::NoCallbackFound).into(), 
-								|cb| Ok(cb.increase_callback_weight(additional_weight)), 
-							)
-						},
-						Message::XcmQuery { callback, .. } => {
-							callback.as_mut().map_or_else(
-								|| Err(Error::<T>::NoCallbackFound).into(), 
-								|cb| Ok(cb.increase_callback_weight(additional_weight)), 
-							)
-						},
-						Message::IsmpResponse { .. } => {
-							Err(Error::<T>::MessageCompleted).into()
-						},
-						Message::XcmResponse { .. } => {
-							Err(Error::<T>::MessageCompleted).into()
-						},
-						Message::IsmpTimeout { .. } => {
-							Err(Error::<T>::RequestTimedOut).into()
-						},
-						Message::XcmTimeout { .. } => {
-							Err(Error::<T>::RequestTimedOut).into()
-						},
+					let total_weight = match message {
+						Message::Ismp { callback, .. } => callback.as_mut().map_or_else(
+							|| Err(Error::<T>::NoCallbackFound).into(),
+							|cb| Ok(cb.increase_callback_weight(additional_weight)),
+						),
+						Message::XcmQuery { callback, .. } => callback.as_mut().map_or_else(
+							|| Err(Error::<T>::NoCallbackFound).into(),
+							|cb| Ok(cb.increase_callback_weight(additional_weight)),
+						),
+						Message::IsmpResponse { .. } => Err(Error::<T>::MessageCompleted).into(),
+						Message::XcmResponse { .. } => Err(Error::<T>::MessageCompleted).into(),
+						Message::IsmpTimeout { .. } => Err(Error::<T>::RequestTimedOut).into(),
+						Message::XcmTimeout { .. } => Err(Error::<T>::RequestTimedOut).into(),
 					}?;
 
 					Self::deposit_event(Event::<T>::CallbackGasIncreased {
 						message_id,
-						total_weight
+						total_weight,
 					})
 				} else {
 					return Err(Error::<T>::MessageNotFound).into();
@@ -881,8 +871,6 @@ impl<T: Config> Pallet<T> {
 				Ok(())
 			},
 		}
-
-		
 	}
 }
 
@@ -1045,7 +1033,7 @@ pub struct Callback {
 
 impl Callback {
 	pub(crate) fn increase_callback_weight(&mut self, additional_weight: Weight) -> Weight {
-		let new_callback_weight = self.weight.saturating_add(additional_weight);	
+		let new_callback_weight = self.weight.saturating_add(additional_weight);
 		self.weight = new_callback_weight;
 		new_callback_weight
 	}

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -696,9 +696,9 @@ pub mod pallet {
 
 		/// Top up the callback weight for a pending message.
 		///
-		/// This extrinsic allows an origin to increase the gas (weight) budget allocated for a callback
-		/// associated with an in-flight message. This is useful when the initially allocated weight
-		/// is insufficient to complete the callback.
+		/// This extrinsic allows an origin to increase the gas (weight) budget allocated for a
+		/// callback associated with an in-flight message. This is useful when the initially
+		/// allocated weight is insufficient to complete the callback.
 		///
 		/// The additional fee for the new weight is held from the origin using the
 		/// `HoldReason::CallbackGas`.

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -735,17 +735,17 @@ pub mod pallet {
 					// Mutate to accrue new weight.
 					let total_weight = match message {
 						Message::Ismp { callback, .. } => callback.as_mut().map_or_else(
-							|| Err(Error::<T>::NoCallbackFound).into(),
+							|| Err(Error::<T>::NoCallbackFound),
 							|cb| Ok(cb.increase_callback_weight(additional_weight)),
 						),
 						Message::XcmQuery { callback, .. } => callback.as_mut().map_or_else(
-							|| Err(Error::<T>::NoCallbackFound).into(),
+							|| Err(Error::<T>::NoCallbackFound),
 							|cb| Ok(cb.increase_callback_weight(additional_weight)),
 						),
-						Message::IsmpResponse { .. } => Err(Error::<T>::MessageCompleted).into(),
-						Message::XcmResponse { .. } => Err(Error::<T>::MessageCompleted).into(),
-						Message::IsmpTimeout { .. } => Err(Error::<T>::RequestTimedOut).into(),
-						Message::XcmTimeout { .. } => Err(Error::<T>::RequestTimedOut).into(),
+						Message::IsmpResponse { .. } => Err(Error::<T>::MessageCompleted),
+						Message::XcmResponse { .. } => Err(Error::<T>::MessageCompleted),
+						Message::IsmpTimeout { .. } => Err(Error::<T>::RequestTimedOut),
+						Message::XcmTimeout { .. } => Err(Error::<T>::RequestTimedOut),
 					}?;
 
 					Self::deposit_event(Event::<T>::CallbackGasIncreased {
@@ -753,7 +753,7 @@ pub mod pallet {
 						total_weight,
 					})
 				} else {
-					return Err(Error::<T>::MessageNotFound).into();
+					return Err(Error::<T>::MessageNotFound);
 				}
 
 				Ok(())

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -696,11 +696,11 @@ pub mod pallet {
 
 		/// Top up the callback weight for a pending message.
 		///
-		/// This extrinsic allows users to increase the gas (weight) budget allocated for a callback
+		/// This extrinsic allows an origin to increase the gas (weight) budget allocated for a callback
 		/// associated with an in-flight message. This is useful when the initially allocated weight
 		/// is insufficient to complete the callback.
 		///
-		/// The additional fee for the new weight is held from the user's balance using the
+		/// The additional fee for the new weight is held from the origin using the
 		/// `HoldReason::CallbackGas`.
 		///
 		/// Only pending requests can have their weight increased.
@@ -712,7 +712,7 @@ pub mod pallet {
 		/// - `additional_weight`: The additional weight to be appended to the message's existing
 		///   callback weight.
 		#[pallet::call_index(6)]
-		#[pallet::weight(Weight::zero())]
+		#[pallet::weight(T::WeightInfo::top_up_callback_weight())]
 		pub fn top_up_callback_weight(
 			origin: OriginFor<T>,
 			message_id: MessageId,

--- a/pallets/api/src/messaging/test_utils.rs
+++ b/pallets/api/src/messaging/test_utils.rs
@@ -25,7 +25,7 @@ mod benchmark_helpers {
 		host::StateMachine,
 		router::{GetRequest, GetResponse, PostResponse, StorageValue},
 	};
-	use sp_std::{vec::Vec, vec};
+	use sp_std::{vec, vec::Vec};
 
 	use super::ismp_post_request;
 

--- a/pallets/api/src/messaging/test_utils.rs
+++ b/pallets/api/src/messaging/test_utils.rs
@@ -1,4 +1,5 @@
 use ismp::{host::StateMachine, router::PostRequest};
+use sp_std::vec;
 
 #[cfg(any(feature = "runtime-benchmarks", test))]
 /// Constructs a dummy `PostRequest` used for testing or benchmarking.
@@ -24,7 +25,7 @@ mod benchmark_helpers {
 		host::StateMachine,
 		router::{GetRequest, GetResponse, PostResponse, StorageValue},
 	};
-	use sp_std::vec::Vec;
+	use sp_std::{vec::Vec, vec};
 
 	use super::ismp_post_request;
 

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -1574,19 +1574,15 @@ mod top_up_callback_weight {
 	fn ismp_pending_no_callback() {
 		new_test_ext().execute_with(|| {
 			let message_id = [0u8; 32];
-			let message = Message::Ismp {
-				commitment: Default::default(),
-				deposit: 100,
-				callback: None,
-			};
+			let message =
+				Message::Ismp { commitment: Default::default(), deposit: 100, callback: None };
 			let additional_weight = Weight::from_parts(100_000, 100_000);
 
 			Messages::<Test>::insert(ALICE, message_id, message);
-			assert_noop!(Messaging::top_up_callback_weight(
-				signed(ALICE),
-				message_id,
-				additional_weight
-			), Error::<Test>::NoCallbackFound);
+			assert_noop!(
+				Messaging::top_up_callback_weight(signed(ALICE), message_id, additional_weight),
+				Error::<Test>::NoCallbackFound
+			);
 		})
 	}
 
@@ -1594,20 +1590,14 @@ mod top_up_callback_weight {
 	fn xcm_pending_no_callback() {
 		new_test_ext().execute_with(|| {
 			let message_id = [0u8; 32];
-			let message = Message::XcmQuery {
-				query_id: 0,
-				deposit: 100,
-				callback: None,
-			};
+			let message = Message::XcmQuery { query_id: 0, deposit: 100, callback: None };
 			let additional_weight = Weight::from_parts(100_000, 100_000);
 
-
 			Messages::<Test>::insert(ALICE, message_id, message);
-			assert_noop!(Messaging::top_up_callback_weight(
-				signed(ALICE),
-				message_id,
-				additional_weight
-			), Error::<Test>::NoCallbackFound);
+			assert_noop!(
+				Messaging::top_up_callback_weight(signed(ALICE), message_id, additional_weight),
+				Error::<Test>::NoCallbackFound
+			);
 		})
 	}
 
@@ -1644,7 +1634,9 @@ mod top_up_callback_weight {
 				additional_weight
 			));
 
-			if let Some(Message::XcmQuery { callback, .. }) = Messages::<Test>::get(ALICE, message_id) {
+			if let Some(Message::XcmQuery { callback, .. }) =
+				Messages::<Test>::get(ALICE, message_id)
+			{
 				// Assert that weight has been accrued and deposit taken.
 				assert_eq!(callback.unwrap().weight, initial_weight + additional_weight);
 				let held = Balances::total_balance_on_hold(&ALICE);

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -1432,110 +1432,111 @@ mod top_up_callback_weight {
 
 	#[test]
 	fn message_not_found() {
-		new_test_ext().execute_with(|| {
-		})
+		new_test_ext().execute_with(|| {})
 	}
 
 	#[test]
 	fn zero_weight_is_err() {
-		new_test_ext().execute_with(|| {
-		})
+		new_test_ext().execute_with(|| {})
 	}
 
 	#[test]
 	fn ismp_response_is_err() {
 		new_test_ext().execute_with(|| {
+			let message_id = [0u8; 32];
+			let message = Message::IsmpResponse {
+				commitment: Default::default(),
+				deposit: 100,
+				response: Default::default(),
+			};
+			let weight = Weight::from_parts(100_000, 100_000);
 
-		let message_id = [0u8;32];
-		let message = Message::IsmpResponse {
-			commitment: Default::default(), 
-			deposit: 100,
-			response: Default::default(),
-		};
-		let weight = Weight::from_parts(100_000, 100_000);
-		
-		Messages::<Test>::insert(ALICE, message_id, message);
-		assert_noop!(Messaging::top_up_callback_weight(signed(ALICE), message_id, weight), Error::<Test>::MessageCompleted);
+			Messages::<Test>::insert(ALICE, message_id, message);
+			assert_noop!(
+				Messaging::top_up_callback_weight(signed(ALICE), message_id, weight),
+				Error::<Test>::MessageCompleted
+			);
 		})
 	}
 
 	#[test]
 	fn xcm_response_is_err() {
 		new_test_ext().execute_with(|| {
-		let message_id = [0u8;32];
-		let message = Message::XcmResponse {
-			query_id: 0, 
-			deposit: 100,
-			response: Response::Null,
-		};
-		let weight = Weight::from_parts(100_000, 100_000);
-		
-		Messages::<Test>::insert(ALICE, message_id, message);
-		assert_noop!(Messaging::top_up_callback_weight(signed(ALICE), message_id, weight), Error::<Test>::MessageCompleted);
+			let message_id = [0u8; 32];
+			let message =
+				Message::XcmResponse { query_id: 0, deposit: 100, response: Response::Null };
+			let weight = Weight::from_parts(100_000, 100_000);
+
+			Messages::<Test>::insert(ALICE, message_id, message);
+			assert_noop!(
+				Messaging::top_up_callback_weight(signed(ALICE), message_id, weight),
+				Error::<Test>::MessageCompleted
+			);
 		})
 	}
 
 	#[test]
 	fn xcm_timeout_is_err() {
 		new_test_ext().execute_with(|| {
-			let message_id = [0u8;32];
-		let message = Message::XcmTimeout {
-			query_id: 0, 
-			deposit: 100,
-		};
-		let weight = Weight::from_parts(100_000, 100_000);
-		
-		Messages::<Test>::insert(ALICE, message_id, message);
-		assert_noop!(Messaging::top_up_callback_weight(signed(ALICE), message_id, weight), Error::<Test>::RequestTimedOut);
+			let message_id = [0u8; 32];
+			let message = Message::XcmTimeout { query_id: 0, deposit: 100 };
+			let weight = Weight::from_parts(100_000, 100_000);
+
+			Messages::<Test>::insert(ALICE, message_id, message);
+			assert_noop!(
+				Messaging::top_up_callback_weight(signed(ALICE), message_id, weight),
+				Error::<Test>::RequestTimedOut
+			);
 		})
 	}
 
 	#[test]
 	fn ismp_timeout_is_err() {
 		new_test_ext().execute_with(|| {
-			let message_id = [0u8;32];
-		let message = Message::IsmpTimeout {
-			commitment: Default::default(), 
-			deposit: 100,
-		};
-		let weight = Weight::from_parts(100_000, 100_000);
-		
-		Messages::<Test>::insert(ALICE, message_id, message);
-		assert_noop!(Messaging::top_up_callback_weight(signed(ALICE), message_id, weight), Error::<Test>::RequestTimedOut);
+			let message_id = [0u8; 32];
+			let message = Message::IsmpTimeout { commitment: Default::default(), deposit: 100 };
+			let weight = Weight::from_parts(100_000, 100_000);
+
+			Messages::<Test>::insert(ALICE, message_id, message);
+			assert_noop!(
+				Messaging::top_up_callback_weight(signed(ALICE), message_id, weight),
+				Error::<Test>::RequestTimedOut
+			);
 		})
 	}
 
 	#[test]
 	fn ismp_pending_works() {
 		new_test_ext().execute_with(|| {
-			let message_id = [0u8;32];
+			let message_id = [0u8; 32];
 			let initial_weight = Weight::from_parts(150_000, 150_000);
 			let initial_fee = <Test as Config>::WeightToFee::weight_to_fee(&initial_weight);
-			let callback = Callback {
-				abi: Abi::Scale,
-				selector: [0u8; 4],
-				weight: initial_weight,
-			};
+			let callback = Callback { abi: Abi::Scale, selector: [0u8; 4], weight: initial_weight };
 			let message = Message::Ismp {
-				commitment: Default::default(), 
+				commitment: Default::default(),
 				deposit: 100,
 				callback: Some(callback),
 			};
 			let additional_weight = Weight::from_parts(100_000, 100_000);
 			let additional_fee = <Test as Config>::WeightToFee::weight_to_fee(&additional_weight);
-			
+
 			// take initial hold
 			<Test as crate::messaging::Config>::Fungibles::hold(
 				&HoldReason::Messaging.into(),
 				&ALICE,
 				initial_fee,
-			).unwrap();
+			)
+			.unwrap();
 
 			Messages::<Test>::insert(ALICE, message_id, message);
 
 			assert_ne!(additional_fee, 0);
 			assert_ne!(initial_fee, 0);
-			assert_ok!(Messaging::top_up_callback_weight(signed(ALICE), message_id, additional_weight));
+			assert_ok!(Messaging::top_up_callback_weight(
+				signed(ALICE),
+				message_id,
+				additional_weight
+			));
 
 			if let Some(Message::Ismp { callback, .. }) = Messages::<Test>::get(ALICE, message_id) {
 				assert_eq!(callback.unwrap().weight, initial_weight + additional_weight);
@@ -1544,31 +1545,26 @@ mod top_up_callback_weight {
 			} else {
 				panic!("Wrong message type or not found.");
 			}
-
 		})
 	}
 
 	#[test]
 	fn ismp_pending_no_callback() {
-		new_test_ext().execute_with(|| {
-		})
+		new_test_ext().execute_with(|| {})
 	}
 
 	#[test]
 	fn xcm_pending_no_callback() {
-		new_test_ext().execute_with(|| {
-		})
+		new_test_ext().execute_with(|| {})
 	}
 
 	#[test]
 	fn xcm_pending_works() {
-		new_test_ext().execute_with(|| {
-		})
+		new_test_ext().execute_with(|| {})
 	}
 
 	#[test]
 	fn assert_event() {
-		new_test_ext().execute_with(|| {
-		})
+		new_test_ext().execute_with(|| {})
 	}
 }

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -1432,12 +1432,33 @@ mod top_up_callback_weight {
 
 	#[test]
 	fn message_not_found() {
-		new_test_ext().execute_with(|| {})
+		new_test_ext().execute_with(|| {
+			let weight = Weight::from_parts(100_000, 100_000);
+			let message_id = [0u8; 32];
+			assert_noop!(
+				Messaging::top_up_callback_weight(signed(ALICE), message_id, weight),
+				Error::<Test>::MessageNotFound
+			);
+		})
 	}
 
 	#[test]
 	fn zero_weight_is_err() {
-		new_test_ext().execute_with(|| {})
+		new_test_ext().execute_with(|| {
+			let message_id = [0u8; 32];
+			let message = Message::IsmpResponse {
+				commitment: Default::default(),
+				deposit: 100,
+				response: Default::default(),
+			};
+			let weight = Weight::zero();
+
+			Messages::<Test>::insert(ALICE, message_id, message);
+			assert_noop!(
+				Messaging::top_up_callback_weight(signed(ALICE), message_id, weight),
+				Error::<Test>::ZeroWeight
+			);
+		})
 	}
 
 	#[test]
@@ -1539,6 +1560,7 @@ mod top_up_callback_weight {
 			));
 
 			if let Some(Message::Ismp { callback, .. }) = Messages::<Test>::get(ALICE, message_id) {
+				// Assert that weight has been accrued and deposit taken.
 				assert_eq!(callback.unwrap().weight, initial_weight + additional_weight);
 				let held = Balances::total_balance_on_hold(&ALICE);
 				assert_eq!(held, initial_fee + additional_fee);
@@ -1550,21 +1572,115 @@ mod top_up_callback_weight {
 
 	#[test]
 	fn ismp_pending_no_callback() {
-		new_test_ext().execute_with(|| {})
+		new_test_ext().execute_with(|| {
+			let message_id = [0u8; 32];
+			let message = Message::Ismp {
+				commitment: Default::default(),
+				deposit: 100,
+				callback: None,
+			};
+			let additional_weight = Weight::from_parts(100_000, 100_000);
+
+			Messages::<Test>::insert(ALICE, message_id, message);
+			assert_noop!(Messaging::top_up_callback_weight(
+				signed(ALICE),
+				message_id,
+				additional_weight
+			), Error::<Test>::NoCallbackFound);
+		})
 	}
 
 	#[test]
 	fn xcm_pending_no_callback() {
-		new_test_ext().execute_with(|| {})
+		new_test_ext().execute_with(|| {
+			let message_id = [0u8; 32];
+			let message = Message::XcmQuery {
+				query_id: 0,
+				deposit: 100,
+				callback: None,
+			};
+			let additional_weight = Weight::from_parts(100_000, 100_000);
+
+
+			Messages::<Test>::insert(ALICE, message_id, message);
+			assert_noop!(Messaging::top_up_callback_weight(
+				signed(ALICE),
+				message_id,
+				additional_weight
+			), Error::<Test>::NoCallbackFound);
+		})
 	}
 
 	#[test]
 	fn xcm_pending_works() {
-		new_test_ext().execute_with(|| {})
+		new_test_ext().execute_with(|| {
+			let message_id = [0u8; 32];
+			let initial_weight = Weight::from_parts(150_000, 150_000);
+			let initial_fee = <Test as Config>::WeightToFee::weight_to_fee(&initial_weight);
+			let callback = Callback { abi: Abi::Scale, selector: [0u8; 4], weight: initial_weight };
+			let message = Message::XcmQuery {
+				query_id: Default::default(),
+				deposit: 100,
+				callback: Some(callback),
+			};
+			let additional_weight = Weight::from_parts(100_000, 100_000);
+			let additional_fee = <Test as Config>::WeightToFee::weight_to_fee(&additional_weight);
+
+			// take initial hold
+			<Test as crate::messaging::Config>::Fungibles::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				initial_fee,
+			)
+			.unwrap();
+
+			Messages::<Test>::insert(ALICE, message_id, message);
+
+			assert_ne!(additional_fee, 0);
+			assert_ne!(initial_fee, 0);
+			assert_ok!(Messaging::top_up_callback_weight(
+				signed(ALICE),
+				message_id,
+				additional_weight
+			));
+
+			if let Some(Message::XcmQuery { callback, .. }) = Messages::<Test>::get(ALICE, message_id) {
+				// Assert that weight has been accrued and deposit taken.
+				assert_eq!(callback.unwrap().weight, initial_weight + additional_weight);
+				let held = Balances::total_balance_on_hold(&ALICE);
+				assert_eq!(held, initial_fee + additional_fee);
+			} else {
+				panic!("Wrong message type or not found.");
+			}
+		})
 	}
 
 	#[test]
 	fn assert_event() {
-		new_test_ext().execute_with(|| {})
+		new_test_ext().execute_with(|| {
+			let message_id = [0u8; 32];
+			let initial_weight = Weight::from_parts(150_000, 150_000);
+			let callback = Callback { abi: Abi::Scale, selector: [0u8; 4], weight: initial_weight };
+			let message = Message::XcmQuery {
+				query_id: Default::default(),
+				deposit: 100,
+				callback: Some(callback),
+			};
+			let additional_weight = Weight::from_parts(100_000, 100_000);
+
+			Messages::<Test>::insert(ALICE, message_id, message);
+
+			assert_ok!(Messaging::top_up_callback_weight(
+				signed(ALICE),
+				message_id,
+				additional_weight
+			));
+
+			let events = events();
+			assert!(events.contains(&Event::<Test>::CallbackGasIncreased {
+				message_id,
+				total_weight: initial_weight + additional_weight,
+			}));
+		})
 	}
 }

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -1426,3 +1426,149 @@ mod ismp_hooks {
 		}
 	}
 }
+
+mod top_up_callback_weight {
+	use super::*;
+
+	#[test]
+	fn message_not_found() {
+		new_test_ext().execute_with(|| {
+		})
+	}
+
+	#[test]
+	fn zero_weight_is_err() {
+		new_test_ext().execute_with(|| {
+		})
+	}
+
+	#[test]
+	fn ismp_response_is_err() {
+		new_test_ext().execute_with(|| {
+
+		let message_id = [0u8;32];
+		let message = Message::IsmpResponse {
+			commitment: Default::default(), 
+			deposit: 100,
+			response: Default::default(),
+		};
+		let weight = Weight::from_parts(100_000, 100_000);
+		
+		Messages::<Test>::insert(ALICE, message_id, message);
+		assert_noop!(Messaging::top_up_callback_weight(signed(ALICE), message_id, weight), Error::<Test>::MessageCompleted);
+		})
+	}
+
+	#[test]
+	fn xcm_response_is_err() {
+		new_test_ext().execute_with(|| {
+		let message_id = [0u8;32];
+		let message = Message::XcmResponse {
+			query_id: 0, 
+			deposit: 100,
+			response: Response::Null,
+		};
+		let weight = Weight::from_parts(100_000, 100_000);
+		
+		Messages::<Test>::insert(ALICE, message_id, message);
+		assert_noop!(Messaging::top_up_callback_weight(signed(ALICE), message_id, weight), Error::<Test>::MessageCompleted);
+		})
+	}
+
+	#[test]
+	fn xcm_timeout_is_err() {
+		new_test_ext().execute_with(|| {
+			let message_id = [0u8;32];
+		let message = Message::XcmTimeout {
+			query_id: 0, 
+			deposit: 100,
+		};
+		let weight = Weight::from_parts(100_000, 100_000);
+		
+		Messages::<Test>::insert(ALICE, message_id, message);
+		assert_noop!(Messaging::top_up_callback_weight(signed(ALICE), message_id, weight), Error::<Test>::RequestTimedOut);
+		})
+	}
+
+	#[test]
+	fn ismp_timeout_is_err() {
+		new_test_ext().execute_with(|| {
+			let message_id = [0u8;32];
+		let message = Message::IsmpTimeout {
+			commitment: Default::default(), 
+			deposit: 100,
+		};
+		let weight = Weight::from_parts(100_000, 100_000);
+		
+		Messages::<Test>::insert(ALICE, message_id, message);
+		assert_noop!(Messaging::top_up_callback_weight(signed(ALICE), message_id, weight), Error::<Test>::RequestTimedOut);
+		})
+	}
+
+	#[test]
+	fn ismp_pending_works() {
+		new_test_ext().execute_with(|| {
+			let message_id = [0u8;32];
+			let initial_weight = Weight::from_parts(150_000, 150_000);
+			let initial_fee = <Test as Config>::WeightToFee::weight_to_fee(&initial_weight);
+			let callback = Callback {
+				abi: Abi::Scale,
+				selector: [0u8; 4],
+				weight: initial_weight,
+			};
+			let message = Message::Ismp {
+				commitment: Default::default(), 
+				deposit: 100,
+				callback: Some(callback),
+			};
+			let additional_weight = Weight::from_parts(100_000, 100_000);
+			let additional_fee = <Test as Config>::WeightToFee::weight_to_fee(&additional_weight);
+			
+			// take initial hold
+			<Test as crate::messaging::Config>::Fungibles::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				initial_fee,
+			).unwrap();
+
+			Messages::<Test>::insert(ALICE, message_id, message);
+
+			assert_ne!(additional_fee, 0);
+			assert_ne!(initial_fee, 0);
+			assert_ok!(Messaging::top_up_callback_weight(signed(ALICE), message_id, additional_weight));
+
+			if let Some(Message::Ismp { callback, .. }) = Messages::<Test>::get(ALICE, message_id) {
+				assert_eq!(callback.unwrap().weight, initial_weight + additional_weight);
+				let held = Balances::total_balance_on_hold(&ALICE);
+				assert_eq!(held, initial_fee + additional_fee);
+			} else {
+				panic!("Wrong message type or not found.");
+			}
+
+		})
+	}
+
+	#[test]
+	fn ismp_pending_no_callback() {
+		new_test_ext().execute_with(|| {
+		})
+	}
+
+	#[test]
+	fn xcm_pending_no_callback() {
+		new_test_ext().execute_with(|| {
+		})
+	}
+
+	#[test]
+	fn xcm_pending_works() {
+		new_test_ext().execute_with(|| {
+		})
+	}
+
+	#[test]
+	fn assert_event() {
+		new_test_ext().execute_with(|| {
+		})
+	}
+}

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -603,7 +603,6 @@ mod xcm_new_query {
 	fn takes_messaging_hold() {
 		new_test_ext().execute_with(|| {
 			let timeout = System::block_number() + 1;
-			let weight = Weight::from_parts(100_000_000, 100_000_000);
 			let callback = None;
 			let message_id = [0; 32];
 			let expected_deposit =

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -188,6 +188,7 @@ impl<T: Config> IsmpModuleWeight for Pallet<T> {
 		};
 
 		T::WeightInfo::ismp_on_response(x).saturating_add(T::CallbackExecutor::execution_weight())
+		// Also add actual weight consumed by contract env.
 	}
 }
 

--- a/pallets/api/src/messaging/weights.rs
+++ b/pallets/api/src/messaging/weights.rs
@@ -8,6 +8,7 @@ pub trait WeightInfo {
 	fn ismp_on_timeout(x: u32) -> Weight;
 	fn ismp_get(x: u32, y: u32, a: u32) -> Weight;
 	fn ismp_post(x: u32, y: u32) -> Weight;
+	fn top_up_callback_weight() -> Weight;
 }
 
 #[cfg(test)]
@@ -37,6 +38,10 @@ impl WeightInfo for () {
 	}
 
 	fn ismp_post(_x: u32, _y: u32) -> Weight {
+		Default::default()
+	}
+	
+	fn top_up_callback_weight() -> Weight {
 		Default::default()
 	}
 }

--- a/pallets/api/src/messaging/weights.rs
+++ b/pallets/api/src/messaging/weights.rs
@@ -40,7 +40,7 @@ impl WeightInfo for () {
 	fn ismp_post(_x: u32, _y: u32) -> Weight {
 		Default::default()
 	}
-	
+
 	fn top_up_callback_weight() -> Weight {
 		Default::default()
 	}

--- a/pallets/api/src/mock.rs
+++ b/pallets/api/src/mock.rs
@@ -320,6 +320,10 @@ impl crate::messaging::WeightInfo for DummyPrepaymentWeights {
 	fn ismp_post(_x: u32, _y: u32) -> Weight {
 		Zero::zero()
 	}
+
+	fn top_up_callback_weight() -> Weight {
+		Zero::zero()
+	}
 }
 
 pub struct Keccak;

--- a/runtime/devnet/src/weights/messaging_weights.rs
+++ b/runtime/devnet/src/weights/messaging_weights.rs
@@ -405,4 +405,21 @@ impl<T: frame_system::Config> pallet_api::messaging::WeightInfo for WeightInfo<T
 			.saturating_add(Weight::from_parts(0, 816).saturating_mul(x.into()))
 			.saturating_add(Weight::from_parts(0, 8448).saturating_mul(y.into()))
 	}
+
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Holds` (r:1 w:1)
+	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(211), added: 2686, mode: `MaxEncodedLen`)
+	/// Storage: `Messaging::Messages` (r:1 w:1)
+	/// Proof: `Messaging::Messages` (`max_values`: None, `max_size`: Some(12842), added: 15317, mode: `MaxEncodedLen`)
+	fn top_up_callback_weight() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `366`
+		//  Estimated: `16307`
+		// Minimum execution time: 31_000_000 picoseconds.
+		Weight::from_parts(34_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 16307))
+			.saturating_add(T::DbWeight::get().reads(3))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
 }


### PR DESCRIPTION
As mentioned in the telegram allow people to top up callback gas for requesting messages.
Was low hanging fruit so thought id get it in before the ismp_weight issue call.

[sc-3601]