### PR TITLE
fix: nonfungible api mismatched balance type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13496,7 +13496,7 @@ dependencies = [
 name = "pop-api"
 version = "0.0.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.8.0",
  "enumflags2",
  "ink",
  "pop-primitives",

--- a/pop-api/Cargo.lock
+++ b/pop-api/Cargo.lock
@@ -331,9 +331,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitvec"
@@ -2411,7 +2411,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]

--- a/pop-api/Cargo.lock
+++ b/pop-api/Cargo.lock
@@ -2222,7 +2222,7 @@ dependencies = [
 name = "pop-api"
 version = "0.0.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.0",
  "enumflags2",
  "ink",
  "pallet-nfts",

--- a/pop-api/Cargo.toml
+++ b/pop-api/Cargo.toml
@@ -6,8 +6,8 @@ name = "pop-api"
 version = "0.0.0"
 
 [dependencies]
-bitflags = { version = "1.3.2" }
-enumflags2 = "0.7.9"
+bitflags = { version = "1.3.2", optional = true }
+enumflags2 = { version = "0.7.9", optional = true }
 
 # Pop.
 pop-primitives = { path = "../primitives", default-features = false }
@@ -35,7 +35,7 @@ path = "src/lib.rs"
 default = [ "std" ]
 fungibles = [  ]
 messaging = [  ]
-nonfungibles = [  ]
+nonfungibles = [ "dep:bitflags", "dep:enumflags2" ]
 std = [
 	"ink/std",
 	"pop-primitives/std",

--- a/pop-api/Cargo.toml
+++ b/pop-api/Cargo.toml
@@ -6,7 +6,7 @@ name = "pop-api"
 version = "0.0.0"
 
 [dependencies]
-bitflags = { version = "1.3.2", optional = true }
+bitflags = { version = "2.8.0", optional = true }
 enumflags2 = { version = "0.7.9", optional = true }
 
 # Pop.

--- a/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.lock
+++ b/pop-api/integration-tests/contracts/create_token_in_constructor/Cargo.lock
@@ -786,26 +786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enumflags2"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
-dependencies = [
- "enumflags2_derive",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "environmental"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,8 +1818,6 @@ dependencies = [
 name = "pop-api"
 version = "0.0.0"
 dependencies = [
- "bitflags 1.3.2",
- "enumflags2",
  "ink",
  "pop-primitives",
  "sp-io",

--- a/pop-api/integration-tests/contracts/fungibles/Cargo.lock
+++ b/pop-api/integration-tests/contracts/fungibles/Cargo.lock
@@ -778,26 +778,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enumflags2"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
-dependencies = [
- "enumflags2_derive",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "environmental"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,8 +1818,6 @@ dependencies = [
 name = "pop-api"
 version = "0.0.0"
 dependencies = [
- "bitflags 1.3.2",
- "enumflags2",
  "ink",
  "pop-primitives",
  "sp-io",

--- a/pop-api/integration-tests/contracts/messaging/Cargo.lock
+++ b/pop-api/integration-tests/contracts/messaging/Cargo.lock
@@ -798,26 +798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enumflags2"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
-dependencies = [
- "enumflags2_derive",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "environmental"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,8 +1840,6 @@ dependencies = [
 name = "pop-api"
 version = "0.0.0"
 dependencies = [
- "bitflags 1.3.2",
- "enumflags2",
  "ink",
  "pop-primitives",
  "sp-io",

--- a/pop-api/integration-tests/contracts/nonfungibles/Cargo.lock
+++ b/pop-api/integration-tests/contracts/nonfungibles/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 name = "pop-api"
 version = "0.0.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.8.0",
  "enumflags2",
  "ink",
  "pop-primitives",

--- a/pop-api/integration-tests/src/nonfungibles/utils.rs
+++ b/pop-api/integration-tests/src/nonfungibles/utils.rs
@@ -352,9 +352,9 @@ pub(super) mod nfts {
 	pub(crate) fn default_mint_settings() -> MintSettings {
 		MintSettings {
 			mint_type: MintType::Issuer,
-			price: None,
-			start_block: None,
-			end_block: None,
+			price: Some(Balance::MAX),
+			start_block: Some(BlockNumber::MIN),
+			end_block: Some(BlockNumber::MAX),
 			default_item_settings: ItemSettings::all_enabled(),
 		}
 	}

--- a/pop-api/integration-tests/src/nonfungibles/utils.rs
+++ b/pop-api/integration-tests/src/nonfungibles/utils.rs
@@ -283,7 +283,7 @@ pub(super) mod nfts {
 	) -> pallet_nfts::CollectionConfig<u128, BlockNumber, CollectionId> {
 		pallet_nfts::CollectionConfig {
 			settings: pallet_nfts::CollectionSettings::all_enabled(),
-			max_supply: None,
+			max_supply: Some(u32::MAX),
 			mint_settings: pallet_nfts::MintSettings::default(),
 		}
 	}
@@ -312,7 +312,7 @@ pub(super) mod nfts {
 			collection,
 			item,
 			operator.clone().into(),
-			None
+			Some(BlockNumber::MAX)
 		));
 		(collection, item)
 	}

--- a/pop-api/integration-tests/src/nonfungibles/utils.rs
+++ b/pop-api/integration-tests/src/nonfungibles/utils.rs
@@ -312,7 +312,7 @@ pub(super) mod nfts {
 			collection,
 			item,
 			operator.clone().into(),
-			Some(BlockNumber::MAX)
+			Some(u32::MAX)
 		));
 		(collection, item)
 	}
@@ -352,9 +352,9 @@ pub(super) mod nfts {
 	pub(crate) fn default_mint_settings() -> MintSettings {
 		MintSettings {
 			mint_type: MintType::Issuer,
-			price: Some(Balance::MAX),
-			start_block: Some(BlockNumber::MIN),
-			end_block: Some(BlockNumber::MAX),
+			price: Some(u128::MAX),
+			start_block: Some(u32::MIN),
+			end_block: Some(u32::MAX),
 			default_item_settings: ItemSettings::all_enabled(),
 		}
 	}

--- a/pop-api/src/v0/nonfungibles/types.rs
+++ b/pop-api/src/v0/nonfungibles/types.rs
@@ -3,9 +3,11 @@
 use enumflags2::{bitflags, BitFlags};
 
 use super::*;
-use crate::{macros::impl_codec_bitflags, primitives::AccountId};
+use crate::{
+	macros::impl_codec_bitflags,
+	primitives::{AccountId, Balance},
+};
 
-type Balance = u32;
 /// The identifier of a collection.
 pub type CollectionId = u32;
 /// The identifier of an item.
@@ -178,18 +180,30 @@ mod tests {
 	#[test]
 	fn ensure_destroy_witness() {
 		assert_eq!(
-			DestroyWitness { item_metadatas: 0, item_configs: 0, attributes: 0 }.encode(),
-			pallet_nfts::DestroyWitness { item_metadatas: 0, item_configs: 0, attributes: 0 }
-				.encode()
+			DestroyWitness {
+				item_metadatas: u32::MAX,
+				item_configs: u32::MAX,
+				attributes: u32::MAX
+			}
+			.encode(),
+			pallet_nfts::DestroyWitness {
+				item_metadatas: u32::MAX,
+				item_configs: u32::MAX,
+				attributes: u32::MAX
+			}
+			.encode()
 		);
 	}
 
 	#[test]
 	fn ensure_mint_witness() {
 		assert_eq!(
-			MintWitness { owned_item: None, mint_price: None }.encode(),
-			pallet_nfts::MintWitness::<ItemId, Balance> { owned_item: None, mint_price: None }
-				.encode()
+			MintWitness { owned_item: Some(ItemId::MAX), mint_price: Some(Balance::MAX) }.encode(),
+			pallet_nfts::MintWitness::<ItemId, Balance> {
+				owned_item: Some(ItemId::MAX),
+				mint_price: Some(Balance::MAX)
+			}
+			.encode()
 		);
 	}
 
@@ -228,13 +242,13 @@ mod tests {
 		assert_eq!(
 			CollectionConfig {
 				settings: CollectionSettings::all_enabled(),
-				max_supply: None,
+				max_supply: Some(u32::MAX),
 				mint_settings: default_mint_settings(),
 			}
 			.encode(),
 			pallet_nfts::CollectionConfig {
 				settings: pallet_nfts::CollectionSettings::all_enabled(),
-				max_supply: None,
+				max_supply: Some(u32::MAX),
 				mint_settings: default_pallet_mint_settings(),
 			}
 			.encode()
@@ -244,11 +258,12 @@ mod tests {
 	#[test]
 	fn ensure_mint_type() {
 		assert_eq!(
-			vec![MintType::Issuer, MintType::Public, MintType::HolderOf(0),].encode(),
+			vec![MintType::Issuer, MintType::Public, MintType::HolderOf(CollectionId::MAX)]
+				.encode(),
 			vec![
 				pallet_nfts::MintType::Issuer,
 				pallet_nfts::MintType::Public,
-				pallet_nfts::MintType::HolderOf(0)
+				pallet_nfts::MintType::HolderOf(CollectionId::MAX)
 			]
 			.encode()
 		);
@@ -281,8 +296,8 @@ mod tests {
 	#[test]
 	fn ensure_cancel_attributes_approval_witness() {
 		assert_eq!(
-			CancelAttributesApprovalWitness { account_attributes: 0 }.encode(),
-			pallet_nfts::CancelAttributesApprovalWitness { account_attributes: 0 }.encode(),
+			CancelAttributesApprovalWitness { account_attributes: u32::MAX }.encode(),
+			pallet_nfts::CancelAttributesApprovalWitness { account_attributes: u32::MAX }.encode(),
 		);
 	}
 
@@ -315,9 +330,9 @@ mod tests {
 	fn default_mint_settings() -> MintSettings {
 		MintSettings {
 			mint_type: MintType::Public,
-			price: None,
-			start_block: None,
-			end_block: None,
+			price: Some(Balance::MAX),
+			start_block: Some(BlockNumber::MIN),
+			end_block: Some(BlockNumber::MAX),
 			default_item_settings: ItemSettings::all_enabled(),
 		}
 	}
@@ -326,9 +341,9 @@ mod tests {
 	) -> pallet_nfts::MintSettings<Balance, BlockNumber, CollectionId> {
 		pallet_nfts::MintSettings::<Balance, BlockNumber, CollectionId> {
 			mint_type: pallet_nfts::MintType::Public,
-			price: None,
-			start_block: None,
-			end_block: None,
+			price: Some(Balance::MAX),
+			start_block: Some(BlockNumber::MIN),
+			end_block: Some(BlockNumber::MAX),
 			default_item_settings: pallet_nfts::ItemSettings::all_enabled(),
 		}
 	}

--- a/pop-api/src/v0/nonfungibles/types.rs
+++ b/pop-api/src/v0/nonfungibles/types.rs
@@ -198,10 +198,10 @@ mod tests {
 	#[test]
 	fn ensure_mint_witness() {
 		assert_eq!(
-			MintWitness { owned_item: Some(ItemId::MAX), mint_price: Some(Balance::MAX) }.encode(),
+			MintWitness { owned_item: Some(u32::MAX), mint_price: Some(u128::MAX) }.encode(),
 			pallet_nfts::MintWitness::<ItemId, Balance> {
-				owned_item: Some(ItemId::MAX),
-				mint_price: Some(Balance::MAX)
+				owned_item: Some(u32::MAX),
+				mint_price: Some(u128::MAX)
 			}
 			.encode()
 		);
@@ -258,12 +258,11 @@ mod tests {
 	#[test]
 	fn ensure_mint_type() {
 		assert_eq!(
-			vec![MintType::Issuer, MintType::Public, MintType::HolderOf(CollectionId::MAX)]
-				.encode(),
+			vec![MintType::Issuer, MintType::Public, MintType::HolderOf(u32::MAX)].encode(),
 			vec![
 				pallet_nfts::MintType::Issuer,
 				pallet_nfts::MintType::Public,
-				pallet_nfts::MintType::HolderOf(CollectionId::MAX)
+				pallet_nfts::MintType::HolderOf(u32::MAX)
 			]
 			.encode()
 		);
@@ -330,9 +329,9 @@ mod tests {
 	fn default_mint_settings() -> MintSettings {
 		MintSettings {
 			mint_type: MintType::Public,
-			price: Some(Balance::MAX),
-			start_block: Some(BlockNumber::MIN),
-			end_block: Some(BlockNumber::MAX),
+			price: Some(u128::MAX),
+			start_block: Some(u32::MIN),
+			end_block: Some(u32::MAX),
 			default_item_settings: ItemSettings::all_enabled(),
 		}
 	}
@@ -341,9 +340,9 @@ mod tests {
 	) -> pallet_nfts::MintSettings<Balance, BlockNumber, CollectionId> {
 		pallet_nfts::MintSettings::<Balance, BlockNumber, CollectionId> {
 			mint_type: pallet_nfts::MintType::Public,
-			price: Some(Balance::MAX),
-			start_block: Some(BlockNumber::MIN),
-			end_block: Some(BlockNumber::MAX),
+			price: Some(u128::MAX),
+			start_block: Some(u32::MIN),
+			end_block: Some(u32::MAX),
 			default_item_settings: pallet_nfts::ItemSettings::all_enabled(),
 		}
 	}


### PR DESCRIPTION
There is an issue in the nonfungible API that when user calls `api::nonfungibles::create`, it throws `Contract Decode Failed`. Reason to that is the mismatched type in the `price` field of `MintSettings` in the runtime and in the API crate. 
- Remove the balance `u32` type in the nonfungibles api crate. Use the `primitives::Balance` type instead.
- Update all tests in the nonfungible integration tests to test with the min / max value of the data types instead of `None`. 