### PR TITLE
chore: `BlockNumberProvider` for multisig, nfts & proxy

### DIFF
--- a/runtime/devnet/src/config/assets.rs
+++ b/runtime/devnet/src/config/assets.rs
@@ -11,7 +11,7 @@ use sp_runtime::traits::Verify;
 
 use crate::{
 	deposit, AccountId, Assets, Balance, Balances, BlockNumber, Nfts, Runtime, RuntimeEvent,
-	RuntimeHoldReason, DAYS, EXISTENTIAL_DEPOSIT, UNIT,
+	RuntimeHoldReason, System, DAYS, EXISTENTIAL_DEPOSIT, UNIT,
 };
 
 /// We allow root to execute privileged asset operations.

--- a/runtime/devnet/src/config/proxy.rs
+++ b/runtime/devnet/src/config/proxy.rs
@@ -6,7 +6,7 @@ use pop_runtime_common::proxy::{
 use sp_runtime::traits::BlakeTwo256;
 
 use super::assets::{TrustBackedAssetsCall, TrustBackedNftsCall};
-use crate::{Balances, Runtime, RuntimeCall, RuntimeEvent};
+use crate::{Balances, Runtime, RuntimeCall, RuntimeEvent, System};
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
@@ -97,6 +97,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 impl pallet_proxy::Config for Runtime {
 	type AnnouncementDepositBase = AnnouncementDepositBase;
 	type AnnouncementDepositFactor = AnnouncementDepositFactor;
+	type BlockNumberProvider = System;
 	type CallHasher = BlakeTwo256;
 	type Currency = Balances;
 	type MaxPending = MaxPending;

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -542,6 +542,7 @@ parameter_types! {
 }
 
 impl pallet_multisig::Config for Runtime {
+	type BlockNumberProvider = System;
 	type Currency = Balances;
 	type DepositBase = DepositBase;
 	type DepositFactor = DepositFactor;

--- a/runtime/mainnet/src/config/assets.rs
+++ b/runtime/mainnet/src/config/assets.rs
@@ -10,7 +10,7 @@ use sp_runtime::traits::Verify;
 
 use crate::{
 	config::monetary::ExistentialDeposit, deposit, weights, AccountId, Balance, Balances,
-	BlockNumber, Runtime, RuntimeEvent, DAYS,
+	BlockNumber, Runtime, RuntimeEvent, System, DAYS,
 };
 
 /// We allow root to execute privileged asset operations.
@@ -78,6 +78,7 @@ parameter_types! {
 impl pallet_nfts::Config for Runtime {
 	type ApprovalsLimit = ConstU32<20>;
 	type AttributeDepositBase = NftsAttributeDepositBase;
+	type BlockNumberProvider = System;
 	type CollectionDeposit = NftsCollectionDeposit;
 	type CollectionId = CollectionId;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
@@ -358,6 +359,14 @@ mod tests {
 				Blake2_128Concat::max_len::<AttributeNamespace<AccountId>>();
 			assert_eq!(key_size, 89);
 			assert_eq!(deposit(1, key_size as u32) / 100, NftsAttributeDepositBase::get());
+		}
+
+		#[test]
+		fn ensure_system_is_block_number_provider() {
+			assert_eq!(
+				TypeId::of::<<Runtime as pallet_nfts::Config>::BlockNumberProvider>(),
+				TypeId::of::<System>(),
+			);
 		}
 
 		#[test]

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -4,7 +4,7 @@ use pop_runtime_common::proxy::{MaxPending, MaxProxies, ProxyType};
 
 use crate::{
 	config::assets::TrustBackedAssetsCall, deposit, parameter_types, weights, Balance, Balances,
-	BlakeTwo256, Runtime, RuntimeCall, RuntimeEvent,
+	BlakeTwo256, Runtime, RuntimeCall, RuntimeEvent, System,
 };
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
@@ -106,6 +106,7 @@ parameter_types! {
 impl pallet_proxy::Config for Runtime {
 	type AnnouncementDepositBase = AnnouncementDepositBase;
 	type AnnouncementDepositFactor = AnnouncementDepositFactor;
+	type BlockNumberProvider = System;
 	type CallHasher = BlakeTwo256;
 	type Currency = Balances;
 	type MaxPending = MaxPending;
@@ -189,6 +190,14 @@ mod tests {
 		assert_eq!(
 			<<Runtime as Config>::AnnouncementDepositFactor as Get<Balance>>::get(),
 			deposit(0, 68),
+		);
+	}
+
+	#[test]
+	fn ensure_system_is_block_number_provider() {
+		assert_eq!(
+			TypeId::of::<<Runtime as Config>::BlockNumberProvider>(),
+			TypeId::of::<System>(),
 		);
 	}
 

--- a/runtime/mainnet/src/config/utility.rs
+++ b/runtime/mainnet/src/config/utility.rs
@@ -2,7 +2,7 @@ use crate::{
 	config::system::RuntimeBlockWeights, deposit, parameter_types, weights, AccountId, Balance,
 	Balances, ConstU32, EnsureRoot, EqualPrivilegeOnly, HoldConsideration, LinearStoragePrice,
 	OriginCaller, Perbill, Preimage, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
-	RuntimeOrigin, Weight,
+	RuntimeOrigin, System, Weight,
 };
 
 parameter_types! {
@@ -15,6 +15,7 @@ parameter_types! {
 }
 
 impl pallet_multisig::Config for Runtime {
+	type BlockNumberProvider = System;
 	type Currency = Balances;
 	type DepositBase = DepositBase;
 	type DepositFactor = DepositFactor;
@@ -86,6 +87,14 @@ mod tests {
 		use parachains_common::BlockNumber;
 
 		use super::*;
+
+		#[test]
+		fn ensure_system_is_block_number_provider() {
+			assert_eq!(
+				TypeId::of::<<Runtime as pallet_multisig::Config>::BlockNumberProvider>(),
+				TypeId::of::<System>(),
+			);
+		}
 
 		#[test]
 		fn balances_is_used_for_deposits() {

--- a/runtime/testnet/src/config/assets.rs
+++ b/runtime/testnet/src/config/assets.rs
@@ -11,7 +11,7 @@ use sp_runtime::traits::Verify;
 
 use crate::{
 	deposit, AccountId, Assets, Balance, Balances, BlockNumber, Nfts, Runtime, RuntimeEvent,
-	RuntimeHoldReason, DAYS, EXISTENTIAL_DEPOSIT, UNIT,
+	RuntimeHoldReason, System, DAYS, EXISTENTIAL_DEPOSIT, UNIT,
 };
 
 /// We allow root to execute privileged asset operations.
@@ -66,6 +66,7 @@ impl pallet_nfts::Config for Runtime {
 	// TODO: source from primitives
 	type ApprovalsLimit = ConstU32<20>;
 	type AttributeDepositBase = NftsAttributeDepositBase;
+	type BlockNumberProvider = System;
 	type CollectionDeposit = NftsCollectionDeposit;
 	// TODO: source from primitives
 	type CollectionId = CollectionId;

--- a/runtime/testnet/src/config/proxy.rs
+++ b/runtime/testnet/src/config/proxy.rs
@@ -7,7 +7,7 @@ use pop_runtime_common::proxy::{
 use sp_runtime::traits::BlakeTwo256;
 
 use super::assets::TrustBackedAssetsCall;
-use crate::{Balances, Runtime, RuntimeCall, RuntimeEvent};
+use crate::{Balances, Runtime, RuntimeCall, RuntimeEvent, System};
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
@@ -98,6 +98,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 impl pallet_proxy::Config for Runtime {
 	type AnnouncementDepositBase = AnnouncementDepositBase;
 	type AnnouncementDepositFactor = AnnouncementDepositFactor;
+	type BlockNumberProvider = System;
 	type CallHasher = BlakeTwo256;
 	type Currency = Balances;
 	type MaxPending = MaxPending;

--- a/runtime/testnet/src/config/utility.rs
+++ b/runtime/testnet/src/config/utility.rs
@@ -8,7 +8,7 @@ use parachains_common::Balance;
 
 use crate::{
 	config::system::RuntimeBlockWeights, deposit, AccountId, Balances, OriginCaller, Perbill,
-	Preimage, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin, Weight,
+	Preimage, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin, System, Weight,
 };
 
 parameter_types! {
@@ -20,6 +20,7 @@ parameter_types! {
 }
 
 impl pallet_multisig::Config for Runtime {
+	type BlockNumberProvider = System;
 	type Currency = Balances;
 	type DepositBase = DepositBase;
 	type DepositFactor = DepositFactor;


### PR DESCRIPTION
Changes for [polkadot-sdk#5723](https://github.com/paritytech/polkadot-sdk/pull/5723).

This PR adds the ability for these pallets to specify their source of the block number.
They have been all configured to depend on the local block number.

Note that `pallet_nfts` in devnet is using a local forked version of the pallet, not depending on the newer version upstream.
Tests to ensure these configurations have been added to mainnet runtime.

---

[sc-3547]