### PR TITLE
feat(devnet): revive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13728,6 +13728,7 @@ dependencies = [
  "pallet-nfts-runtime-api 25.0.0",
  "pallet-preimage 39.0.0",
  "pallet-proxy 39.0.0",
+ "pallet-revive",
  "pallet-scheduler 40.0.0",
  "pallet-session 39.0.0",
  "pallet-sudo 39.0.0",

--- a/runtime/devnet/Cargo.toml
+++ b/runtime/devnet/Cargo.toml
@@ -50,6 +50,7 @@ pallet-nft-fractionalization.workspace = true
 pallet-nfts-runtime-api.workspace = true
 pallet-preimage.workspace = true
 pallet-proxy.workspace = true
+pallet-revive.workspace = true
 pallet-scheduler.workspace = true
 pallet-session.workspace = true
 pallet-sudo.workspace = true
@@ -147,6 +148,7 @@ std = [
 	"pallet-nfts/std",
 	"pallet-preimage/std",
 	"pallet-proxy/std",
+	"pallet-revive/std",
 	"pallet-scheduler/std",
 	"pallet-session/std",
 	"pallet-sudo/std",
@@ -204,6 +206,7 @@ runtime-benchmarks = [
 	"pallet-nfts/runtime-benchmarks",
 	"pallet-preimage/runtime-benchmarks",
 	"pallet-proxy/runtime-benchmarks",
+	"pallet-revive/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
@@ -244,6 +247,7 @@ try-runtime = [
 	"pallet-nfts/try-runtime",
 	"pallet-preimage/try-runtime",
 	"pallet-proxy/try-runtime",
+	"pallet-revive/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"pallet-session/try-runtime",
 	"pallet-sudo/try-runtime",

--- a/runtime/devnet/src/config/contracts.rs
+++ b/runtime/devnet/src/config/contracts.rs
@@ -2,14 +2,15 @@ use core::marker::PhantomData;
 
 use frame_support::{
 	parameter_types,
-	traits::{ConstBool, ConstU32, Nothing, Randomness},
+	traits::{ConstBool, ConstU32, ConstU64, Nothing, Randomness},
 };
 use frame_system::{pallet_prelude::BlockNumberFor, EnsureSigned};
+use pop_runtime_common::UNIT;
 
 use super::api::{self, Config};
 use crate::{
-	deposit, Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
-	Timestamp,
+	deposit, Balance, Balances, Perbill, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
+	RuntimeHoldReason, Timestamp, TransactionPayment,
 };
 
 fn schedule<T: pallet_contracts::Config>() -> pallet_contracts::Schedule<T> {
@@ -33,12 +34,16 @@ impl<T: pallet_contracts::Config> Randomness<T::Hash, BlockNumberFor<T>> for Dum
 	}
 }
 
+// 18 decimals
+const ETH: u128 = 1_000_000_000_000_000_000;
+
 parameter_types! {
 	pub const DepositPerItem: Balance = deposit(1, 0);
 	pub const DepositPerByte: Balance = deposit(0, 1);
 	pub Schedule: pallet_contracts::Schedule<Runtime> = schedule::<Runtime>();
 	pub const DefaultDepositLimit: Balance = deposit(1024, 1024 * 1024);
 	pub const CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);
+	pub const NativeToEthRatio: u32 = (ETH/UNIT) as u32;
 }
 
 impl pallet_contracts::Config for Runtime {
@@ -81,6 +86,49 @@ impl pallet_contracts::Config for Runtime {
 	type WeightInfo = pallet_contracts::weights::SubstrateWeight<Self>;
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
 	type Xcm = pallet_xcm::Pallet<Self>;
+}
+
+impl pallet_revive::Config for Runtime {
+	type AddressMapper = pallet_revive::AccountId32Mapper<Self>;
+	// No runtime dispatchables are callable from contracts.
+	type CallFilter = Nothing;
+	type ChainExtension = ();
+	// EVM chain id. 3,395 is a unique ID still.
+	type ChainId = ConstU64<3_395>;
+	// 30 percent of storage deposit held for using a code hash.
+	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
+	type Currency = Balances;
+	type Debug = ();
+	type DepositPerByte = DepositPerByte;
+	type DepositPerItem = DepositPerItem;
+	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
+	// 1 ETH : 1_000_000 UNIT
+	type NativeToEthRatio = NativeToEthRatio;
+	// 512 MB. Used in an integrity test that verifies the runtime has enough memory.
+	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	// 128 MB. Used in an integrity that verifies the runtime has enough memory.
+	type RuntimeMemory = ConstU32<{ 128 * 1024 * 1024 }>;
+	type Time = Timestamp;
+	// Disables access to unsafe host fns such as xcm_send.
+	type UnsafeUnstableInterface = ConstBool<false>;
+	type UploadOrigin = EnsureSigned<Self::AccountId>;
+	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
+	type WeightPrice = TransactionPayment;
+	type Xcm = PolkadotXcm;
+}
+
+impl TryFrom<RuntimeCall> for pallet_revive::Call<Runtime> {
+	type Error = ();
+
+	fn try_from(value: RuntimeCall) -> Result<Self, Self::Error> {
+		match value {
+			RuntimeCall::Revive(call) => Ok(call),
+			_ => Err(()),
+		}
+	}
 }
 
 // IMPORTANT: only runtime calls through the api are allowed.

--- a/runtime/devnet/src/config/contracts.rs
+++ b/runtime/devnet/src/config/contracts.rs
@@ -38,11 +38,13 @@ impl<T: pallet_contracts::Config> Randomness<T::Hash, BlockNumberFor<T>> for Dum
 const ETH: u128 = 1_000_000_000_000_000_000;
 
 parameter_types! {
+	pub ChainId: u64 = u32::from(crate::genesis::PARA_ID) as u64;
 	pub const DepositPerItem: Balance = deposit(1, 0);
 	pub const DepositPerByte: Balance = deposit(0, 1);
 	pub Schedule: pallet_contracts::Schedule<Runtime> = schedule::<Runtime>();
 	pub const DefaultDepositLimit: Balance = deposit(1024, 1024 * 1024);
-	pub const CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);
+	// 30 percent of storage deposit held for using a code hash.
+	pub const CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
 	pub const NativeToEthRatio: u32 = (ETH/UNIT) as u32;
 }
 
@@ -93,9 +95,7 @@ impl pallet_revive::Config for Runtime {
 	// No runtime dispatchables are callable from contracts.
 	type CallFilter = Nothing;
 	type ChainExtension = ();
-	// EVM chain id. 3,395 is a unique ID still.
-	type ChainId = ConstU64<3_395>;
-	// 30 percent of storage deposit held for using a code hash.
+	type ChainId = ChainId;
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type Currency = Balances;
 	type Debug = ();


### PR DESCRIPTION
Adds revive to the devnet runtime.

This is to ensure devs can deploy revive contracts on a local devnet.

Consider the upcoming PRs:
- 2503 upgrade
  - [ ] https://github.com/r0gue-io/pop-node/pull/524/
  - [ ] https://github.com/r0gue-io/pop-node/pull/525
- Sync devnet with mainnet (includes removal of pallet contracts)
- Add api to revive