### PR TITLE
chore(messaging): final weight revision

### DIFF
--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -12,7 +12,7 @@ use frame_support::{
 		tokens::{
 			fungible::{hold::Mutate as HoldMutate, Inspect, Mutate},
 			Fortitude,
-			Precision::{BestEffort, Exact},
+			Precision::Exact,
 			Preservation, Restriction,
 		},
 		Get,
@@ -279,13 +279,10 @@ pub mod pallet {
 		IsmpTimedOut { commitment: H256 },
 		/// A collection of xcm queries have timed out.
 		XcmQueriesTimedOut { query_ids: Vec<QueryId> },
-<<<<<<< HEAD
 		/// An error has occured while attempting to refund weight.
 		WeightRefundErrored { message_id: MessageId, error: DispatchError },
-=======
 		/// Callback gas has been topped up.
 		CallbackGasIncreased { message_id: MessageId, total_weight: Weight },
->>>>>>> c2fb2bf87298301a86a266590c8fc5c0cc8fd25a
 	}
 
 	#[pallet::error]
@@ -310,17 +307,14 @@ pub mod pallet {
 		FutureTimeoutMandatory,
 		/// Message block limit has been reached for this expiry block. Try a different timeout.
 		MaxMessageTimeoutPerBlockReached,
-<<<<<<< HEAD
 		/// This callback cannot be processed due to lack of blockspace. Please poll the response.
 		BlockspaceAllowanceReached,
-=======
 		/// This is not possible as the message has completed.
 		MessageCompleted,
 		/// No callback has been found for this query.
 		NoCallbackFound,
 		/// Weight cannot be zero.
 		ZeroWeight,
->>>>>>> c2fb2bf87298301a86a266590c8fc5c0cc8fd25a
 	}
 
 	/// A reason for the pallet placing a hold on funds.
@@ -474,7 +468,7 @@ pub mod pallet {
 			.saturating_add(calculate_message_deposit::<T, T::OnChainByteFee>())
 			.saturating_add(calculate_deposit_of::<T, T::OffChainByteFee, ismp::Post<T>>());
 
-			T::Fungibles::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
+			T::Fungibles::hold(&HoldReason::Messaging.into(), &origin, message_deposit)?;
 
 			if let Some(cb) = callback.as_ref() {
 				T::Fungibles::hold(
@@ -626,15 +620,8 @@ pub mod pallet {
 			let xcm_query_message =
 				Messages::<T>::get(&initiating_origin, id).ok_or(Error::<T>::MessageNotFound)?;
 
-<<<<<<< HEAD
-			let (query_id, callback, deposit) = match &xcm_query_message {
-				Message::XcmQuery { query_id, callback, deposit } => (query_id, callback, deposit),
-				// TODO: check what happens on err.
-=======
 			let (query_id, callback, message_deposit) = match &xcm_query_message {
-				Message::XcmQuery { query_id, callback, message_deposit } =>
-					(query_id, callback, message_deposit),
->>>>>>> c2fb2bf87298301a86a266590c8fc5c0cc8fd25a
+				Message::XcmQuery { query_id, callback, message_deposit } => (query_id, callback, message_deposit),
 				Message::XcmTimeout { .. } => return Err(Error::<T>::RequestTimedOut.into()),
 				_ => return Err(Error::<T>::InvalidMessage.into()),
 			};
@@ -654,7 +641,8 @@ pub mod pallet {
 				// manually adjust the blockweight to weight of the extrinsic.
 				let static_weight_adjustment = T::WeightInfo::xcm_response()
 					.saturating_add(T::CallbackExecutor::execution_weight());
-				// Never roll back state if call fails.
+				
+					// Never roll back state if call fails.
 				// Ensure that the response can be polled.
 				if Self::call(
 					&initiating_origin,
@@ -826,8 +814,10 @@ pub mod pallet {
 
 			Ok(())
 		}
+	
 	}
-}
+
+
 impl<T: Config> Pallet<T> {
 	/// Executes a registered callback with the given input data and manually charges block weight.
 	///
@@ -1040,7 +1030,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 }
-
+}
 #[derive(Encode, Decode, Debug, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(PartialEq, Clone))]
 #[repr(u8)]

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -5,9 +5,7 @@ pub use alloc::borrow::ToOwned;
 use ::ismp::Error as IsmpError;
 use codec::{Decode, Encode};
 use frame_support::{
-	dispatch::{
-		DispatchErrorWithPostInfo, DispatchResult, DispatchResultWithPostInfo, PostDispatchInfo,
-	},
+	dispatch::{DispatchErrorWithPostInfo, DispatchResult, DispatchResultWithPostInfo},
 	pallet_prelude::*,
 	storage::KeyLenOf,
 	traits::{
@@ -621,7 +619,7 @@ pub mod pallet {
 				// manually adjust the blockweight to weight of the extrinsic.
 				let static_weight_adjustment =
 					T::WeightInfo::xcm_response() + T::CallbackExecutor::execution_weight();
-				/// Never roll back state if call fails.
+				// Never roll back state if call fails.
 				match Self::call(
 					&initiating_origin,
 					callback.to_owned(),

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -617,8 +617,8 @@ pub mod pallet {
 				log::debug!(target: "pop-api::extension", "xcm callback={:?}, response={:?}", callback, xcm_response);
 				// Since we are dispatching in the xcm-executor with call.dispatch_call, we must
 				// manually adjust the blockweight to weight of the extrinsic.
-				let static_weight_adjustment =
-					T::WeightInfo::xcm_response().saturating_add(T::CallbackExecutor::execution_weight());
+				let static_weight_adjustment = T::WeightInfo::xcm_response()
+					.saturating_add(T::CallbackExecutor::execution_weight());
 				// Never roll back state if call fails.
 				// Ensure that the response can be polled.
 				if Self::call(

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -1605,8 +1605,11 @@ mod top_up_callback_weight {
 	fn xcm_response_is_err() {
 		new_test_ext().execute_with(|| {
 			let message_id = [0u8; 32];
-			let message =
-				Message::XcmResponse { query_id: 0, message_deposit: 100, response: Response::Null };
+			let message = Message::XcmResponse {
+				query_id: 0,
+				message_deposit: 100,
+				response: Response::Null,
+			};
 			let weight = Weight::from_parts(100_000, 100_000);
 
 			Messages::<Test>::insert(ALICE, message_id, message);
@@ -1621,7 +1624,11 @@ mod top_up_callback_weight {
 	fn xcm_timeout_is_err() {
 		new_test_ext().execute_with(|| {
 			let message_id = [0u8; 32];
-			let message = Message::XcmTimeout { query_id: 0, message_deposit: Default::default(), callback_deposit: Default::default() };	
+			let message = Message::XcmTimeout {
+				query_id: 0,
+				message_deposit: Default::default(),
+				callback_deposit: Default::default(),
+			};
 			let weight = Weight::from_parts(100_000, 100_000);
 
 			Messages::<Test>::insert(ALICE, message_id, message);
@@ -1636,7 +1643,11 @@ mod top_up_callback_weight {
 	fn ismp_timeout_is_err() {
 		new_test_ext().execute_with(|| {
 			let message_id = [0u8; 32];
-			let message = Message::IsmpTimeout { commitment: Default::default(), message_deposit: Default::default(), callback_deposit: Default::default() };
+			let message = Message::IsmpTimeout {
+				commitment: Default::default(),
+				message_deposit: Default::default(),
+				callback_deposit: Default::default(),
+			};
 			let weight = Weight::from_parts(100_000, 100_000);
 
 			Messages::<Test>::insert(ALICE, message_id, message);
@@ -1695,8 +1706,11 @@ mod top_up_callback_weight {
 	fn ismp_pending_no_callback() {
 		new_test_ext().execute_with(|| {
 			let message_id = [0u8; 32];
-			let message =
-				Message::Ismp { commitment: Default::default(), message_deposit: 100, callback: None };
+			let message = Message::Ismp {
+				commitment: Default::default(),
+				message_deposit: 100,
+				callback: None,
+			};
 			let additional_weight = Weight::from_parts(100_000, 100_000);
 
 			Messages::<Test>::insert(ALICE, message_id, message);

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -893,6 +893,58 @@ mod call {
 	fn registers_extra_weight() {}
 }
 
+mod process_callback_weight {
+	use super::*;
+
+	#[test]
+	fn ok_with_weight_returns_weight() {
+		new_test_ext().execute_with(|| {
+		let weight = Weight::from_parts(100_000, 100_000);
+		let max_weight = Weight::zero();
+		let result = DispatchResultWithPostInfo::Ok(PostDispatchInfo {
+			actual_weight: Some(weight),
+			pays_fee: Pays::Yes,
+		});
+
+		let processed_weight = Pallet::<T>::process_callback_weight(&result, max_weight);
+
+		assert_eq!(processed_weight, weight);
+		})
+	}
+
+	#[test]
+	fn ok_without_weight_returns_max_weight() {
+		new_test_ext().execute_with(|| {
+		let weight = Weight::from_parts(100_000, 100_000);
+		let max_weight = Weight::from_parts(200_000, 200_000);
+		let result = DispatchResultWithPostInfo::Ok(PostDispatchInfo {
+			actual_weight: None,
+			pays_fee: Pays::Yes,
+		});
+
+		let processed_weight = Pallet::<T>::process_callback_weight(&result, max_weight);
+
+		assert_eq!(processed_weight, max_weight);
+		})
+	}
+
+	#[test]
+	fn err_returns_max_weight() {
+		new_test_ext().execute_with(|| {
+		let weight = Weight::from_parts(100_000, 100_000);
+		let max_weight = Weight::from_parts(200_000, 200_000);
+		let result = DispatchResultWithPostInfo::Err(DispatchErrorWithPostInfo {
+			post_info: Default::default(),
+			error: Error::<Test>::InvalidMessage.into(),
+		});
+		let processed_weight = Pallet::<T>::process_callback_weight(&result, max_weight);
+		assert_eq!(processed_weight, max_weight);
+		})
+	}
+
+}
+
+
 mod try_refund_unused_weight {
 	use frame_support::dispatch::{DispatchResultWithPostInfo, Pays, PostDispatchInfo};
 	use sp_runtime::DispatchErrorWithPostInfo;

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -801,6 +801,9 @@ mod xcm_response {
 			));
 
 			assert_ok!(Messaging::xcm_response(root(), expected_query_id, xcm_response.clone()));
+
+			let events = events();
+
 			assert!(Messages::<Test>::get(ALICE, message_id).is_none());
 			assert!(XcmQueries::<Test>::get(expected_query_id).is_none());
 		})
@@ -884,7 +887,16 @@ mod xcm_hooks {
 	}
 }
 
-mod handle_callback_result {
+mod call {
+	use super::*;
+	#[test]
+	fn registers_extra_weight() {
+
+	}
+
+}
+
+mod try_refund_unused_weight {
 	use frame_support::dispatch::{DispatchResultWithPostInfo, Pays, PostDispatchInfo};
 	use sp_runtime::DispatchErrorWithPostInfo;
 
@@ -917,7 +929,7 @@ mod handle_callback_result {
 			let pot_pre_handle = Balances::free_balance(FEE_ACCOUNT);
 			let alice_balance_pre_handle = Balances::free_balance(ALICE);
 
-			assert!(crate::messaging::Pallet::<Test>::handle_callback_result(
+			assert!(crate::messaging::Pallet::<Test>::try_refund_unused_weight(
 				&origin, &id, result, callback
 			)
 			.is_ok());
@@ -956,7 +968,7 @@ mod handle_callback_result {
 			)
 			.unwrap();
 
-			assert_ok!(crate::messaging::Pallet::<Test>::handle_callback_result(
+			assert_ok!(crate::messaging::Pallet::<Test>::try_refund_unused_weight(
 				&origin, &id, result, callback
 			));
 			assert!(events().contains(&Event::<Test>::CallbackExecuted { origin, id, callback }));
@@ -979,7 +991,7 @@ mod handle_callback_result {
 				abi: Abi::Scale,
 			};
 
-			assert!(crate::messaging::Pallet::<Test>::handle_callback_result(
+			assert!(crate::messaging::Pallet::<Test>::try_refund_unused_weight(
 				&origin, &id, result, callback
 			)
 			.is_ok());
@@ -1032,7 +1044,7 @@ mod handle_callback_result {
 			let fee_account_pre_handle = Balances::free_balance(FEE_ACCOUNT);
 			let alice_balance_pre_handle = Balances::free_balance(ALICE);
 
-			assert!(crate::messaging::Pallet::<Test>::handle_callback_result(
+			assert!(crate::messaging::Pallet::<Test>::try_refund_unused_weight(
 				&origin, &id, result, callback
 			)
 			.is_ok());

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 use frame_support::{
-	assert_noop, assert_ok, testing_prelude::bounded_vec, traits::fungible::hold::Inspect,
-	weights::Weight,
+	assert_noop, assert_ok, dispatch::PostDispatchInfo, testing_prelude::bounded_vec,
+	traits::fungible::hold::Inspect, weights::Weight,
 };
 use sp_core::H256;
 

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -889,9 +889,62 @@ mod xcm_hooks {
 
 mod call {
 	use super::*;
+	use frame_system::pallet::BlockWeight;
+	use frame_support::traits::fungibles::InspectHold;
 	#[test]
-	fn registers_extra_weight() {}
+	fn assert_error_event() {
+		new_test_ext().execute_with(|| {
+		let message_id = [1u8; 32];
+		let callback_weight = Weight::from_parts(100_000, 100_000);
+		let data = [100u8; 5];
+		let callback = Callback {
+			abi: Abi::Scale,
+			selector: [0u8; 4],
+			weight: callback_weight,
+		};
+		let static_weight_adjustment = Weight::from_parts(150_000, 150_000);
+		assert_ok!(Pallet::<Test>::call(&ALICE, callback, &message_id, &data, Some(static_weight_adjustment)));
+
+		System::assert_last_event(
+			Event::<Test>::WeightRefundErrored {
+				message_id,
+				error: DispatchError::Token(sp_runtime::TokenError::FundsUnavailable),
+			}.into()
+		);
+		})
+	}
+
+	// AlwaysSuccessfullCallbackExecutor should return half the weight of the callback.weight
+	// TODO: there may be a better way of handling this case.
+	#[test]
+	fn blockweight_mutation_happens() {
+		new_test_ext().execute_with(|| {
+		let blockweight_pre_call = BlockWeight::<Test>::get().get(DispatchClass::Normal).to_owned();
+		let message_id = [1u8; 32];
+		let callback_weight = Weight::from_parts(10_000_000, 10_000_000);
+		let callback_fee = <Test as Config>::WeightToFee::weight_to_fee(&callback_weight);
+		let data = [100u8; 5];
+		let callback = Callback {
+			abi: Abi::Scale,
+			selector: [0u8; 4],
+			weight: callback_weight,
+		};
+		let static_weight_adjustment = Weight::from_parts(15_000_000, 15_000_000);
+		<Test as Config>::Fungibles::hold(&HoldReason::CallbackGas.into(), &ALICE, callback_fee).unwrap();
+	
+		assert_ok!(Pallet::<Test>::call(&ALICE, callback, &message_id, &data, Some(static_weight_adjustment)));
+
+		let blockweight_post_call = BlockWeight::<Test>::get().get(DispatchClass::Normal).to_owned();
+		assert_ne!(blockweight_post_call, Zero::zero());
+
+		// callback weight used in tests is total / 2.
+		assert_eq!(blockweight_post_call - blockweight_pre_call, callback_weight / 2 + static_weight_adjustment);
+		})
+	}
 }
+
+
+
 
 mod process_callback_weight {
 	use super::*;
@@ -906,7 +959,7 @@ mod process_callback_weight {
 			pays_fee: Pays::Yes,
 		});
 
-		let processed_weight = Pallet::<T>::process_callback_weight(&result, max_weight);
+		let processed_weight = Pallet::<Test>::process_callback_weight(&result, max_weight);
 
 		assert_eq!(processed_weight, weight);
 		})
@@ -922,7 +975,7 @@ mod process_callback_weight {
 			pays_fee: Pays::Yes,
 		});
 
-		let processed_weight = Pallet::<T>::process_callback_weight(&result, max_weight);
+		let processed_weight = Pallet::<Test>::process_callback_weight(&result, max_weight);
 
 		assert_eq!(processed_weight, max_weight);
 		})
@@ -937,124 +990,82 @@ mod process_callback_weight {
 			post_info: Default::default(),
 			error: Error::<Test>::InvalidMessage.into(),
 		});
-		let processed_weight = Pallet::<T>::process_callback_weight(&result, max_weight);
+		let processed_weight = Pallet::<Test>::process_callback_weight(&result, max_weight);
 		assert_eq!(processed_weight, max_weight);
 		})
 	}
-
 }
 
 
-mod try_refund_unused_weight {
+mod deposit_callback_event {
+	use super::*;
+	#[test]
+	fn emits_callback_executed_event_on_success() {
+		new_test_ext().execute_with(|| {
+			let origin = ALICE;
+			let message_id = [1u8; 32];
+			let callback = Callback {
+				abi: Abi::Scale,
+				selector: [0; 4],
+				weight: Weight::from_parts(100_000, 100_000),
+			};
+
+			let result: DispatchResultWithPostInfo = Ok(PostDispatchInfo {
+				actual_weight: Some(Weight::from_parts(1_000, 0)),
+				pays_fee: Default::default(),
+			});
+
+			Pallet::<Test>::deposit_callback_event(&origin, message_id, &callback, &result);
+
+			System::assert_last_event(
+				Event::<Test>::CallbackExecuted {
+					origin,
+					id: message_id,
+					callback,
+				}
+				.into()
+			);
+		});
+	}
+
+	#[test]
+	fn emits_callback_failed_event_on_error() {
+		new_test_ext().execute_with(|| {
+			let origin = BOB;
+			let message_id = [2u8; 32];
+			let callback = Callback {
+				abi: Abi::Scale,
+				selector: [0; 4],
+				weight: Weight::from_parts(100_000, 100_000),
+			}; 
+
+			let result = DispatchResultWithPostInfo::Err(DispatchErrorWithPostInfo {
+				post_info: Default::default(),
+				error: Error::<Test>::InvalidMessage.into(),
+			});
+
+			Pallet::<Test>::deposit_callback_event(&origin, message_id, &callback, &result);
+
+			System::assert_last_event(
+				Event::<Test>::CallbackFailed {
+					origin,
+					id: message_id,
+					callback,
+					error: result.unwrap_err(),
+				}
+				.into()
+			);
+		});
+	}
+}
+
+
+mod manage_fees {
 	use frame_support::dispatch::{DispatchResultWithPostInfo, Pays, PostDispatchInfo};
 	use sp_runtime::DispatchErrorWithPostInfo;
 
 	use super::*;
-
-	#[test]
-	fn claims_all_weight_to_fee_pot_on_failure() {
-		new_test_ext().execute_with(|| {
-			let origin = ALICE;
-			let id = [1u8; 32];
-			let result = DispatchResultWithPostInfo::Err(DispatchErrorWithPostInfo {
-				post_info: Default::default(),
-				error: Error::<Test>::InvalidMessage.into(),
-			});
-			let actual_weight = Weight::from_parts(100_000_000, 100_000_000);
-
-			let callback = Callback { selector: [1; 4], weight: actual_weight, abi: Abi::Scale };
-
-			let deposit = <Test as Config>::WeightToFee::weight_to_fee(&actual_weight);
-
-			assert!(deposit != 0);
-			// Artificially take the deposit
-			<Test as crate::messaging::Config>::Fungibles::hold(
-				&HoldReason::CallbackGas.into(),
-				&ALICE,
-				deposit,
-			)
-			.unwrap();
-
-			let pot_pre_handle = Balances::free_balance(FEE_ACCOUNT);
-			let alice_balance_pre_handle = Balances::free_balance(ALICE);
-
-			assert!(crate::messaging::Pallet::<Test>::try_refund_unused_weight(
-				&origin, &id, result, callback
-			)
-			.is_ok());
-
-			let alice_balance_post_handle = Balances::free_balance(ALICE);
-			let pot_post_handle = Balances::free_balance(FEE_ACCOUNT);
-
-			assert_eq!(alice_balance_post_handle, alice_balance_pre_handle);
-			assert_eq!(pot_post_handle, pot_pre_handle + deposit);
-		})
-	}
-
-	#[test]
-	fn assert_event_success() {
-		new_test_ext().execute_with(|| {
-			let origin = ALICE;
-			let id = [1u8; 32];
-			let actual_weight = Weight::from_parts(100, 100);
-			let result = DispatchResultWithPostInfo::Ok(PostDispatchInfo {
-				actual_weight: Some(actual_weight),
-				pays_fee: Pays::Yes,
-			});
-			let callback = Callback {
-				selector: [1; 4],
-				weight: Weight::from_parts(1000, 1000),
-				abi: Abi::Scale,
-			};
-
-			let deposit = <Test as Config>::WeightToFee::weight_to_fee(&actual_weight);
-
-			// Artificially take the deposit
-			<Test as crate::messaging::Config>::Fungibles::hold(
-				&HoldReason::CallbackGas.into(),
-				&ALICE,
-				deposit,
-			)
-			.unwrap();
-
-			assert_ok!(crate::messaging::Pallet::<Test>::try_refund_unused_weight(
-				&origin, &id, result, callback
-			));
-			assert!(events().contains(&Event::<Test>::CallbackExecuted { origin, id, callback }));
-		})
-	}
-
-	#[test]
-	fn assert_event_failure() {
-		new_test_ext().execute_with(|| {
-			let origin = ALICE;
-			let id = [1u8; 32];
-			let result = DispatchResultWithPostInfo::Err(DispatchErrorWithPostInfo {
-				post_info: Default::default(),
-				error: Error::<Test>::InvalidMessage.into(),
-			});
-
-			let callback = Callback {
-				selector: [1; 4],
-				weight: Weight::from_parts(1000, 1000),
-				abi: Abi::Scale,
-			};
-
-			assert!(crate::messaging::Pallet::<Test>::try_refund_unused_weight(
-				&origin, &id, result, callback
-			)
-			.is_ok());
-
-			assert!(events().contains(&Event::<Test>::CallbackFailed {
-				origin,
-				id,
-				callback,
-				post_info: Default::default(),
-				error: Error::<Test>::InvalidMessage.into()
-			}));
-		})
-	}
-
+	
 	#[test]
 	fn assert_payback_when_execution_weight_is_less_than_deposit_held() {
 		new_test_ext().execute_with(|| {
@@ -1063,17 +1074,11 @@ mod try_refund_unused_weight {
 			let actual_weight_executed = Weight::from_parts(50_000_000, 70_000_000);
 			let callback_weight_reserved = Weight::from_parts(100_000_000, 100_000_000);
 
-			let result = DispatchResultWithPostInfo::Ok(PostDispatchInfo {
-				actual_weight: Some(actual_weight_executed),
-				pays_fee: Pays::Yes,
-			});
-
-			let callback =
 				Callback { selector: [1; 4], weight: callback_weight_reserved, abi: Abi::Scale };
 
 			let deposit = <Test as Config>::WeightToFee::weight_to_fee(&callback_weight_reserved);
 
-			assert!(deposit != 0);
+			assert!(deposit != 0, "Please set an appropriate weight to fee implementation.");
 
 			// Artificially take the deposit
 			<Test as crate::messaging::Config>::Fungibles::hold(
@@ -1093,8 +1098,8 @@ mod try_refund_unused_weight {
 			let fee_account_pre_handle = Balances::free_balance(FEE_ACCOUNT);
 			let alice_balance_pre_handle = Balances::free_balance(ALICE);
 
-			assert!(crate::messaging::Pallet::<Test>::try_refund_unused_weight(
-				&origin, &id, result, callback
+			assert!(crate::messaging::Pallet::<Test>::manage_fees(
+				&origin, actual_weight_executed, callback_weight_reserved
 			)
 			.is_ok());
 

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -890,10 +890,7 @@ mod xcm_hooks {
 mod call {
 	use super::*;
 	#[test]
-	fn registers_extra_weight() {
-
-	}
-
+	fn registers_extra_weight() {}
 }
 
 mod try_refund_unused_weight {

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -187,7 +187,7 @@ impl<T: Config> IsmpModuleWeight for Pallet<T> {
 			Response::Post(_) => 0,
 		};
 
-		T::WeightInfo::ismp_on_response(x).saturating_add(T::CallbackExecutor::execution_weight())
+		T::WeightInfo::ismp_on_response(x)
 	}
 }
 
@@ -215,7 +215,8 @@ pub(crate) fn process_response<T: Config>(
 
 	// Attempt callback with result if specified.
 	if let Some(callback) = callback {
-		if Pallet::<T>::call(&initiating_origin, callback, &id, response_data).is_ok() {
+		// We dont accrue any additional weight as the dispatch is handled normally by pallet-ismp.
+		if Pallet::<T>::call(&initiating_origin, callback, &id, response_data, None).is_ok() {
 			// Clean storage, return deposit
 			Messages::<T>::remove(&initiating_origin, id);
 			IsmpRequests::<T>::remove(commitment);

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -181,13 +181,14 @@ impl<T: Config> IsmpModuleWeight for Pallet<T> {
 		T::WeightInfo::ismp_on_timeout(x)
 	}
 
+	// todo: test
 	fn on_response(&self, response: &Response) -> Weight {
 		let x = match response {
 			Response::Get(_) => 1,
 			Response::Post(_) => 0,
 		};
 
-		T::WeightInfo::ismp_on_response(x)
+		T::WeightInfo::ismp_on_response(x) + T::CallbackExecutor::execution_weight()
 	}
 }
 
@@ -215,7 +216,7 @@ pub(crate) fn process_response<T: Config>(
 
 	// Attempt callback with result if specified.
 	if let Some(callback) = callback {
-		// We dont accrue any additional weight as the dispatch is handled normally by pallet-ismp.
+		// We dont accrue any additional weight as the dispatch is handled normally by pallet-ismp. This includes the CallbackExecutor::execution_weight
 		if Pallet::<T>::call(&initiating_origin, callback, &id, response_data, None).is_ok() {
 			// Clean storage, return deposit
 			Messages::<T>::remove(&initiating_origin, id);

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -188,7 +188,7 @@ impl<T: Config> IsmpModuleWeight for Pallet<T> {
 			Response::Post(_) => 0,
 		};
 
-		T::WeightInfo::ismp_on_response(x) + T::CallbackExecutor::execution_weight()
+		T::WeightInfo::ismp_on_response(x).saturating_add(T::CallbackExecutor::execution_weight())
 	}
 }
 

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -216,7 +216,8 @@ pub(crate) fn process_response<T: Config>(
 
 	// Attempt callback with result if specified.
 	if let Some(callback) = callback {
-		// We dont accrue any additional weight as the dispatch is handled normally by pallet-ismp. This includes the CallbackExecutor::execution_weight
+		// We dont accrue any additional weight as the dispatch is handled normally by pallet-ismp.
+		// This includes the CallbackExecutor::execution_weight
 		if Pallet::<T>::call(&initiating_origin, callback, &id, response_data, None).is_ok() {
 			// Clean storage, return deposit
 			Messages::<T>::remove(&initiating_origin, id);

--- a/runtime/devnet/src/config/api/mod.rs
+++ b/runtime/devnet/src/config/api/mod.rs
@@ -214,6 +214,7 @@ impl messaging::CallbackExecutor<Runtime> for CallbackExecutor {
 			debug,
 			collect_events,
 		);
+
 		log::debug!(target: "pop-api::extension", "callback weight consumed={:?}, weight required={:?}", output.gas_consumed, output.gas_required);
 		if let Ok(return_value) = &output.result {
 			let pallet_revive::ExecReturnValue { flags, data } = return_value;
@@ -224,8 +225,8 @@ impl messaging::CallbackExecutor<Runtime> for CallbackExecutor {
 		}
 
 		let post_info = PostDispatchInfo {
-			actual_weight: Some(output.gas_consumed.saturating_add(Self::execution_weight())),
-			pays_fee: Default::default(),
+			actual_weight: Some(output.gas_consumed),
+			pays_fee: Pays::No,
 		};
 
 		output

--- a/runtime/devnet/src/config/api/mod.rs
+++ b/runtime/devnet/src/config/api/mod.rs
@@ -224,10 +224,8 @@ impl messaging::CallbackExecutor<Runtime> for CallbackExecutor {
 			}
 		}
 
-		let post_info = PostDispatchInfo {
-			actual_weight: Some(output.gas_consumed),
-			pays_fee: Pays::No,
-		};
+		let post_info =
+			PostDispatchInfo { actual_weight: Some(output.gas_consumed), pays_fee: Pays::No };
 
 		output
 			.result


### PR DESCRIPTION
The aim of this PR is to address the use of blockspace when: 
- A callback is executed
- A dispatchables weight is not accounted for

A refactor has been done to split apart `handle_callback_result` into: 
- process_callback_weight
- deposit_event
- manage_fees


The new parameter `static_weight_adjustment` is intended to provide flexibility between different protocols that handle weight and fees in different ways. 
For ismp: The weights are charged in the normal extrinsic route, hence no static_weight_adjustment is required. 
for xcm: Since we are dispatching a call plainly, outside the normal extrinsic flow, we must charge weight manually hence, we include the weight of the response extrinsic and the callback executor as a static_weight_adjustment.






 