### PR TITLE
chore(devnet): improve default logging

### DIFF
--- a/networks/devnet.toml
+++ b/networks/devnet.toml
@@ -37,7 +37,12 @@ balances = [
 [[parachains.collators]]
 name = "pop"
 rpc_port = 9944
-args = ["-lruntime::contracts=debug", "-lpopapi::extension=debug", "--enable-offchain-indexing=true"]
+args = [
+    "-lpop-api::extension=debug",
+    "-lruntime::contracts=trace",
+    "-lxcm=trace",
+    "--enable-offchain-indexing=true"
+]
 
 [[parachains]]
 id = 1000


### PR DESCRIPTION
Improves the default logging levels within the `devnet` network config file, correcting a typo which means that nothing from api is currently emitted.