### PR TITLE
docs: note required missing revive migration for testnet

### DIFF
--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -154,6 +154,12 @@ pub type UncheckedExtrinsic =
 ///
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
 pub type Migrations = (
+	// ----- pallet-revive -----
+	// With pop-node uplift to polkadot-sdk 2503 revive needs a migration if it is being depolyed
+	// on a live chain.
+	// src: https://github.com/paritytech/polkadot-sdk/pull/7230
+	// The migration is not included in this runtime version.
+	// -------------------------
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
 	// Unreleased.
 	pallet_assets::migration::next_asset_id::SetNextAssetId<


### PR DESCRIPTION
As per [polkadot-sdk#7230](https://github.com/paritytech/polkadot-sdk/pull/7230).

Testnet needs a migration for `pallet-revive` in case a new version of the runtime is to be deployed.