### PR TITLE
chore: change toolchain to wasm32v1-none

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
-components = [ "clippy", "rust-src", "rustfmt" ]
-targets = [ "wasm32-unknown-unknown" ]
+components = [ "clippy", "rustfmt" ]
+targets = [ "wasm32v1-none" ]


### PR DESCRIPTION
As per [polkadot-sdk#7008](https://github.com/paritytech/polkadot-sdk/pull/7008).

We can change the toolchain we are using from `wasm32-unknown-unknown` to [`wasm32v1-none`](https://doc.rust-lang.org/beta/rustc/platform-support/wasm32v1-none.html).

Note the following - [source](https://github.com/paritytech/polkadot-sdk/blob/0c0d4ceba45a70f4e8dc40b1ee0cfae1fd759454/substrate/utils/wasm-builder/src/lib.rs#L103):

> //! Wasm builder requires the following prerequisites for building the Wasm binary:
> //! - Rust >= 1.68 and Rust < 1.84:
> //!   - `wasm32-unknown-unknown` target
> //!   - `rust-src` component
> //! - Rust >= 1.84:
> //!   - `wasm32v1-none` target