### PR TITLE
feat(xcm): implement XcmEventEmitter

### DIFF
--- a/runtime/devnet/src/config/xcm.rs
+++ b/runtime/devnet/src/config/xcm.rs
@@ -174,6 +174,7 @@ impl xcm_executor::Config for XcmConfig {
 	// Teleporting is disabled.
 	type UniversalLocation = UniversalLocation;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
+	type XcmEventEmitter = PolkadotXcm;
 	type XcmRecorder = PolkadotXcm;
 	type XcmSender = XcmRouter;
 }

--- a/runtime/mainnet/src/config/xcm.rs
+++ b/runtime/mainnet/src/config/xcm.rs
@@ -208,6 +208,7 @@ impl xcm_executor::Config for XcmConfig {
 	type UniversalLocation = UniversalLocation;
 	type Weigher =
 		WeightInfoBounds<xcm_weights::PopXcmWeight<RuntimeCall>, RuntimeCall, MaxInstructions>;
+	type XcmEventEmitter = PolkadotXcm;
 	type XcmRecorder = PolkadotXcm;
 	type XcmSender = XcmRouter;
 }
@@ -861,6 +862,14 @@ mod tests {
 						MaxInstructions,
 					>,
 				>(),
+			);
+		}
+
+		#[test]
+		fn uses_pallet_xcm_to_emit_events() {
+			assert_eq!(
+				TypeId::of::<<XcmConfig as xcm_executor::Config>::XcmEventEmitter>(),
+				TypeId::of::<PolkadotXcm>(),
 			);
 		}
 

--- a/runtime/testnet/src/config/xcm.rs
+++ b/runtime/testnet/src/config/xcm.rs
@@ -212,6 +212,7 @@ impl xcm_executor::Config for XcmConfig {
 	// Teleporting is disabled.
 	type UniversalLocation = UniversalLocation;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
+	type XcmEventEmitter = PolkadotXcm;
 	type XcmRecorder = PolkadotXcm;
 	type XcmSender = XcmRouter;
 }


### PR DESCRIPTION
As per [polkadot-sdk#7234](https://github.com/paritytech/polkadot-sdk/pull/7234).

This PR implements the `EventEmitter` trait of the XCM executor for all the runtimes, allowing configurable event emission.