### PR TITLE
fix: version conversion in `XcmPaymentApi::query_weight_to_asset_fee`

### DIFF
--- a/runtime/mainnet/src/apis.rs
+++ b/runtime/mainnet/src/apis.rs
@@ -336,9 +336,10 @@ impl_runtime_apis! {
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
 			let native_asset = xcm_config::RelayLocation::get();
 			let fee_in_native = WeightToFee::weight_to_fee(&weight);
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == native_asset => {
-					// for native asset
+					// For native asset.
 					Ok(fee_in_native)
 				},
 				Ok(asset_id) => {


### PR DESCRIPTION
As per [polkadot-sdk#6459](https://github.com/paritytech/polkadot-sdk/pull/6459).

The `query_weight_to_asset_fee` function of the `XcmPaymentApi` was trying to convert versions wrong. Resulting in all calls made with lower versions failing.
The version conversion is now done correctly and the previous failing calls will now succeed.

---

[sc-3547]