### PR TITLE
chore: add `BlockNumberProvider` to `pallet_scheduler`

### DIFF
--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -499,6 +499,7 @@ parameter_types! {
 }
 
 impl pallet_scheduler::Config for Runtime {
+	type BlockNumberProvider = System;
 	#[cfg(feature = "runtime-benchmarks")]
 	type MaxScheduledPerBlock = ConstU32<512>;
 	#[cfg(not(feature = "runtime-benchmarks"))]

--- a/runtime/mainnet/src/config/utility.rs
+++ b/runtime/mainnet/src/config/utility.rs
@@ -2,7 +2,7 @@ use crate::{
 	config::system::RuntimeBlockWeights, deposit, parameter_types, weights, AccountId, Balance,
 	Balances, ConstU32, EnsureRoot, EqualPrivilegeOnly, HoldConsideration, LinearStoragePrice,
 	OriginCaller, Perbill, Preimage, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
-	RuntimeOrigin, Weight,
+	RuntimeOrigin, System, Weight,
 };
 
 parameter_types! {
@@ -51,6 +51,7 @@ parameter_types! {
 }
 
 impl pallet_scheduler::Config for Runtime {
+	type BlockNumberProvider = System;
 	#[cfg(feature = "runtime-benchmarks")]
 	type MaxScheduledPerBlock = ConstU32<512>;
 	#[cfg(not(feature = "runtime-benchmarks"))]
@@ -205,6 +206,14 @@ mod tests {
 
 	mod scheduler {
 		use super::*;
+
+		#[test]
+		fn ensure_system_is_block_number_provider() {
+			assert_eq!(
+				TypeId::of::<<Runtime as pallet_scheduler::Config>::BlockNumberProvider>(),
+				TypeId::of::<System>(),
+			);
+		}
 
 		#[test]
 		#[cfg(feature = "runtime-benchmarks")]

--- a/runtime/testnet/src/config/utility.rs
+++ b/runtime/testnet/src/config/utility.rs
@@ -8,7 +8,7 @@ use parachains_common::Balance;
 
 use crate::{
 	config::system::RuntimeBlockWeights, deposit, AccountId, Balances, OriginCaller, Perbill,
-	Preimage, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin, Weight,
+	Preimage, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin, System, Weight,
 };
 
 parameter_types! {
@@ -54,6 +54,7 @@ parameter_types! {
 }
 
 impl pallet_scheduler::Config for Runtime {
+	type BlockNumberProvider = System;
 	#[cfg(feature = "runtime-benchmarks")]
 	type MaxScheduledPerBlock = ConstU32<512>;
 	#[cfg(not(feature = "runtime-benchmarks"))]


### PR DESCRIPTION
Changes for [polkadot-sdk#7441](https://github.com/paritytech/polkadot-sdk/pull/7441).

This PR adds the ability for this pallet to specify its source of the block number.
`pallet_scheduler` has been configured to depend on the local block number.

A test to ensure this configurations has been added to mainnet runtime.

---

[sc-3547]