### PR TITLE
refactor: remove dependencies on `sp-std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9954,7 +9954,6 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-io 40.0.0",
  "sp-runtime 41.1.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "staging-xcm 16.1.0",
 ]
 
@@ -15581,7 +15580,6 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-io 40.0.0",
  "sp-runtime 41.1.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,6 @@ sp-mmr-primitives = { version = "36.1.0", default-features = false }
 sp-offchain = { version = "36.0.0", default-features = false }
 sp-runtime = { version = "41.1.0", default-features = false }
 sp-session = { version = "38.1.0", default-features = false }
-sp-std = { version = "14.0.0", default-features = false }
 sp-timestamp = { version = "36.0.0" }
 sp-transaction-pool = { version = "36.0.0", default-features = false }
 sp-version = { version = "39.0.0", default-features = false }

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -23,7 +23,6 @@ frame-system.workspace = true
 pallet-contracts.workspace = true
 sp-core.workspace = true
 sp-runtime.workspace = true
-sp-std.workspace = true
 
 [dev-dependencies]
 contract-build.workspace = true
@@ -57,5 +56,4 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]

--- a/extension/src/decoding.rs
+++ b/extension/src/decoding.rs
@@ -1,5 +1,6 @@
+use alloc::vec::Vec;
+
 use sp_runtime::DispatchError;
-use sp_std::vec::Vec;
 
 use super::*;
 

--- a/extension/src/environment.rs
+++ b/extension/src/environment.rs
@@ -1,8 +1,8 @@
+use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use frame_support::pallet_prelude::Weight;
 use pallet_contracts::chain_extension::{BufInBufOutState, ChargedAmount, Result, State};
-use sp_std::vec::Vec;
 
 use crate::AccountIdOf;
 

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 pub use decoding::{Decode, Decodes, DecodingFailed, Identity, Processor};
@@ -21,7 +23,6 @@ use pallet_contracts::{
 };
 use sp_core::Get;
 use sp_runtime::{traits::Dispatchable, DispatchError};
-use sp_std::vec::Vec;
 
 mod decoding;
 mod environment;

--- a/pallets/api/Cargo.toml
+++ b/pallets/api/Cargo.toml
@@ -26,7 +26,6 @@ pallet-assets.workspace = true
 pallet-nfts.workspace = true
 sp-core.workspace = true
 sp-runtime.workspace = true
-sp-std.workspace = true
 
 # Cross chain
 ismp.workspace = true
@@ -63,7 +62,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/pallets/api/src/extension.rs
+++ b/pallets/api/src/extension.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use alloc::vec::Vec;
 use core::{fmt::Debug, marker::PhantomData};
 

--- a/pallets/api/src/extension.rs
+++ b/pallets/api/src/extension.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+use alloc::vec::Vec;
 use core::{fmt::Debug, marker::PhantomData};
 
 use frame_support::traits::Get;
@@ -8,7 +10,6 @@ use pop_chain_extension::{
 	Converter, Decodes, Environment, LogTarget, Matches, Processor, Result, RetVal,
 };
 use sp_runtime::DispatchError;
-use sp_std::vec::Vec;
 
 /// Encoded version of `pallet_contracts::Error::DecodingFailed`, as found within
 /// `DispatchError::ModuleError`.

--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -2,6 +2,7 @@
 //! goal is to provide a simplified, consistent API that adheres to standards in the smart contract
 //! space.
 
+extern crate alloc;
 use frame_support::traits::fungibles::{metadata::Inspect as MetadataInspect, Inspect};
 pub use pallet::*;
 use pallet_assets::WeightInfo as AssetsWeightInfoTrait;
@@ -37,7 +38,7 @@ pub mod pallet {
 		traits::{CheckedSub, StaticLookup, Zero},
 		Saturating,
 	};
-	use sp_std::vec::Vec;
+	use alloc::vec::Vec;
 
 	use super::*;
 

--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -2,7 +2,6 @@
 //! goal is to provide a simplified, consistent API that adheres to standards in the smart contract
 //! space.
 
-extern crate alloc;
 use frame_support::traits::fungibles::{metadata::Inspect as MetadataInspect, Inspect};
 pub use pallet::*;
 use pallet_assets::WeightInfo as AssetsWeightInfoTrait;
@@ -26,6 +25,7 @@ type WeightOf<T> = <T as Config>::WeightInfo;
 
 #[frame_support::pallet]
 pub mod pallet {
+	use alloc::vec::Vec;
 	use core::cmp::Ordering::*;
 
 	use frame_support::{
@@ -38,7 +38,6 @@ pub mod pallet {
 		traits::{CheckedSub, StaticLookup, Zero},
 		Saturating,
 	};
-	use alloc::vec::Vec;
 
 	use super::*;
 

--- a/pallets/api/src/lib.rs
+++ b/pallets/api/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
 pub use extension::Extension;
 use frame_support::pallet_prelude::Weight;
 

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -1,6 +1,7 @@
 //! TODO: pallet docs.
 
-extern crate alloc;
+use alloc::vec::Vec;
+
 use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchResult, DispatchResultWithPostInfo},
@@ -17,7 +18,6 @@ pub use pallet::*;
 use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_runtime::{traits::Saturating, BoundedVec, SaturatedConversion};
-use alloc::vec::Vec;
 use transports::{
 	ismp::{self as ismp, FeeMetadata, IsmpDispatcher},
 	xcm::{self as xcm, Location, QueryId},

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -1,5 +1,6 @@
 //! TODO: pallet docs.
 
+extern crate alloc;
 use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchResult, DispatchResultWithPostInfo},
@@ -16,7 +17,7 @@ pub use pallet::*;
 use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_runtime::{traits::Saturating, BoundedVec, SaturatedConversion};
-use sp_std::vec::Vec;
+use alloc::vec::Vec;
 use transports::{
 	ismp::{self as ismp, FeeMetadata, IsmpDispatcher},
 	xcm::{self as xcm, Location, QueryId},


### PR DESCRIPTION
As per [polkadot-sdk#7043](https://github.com/paritytech/polkadot-sdk/pull/7043).

This PR substitutes the remaining dependencies on `sp-std`, all of them bringing `Vec` into scope. Now `Vec` is brought from `alloc` instead.