### PR TITLE
chore: Configurable number of genesis accounts in pallet_balances

### DIFF
--- a/integration-tests/src/chains/asset_hub/genesis.rs
+++ b/integration-tests/src/chains/asset_hub/genesis.rs
@@ -24,6 +24,7 @@ pub(crate) fn genesis() -> Storage {
 				.cloned()
 				.map(|k| (k, ED * 4096 * 4096))
 				.collect(),
+			..Default::default()
 		},
 		parachain_info: ParachainInfoConfig { parachain_id: PARA_ID.into(), ..Default::default() },
 		collator_selection: CollatorSelectionConfig {

--- a/integration-tests/src/chains/relay/genesis.rs
+++ b/integration-tests/src/chains/relay/genesis.rs
@@ -24,6 +24,7 @@ pub(crate) fn genesis() -> Storage {
 		system: SystemConfig::default(),
 		balances: BalancesConfig {
 			balances: accounts::init_balances().iter().map(|k| (k.clone(), ENDOWMENT)).collect(),
+			..Default::default()
 		},
 		session: SessionConfig {
 			keys: validators::initial_authorities()

--- a/runtime/devnet/src/genesis.rs
+++ b/runtime/devnet/src/genesis.rs
@@ -118,7 +118,7 @@ fn genesis(
 			next_asset_id: Some(1),
 			..Default::default()
 		},
-		"balances": BalancesConfig { balances: balances(endowed_accounts) },
+		"balances": BalancesConfig { balances: balances(endowed_accounts), ..Default::default() },
 		"collatorSelection": {
 			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
 			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,

--- a/runtime/mainnet/src/genesis.rs
+++ b/runtime/mainnet/src/genesis.rs
@@ -157,7 +157,7 @@ fn genesis(
 			next_asset_id: Some(1),
 			..Default::default()
 		},
-		"balances": BalancesConfig { balances: balances(endowed_accounts) },
+		"balances": BalancesConfig { balances: balances(endowed_accounts), ..Default::default() },
 		"collatorSelection": {
 			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
 			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,

--- a/runtime/testnet/src/genesis.rs
+++ b/runtime/testnet/src/genesis.rs
@@ -132,7 +132,7 @@ fn genesis(
 			next_asset_id: Some(1),
 			..Default::default()
 		},
-		"balances": BalancesConfig { balances: balances(endowed_accounts) },
+		"balances": BalancesConfig { balances: balances(endowed_accounts), ..Default::default() },
 		"collatorSelection": {
 			"invulnerables": invulnerables.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
 			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,


### PR DESCRIPTION
As per [polkadot-sdk#6267](https://github.com/paritytech/polkadot-sdk/pull/6267).

This PR configures the genesis of devnet, testnet and mainnet runtime to include the missing element in pallet_balances'' GenesisConfig.

- [x] TODO: amend genesis configuration for runtimes in integration-tests