### PR TITLE
chore: impl `EthGasEncoder` for `pallet_revive`

### DIFF
--- a/runtime/mainnet/src/config/revive.rs
+++ b/runtime/mainnet/src/config/revive.rs
@@ -32,6 +32,7 @@ impl pallet_revive::Config for Runtime {
 	type Debug = ();
 	type DepositPerByte = DepositPerByte;
 	type DepositPerItem = DepositPerItem;
+	type EthGasEncoder = ();
 	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
 	// 1 ETH : 1_000_000 UNIT
 	type NativeToEthRatio = NativeToEthRatio;
@@ -127,6 +128,11 @@ mod tests {
 	#[test]
 	fn deposit_per_item_is_correct() {
 		assert_eq!(<<Runtime as Config>::DepositPerItem as Get<Balance>>::get(), deposit(1, 0),);
+	}
+
+	#[test]
+	fn ensure_eth_gas_encoder() {
+		assert_eq!(TypeId::of::<<Runtime as Config>::EthGasEncoder>(), TypeId::of::<()>(),);
 	}
 
 	#[test]

--- a/runtime/testnet/src/config/contracts.rs
+++ b/runtime/testnet/src/config/contracts.rs
@@ -101,6 +101,7 @@ impl pallet_revive::Config for Runtime {
 	type Debug = ();
 	type DepositPerByte = DepositPerByte;
 	type DepositPerItem = DepositPerItem;
+	type EthGasEncoder = ();
 	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
 	// 1 ETH : 1_000_000 UNIT
 	type NativeToEthRatio = NativeToEthRatio;


### PR DESCRIPTION
As per [polkadot-sdk#6689](https://github.com/paritytech/polkadot-sdk/pull/6689).

Implement `EthGasEncoder` in pallet_revive for testnet and mainnet runtimes.
Includes a unit tests to ensure the configuration for `EthGasEncoder` is `()` in mainnet.

---

[sc-3547]