### PR TITLE
chore: substitute `AccountKeyring` with `Sr25519Keyring`

### DIFF
--- a/runtime/mainnet/src/config/assets.rs
+++ b/runtime/mainnet/src/config/assets.rs
@@ -118,7 +118,7 @@ mod tests {
 	mod assets {
 		use frame_support::traits::Incrementable;
 		use pallet_assets::{AssetsCallback, NextAssetId};
-		use sp_keyring::AccountKeyring::Alice;
+		use sp_keyring::Sr25519Keyring::Alice;
 
 		use super::*;
 		use crate::System;

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -134,7 +134,7 @@ mod tests {
 
 	#[test]
 	fn proxy_type_assets_can_only_transfer_assets() {
-		use sp_keyring::AccountKeyring::Alice;
+		use sp_keyring::Sr25519Keyring::Alice;
 		let alice_address = MultiAddress::Id(Alice.to_account_id());
 
 		// Assert proxy type whitelists any asset related call.
@@ -247,7 +247,7 @@ mod tests {
 
 	// Returns a list with some calls transferring assets.
 	fn asset_transfer_calls() -> Vec<RuntimeCall> {
-		use sp_keyring::AccountKeyring::Alice;
+		use sp_keyring::Sr25519Keyring::Alice;
 		let alice_address = MultiAddress::Id(Alice.to_account_id());
 
 		vec![

--- a/runtime/mainnet/src/config/xcm.rs
+++ b/runtime/mainnet/src/config/xcm.rs
@@ -297,7 +297,7 @@ mod tests {
 	use polkadot_runtime_common::xcm_sender::*;
 	use polkadot_runtime_parachains::FeeTracker;
 	use sp_core::crypto::Ss58Codec;
-	use sp_keyring::AccountKeyring;
+	use sp_keyring::Sr25519Keyring;
 	use sp_runtime::FixedPointNumber;
 	use xcm_executor::traits::{ConvertLocation, FeeManager, FeeReason};
 
@@ -366,7 +366,7 @@ mod tests {
 					1,
 					[AccountId32 {
 						network: None,
-						id: AccountKeyring::Alice.to_account_id().into(),
+						id: Sr25519Keyring::Alice.to_account_id().into(),
 					}],
 				),
 				expected_account_id_str: "5EueAXd4h8u75nSbFdDJbC29cmi4Uo1YJssqEL9idvindxFL",
@@ -379,7 +379,7 @@ mod tests {
 						Parachain(1111),
 						Junction::AccountId32 {
 							network: None,
-							id: AccountKeyring::Alice.to_account_id().into(),
+							id: Sr25519Keyring::Alice.to_account_id().into(),
 						},
 					],
 				),


### PR DESCRIPTION
As per [polkadot-sdk#5899](https://github.com/paritytech/polkadot-sdk/pull/5899).

This PR substitutes all occurrences of `AccountKeyring` with `Sr25519Keyring`.

---

[sc-3547]