### PR TITLE
refactor: derive `DecodeWithMemTracking`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
 ]
@@ -89,10 +89,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -165,7 +165,7 @@ dependencies = [
  "derive_more 2.0.1",
  "foldhash",
  "hashbrown 0.15.2",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -173,7 +173,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "ruint",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -200,7 +200,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -212,11 +212,11 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -233,7 +233,7 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "syn-solidity",
 ]
 
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "approx"
@@ -357,7 +357,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -539,7 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -577,7 +577,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -662,7 +662,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -805,7 +805,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -829,7 +829,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "synstructure 0.13.1",
 ]
 
@@ -841,7 +841,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "synstructure 0.13.1",
 ]
 
@@ -864,7 +864,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -955,7 +955,7 @@ dependencies = [
  "staging-xcm 14.0.3",
  "staging-xcm-builder 15.0.0",
  "staging-xcm-executor 15.0.0",
- "substrate-wasm-builder 23.0.0",
+ "substrate-wasm-builder 23.0.1",
  "system-parachains-constants 1.0.0 (git+https://github.com/paseo-network/runtimes?tag=v1.3.4)",
  "xcm-runtime-apis 0.2.0",
 ]
@@ -1106,7 +1106,7 @@ dependencies = [
  "staging-xcm 14.0.3",
  "staging-xcm-builder 15.0.0",
  "staging-xcm-executor 15.0.0",
- "substrate-wasm-builder 23.0.0",
+ "substrate-wasm-builder 23.0.1",
 ]
 
 [[package]]
@@ -1334,13 +1334,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1400,7 +1400,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1462,9 +1462,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "binary-merkle-tree"
@@ -1490,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "hash-db",
  "log",
@@ -1524,7 +1524,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1610,9 +1610,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitvec"
@@ -1682,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -1736,7 +1736,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-named-pipe",
@@ -1749,7 +1749,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -2242,9 +2242,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byte-tools"
@@ -2254,9 +2254,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -2266,21 +2266,20 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -2320,7 +2319,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2328,23 +2327,23 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.12"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -2429,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2439,7 +2438,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -2501,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2511,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2524,14 +2523,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2542,9 +2541,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "coarsetime"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4252bf230cb600c19826a575b31c8c9c84c6f11acfab6dfcad2e941b10b6f8e2"
+checksum = "91849686042de1b41cd81490edc83afbcb0abe5a9b6f2c4114f23ce8cca1bcf4"
 dependencies = [
  "libc",
  "wasix",
@@ -2553,12 +2552,13 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2584,7 +2584,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2620,7 +2620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2640,14 +2640,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys 0.59.0",
 ]
 
@@ -2685,7 +2685,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -2743,12 +2743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
-name = "constcat"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
-
-[[package]]
 name = "contract-build"
 version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,7 +2751,7 @@ dependencies = [
  "anyhow",
  "blake2 0.10.6",
  "bollard",
- "cargo_metadata 0.19.1",
+ "cargo_metadata 0.19.2",
  "clap",
  "colored",
  "contract-metadata",
@@ -2769,7 +2763,7 @@ dependencies = [
  "parity-scale-codec",
  "regex",
  "rustc_version 0.4.1",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "strum 0.26.3",
@@ -2777,14 +2771,14 @@ dependencies = [
  "term_size",
  "tokio",
  "tokio-stream",
- "toml 0.8.19",
+ "toml 0.8.21",
  "tracing",
  "url",
  "uzers",
  "walkdir",
  "wasm-encoder",
  "wasm-opt",
- "wasmparser 0.220.0",
+ "wasmparser 0.220.1",
  "which",
  "zip",
 ]
@@ -2797,7 +2791,7 @@ checksum = "3ce11bf540c9b154aca38e9d828ae7ea93ec7b4486c5dea87d553016b28af175"
 dependencies = [
  "anyhow",
  "impl-serde 0.5.0",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "url",
@@ -3019,7 +3013,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "crossterm_winapi",
  "mio",
  "parking_lot 0.12.3",
@@ -3437,8 +3431,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "0.18.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro 0.6.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
@@ -3447,15 +3441,15 @@ dependencies = [
  "cumulus-primitives-proof-size-hostfunction 0.11.0",
  "environmental",
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue 42.0.0",
  "parity-scale-codec",
  "polkadot-parachain-primitives 15.0.0",
- "polkadot-runtime-common 18.0.0",
- "polkadot-runtime-parachains 18.0.1",
+ "polkadot-runtime-common 18.1.0",
+ "polkadot-runtime-parachains 18.1.0",
  "scale-info",
  "sp-core 35.0.0",
  "sp-externalities 0.30.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
@@ -3466,8 +3460,8 @@ dependencies = [
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-trie 38.0.0",
  "sp-version 38.0.0",
- "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
+ "staging-xcm 15.0.3",
+ "staging-xcm-builder 18.1.0",
  "trie-db 0.29.1",
 ]
 
@@ -3513,21 +3507,21 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "befbaf3a1ce23ac8476481484fef5f4d500cbd15b4dad6380ce1d28134b0c1f7"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3711,17 +3705,17 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives 16.0.0",
  "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives 17.1.0",
  "scale-info",
  "sp-api 35.0.0",
  "sp-runtime 40.1.0",
  "sp-trie 38.0.0",
- "staging-xcm 15.0.1",
+ "staging-xcm 15.0.3",
 ]
 
 [[package]]
@@ -3762,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core 0.17.0",
@@ -3802,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "sp-externalities 0.30.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-runtime-interface 29.0.0",
@@ -3905,14 +3899,14 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core 0.17.0",
  "futures",
  "jsonrpsee-core",
  "parity-scale-codec",
- "polkadot-overseer 21.0.0",
+ "polkadot-overseer 21.1.0",
  "sc-client-api 38.0.0",
  "sp-api 35.0.0",
  "sp-blockchain 38.0.0",
@@ -4055,7 +4049,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4073,9 +4067,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.137"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc894913dccfed0f84106062c284fa021c3ba70cb1d78797d6f5165d4492e45"
+checksum = "a71ea7f29c73f7ffa64c50b83c9fe4d3a6d4be89a86b009eb80d5a6d3429d741"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -4087,47 +4081,47 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.137"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b2bfb6b3e8ce7f95d865a67419451832083d3186958290cee6c53e39dfcfe"
+checksum = "36a8232661d66dcf713394726157d3cfe0a89bfc85f52d6e9f9bbc2306797fe7"
 dependencies = [
  "cc",
  "codespan-reporting",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.137"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d2cb64a95b4b5a381971482235c4db2e0208302a962acdbe314db03cbbe2fb"
+checksum = "4f44296c8693e9ea226a48f6a122727f77aa9e9e338380cb021accaeeb7ee279"
 dependencies = [
  "clap",
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.137"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f797b0206463c9c2a68ed605ab28892cca784f1ef066050f4942e3de26ad885"
+checksum = "c42f69c181c176981ae44ba9876e2ea41ce8e574c296b38d06925ce9214fb8e4"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.137"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79010a2093848e65a3e0f7062d3f02fb2ef27f866416dfe436fccfa73d3bb59"
+checksum = "8faff5d4467e0709448187df29ccbf3b0982cc426ee444a193f87b11afb565a8"
 dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4142,12 +4136,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.10",
- "darling_macro 0.20.10",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -4166,16 +4160,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4191,13 +4185,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.10",
+ "darling_core 0.20.11",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4215,15 +4209,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b"
+checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -4231,19 +4225,19 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
+checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -4293,9 +4287,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -4320,18 +4314,18 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.2.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+checksum = "2364b9aa47e460ce9bca6ac1777d14c98eef7e274eb077beed49f3adc94183ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4342,20 +4336,20 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4384,7 +4378,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -4396,7 +4390,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -4495,7 +4489,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4519,9 +4513,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.98",
+ "syn 2.0.101",
  "termcolor",
- "toml 0.8.19",
+ "toml 0.8.21",
  "walkdir",
 ]
 
@@ -4539,9 +4533,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dtoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
 name = "duct"
@@ -4579,14 +4573,14 @@ checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -4652,14 +4646,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -4745,7 +4739,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4765,7 +4759,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4785,7 +4779,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4805,7 +4799,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4816,7 +4810,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4850,14 +4844,14 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
@@ -4869,15 +4863,15 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -4926,7 +4920,7 @@ checksum = "8c321610643004cf908ec0f5f2aa0d8f1f8e14b540562a2887a1111ff1ecbf7b"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec 0.7.0",
+ "impl-codec 0.7.1",
  "impl-rlp 0.4.0",
  "impl-serde 0.5.0",
  "scale-info",
@@ -4957,7 +4951,7 @@ checksum = "1ab15ed80916029f878e0267c3a9f92b67df55e79af370bf66199059ae2b4ee3"
 dependencies = [
  "ethbloom 0.14.1",
  "fixed-hash",
- "impl-codec 0.7.0",
+ "impl-codec 0.7.1",
  "impl-rlp 0.4.0",
  "impl-serde 0.5.0",
  "primitive-types 0.13.1",
@@ -4995,9 +4989,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
@@ -5024,7 +5018,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5093,11 +5087,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
  "expander",
- "indexmap 2.7.1",
- "proc-macro-crate 3.2.0",
+ "indexmap 2.9.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5112,9 +5106,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle 2.6.1",
@@ -5193,6 +5187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5209,9 +5209,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fork-tree"
@@ -5225,7 +5225,7 @@ dependencies = [
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5262,9 +5262,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
@@ -5273,7 +5273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709b26657ebbba53dc7bb616577375ca462b20fef1b00e8d9b20d2435e87f7bc"
 dependencies = [
  "frame-support 36.0.1",
- "frame-support-procedural 30.0.4",
+ "frame-support-procedural 30.0.6",
  "frame-system 36.1.0",
  "linregress",
  "log",
@@ -5295,10 +5295,10 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
- "frame-support 39.0.0",
- "frame-support-procedural 31.0.0",
+ "frame-support 39.1.0",
+ "frame-support-procedural 31.1.0",
  "frame-system 39.1.0",
  "linregress",
  "log",
@@ -5422,21 +5422,21 @@ version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8156f209055d352994ecd49e19658c6b469d7c6de923bd79868957d0dcfb6f71"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5445,10 +5445,10 @@ version = "16.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b9ebdd91dfac51469c51f46d9d946f094be5dd4e7b1041f132ca1b40910f900"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5472,10 +5472,10 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-election-provider-solution-type 14.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "parity-scale-codec",
  "scale-info",
@@ -5634,7 +5634,7 @@ dependencies = [
  "docify",
  "environmental",
  "frame-metadata 16.0.0",
- "frame-support-procedural 30.0.4",
+ "frame-support-procedural 30.0.6",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -5666,8 +5666,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "39.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -5676,7 +5676,7 @@ dependencies = [
  "docify",
  "environmental",
  "frame-metadata 18.0.0",
- "frame-support-procedural 31.0.0",
+ "frame-support-procedural 31.1.0",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -5751,28 +5751,29 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "30.0.4"
+version = "30.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8f9b6bc1517a6fcbf0b2377e5c8c6d39f5bb7862b191a59a9992081d63972d"
+checksum = "8da784d943f2a945be923ab081a7c0837355b38045c50945d7ec1a138e2f3c52"
 dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
+ "docify",
  "expander",
  "frame-support-procedural-tools 13.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.11.0",
  "macro_magic",
- "proc-macro-warning 1.0.2",
+ "proc-macro-warning 1.84.1",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "frame-support-procedural"
-version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "31.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5782,11 +5783,11 @@ dependencies = [
  "frame-support-procedural-tools 13.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "itertools 0.11.0",
  "macro_magic",
- "proc-macro-warning 1.0.2",
+ "proc-macro-warning 1.84.1",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5803,11 +5804,11 @@ dependencies = [
  "frame-support-procedural-tools 13.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.11.0",
  "macro_magic",
- "proc-macro-warning 1.0.2",
+ "proc-macro-warning 1.84.1",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5817,22 +5818,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a088fd6fda5f53ff0c17fc7551ce8bd0ead14ba742228443c8196296a7369b"
 dependencies = [
  "frame-support-procedural-tools-derive 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-support-procedural-tools-derive 12.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5843,17 +5844,17 @@ checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5880,11 +5881,11 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
@@ -6134,7 +6135,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6154,7 +6155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.22",
+ "rustls 0.23.26",
  "rustls-pki-types",
 ]
 
@@ -6235,9 +6236,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6248,16 +6249,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6360,7 +6361,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -6369,17 +6370,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
- "indexmap 2.7.1",
+ "http 1.3.1",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -6490,6 +6491,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6521,9 +6528,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.2"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -6536,7 +6543,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand 0.8.5",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -6546,9 +6553,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.2"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6606,13 +6613,13 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
+ "cfg-if",
  "libc",
- "match_cfg",
- "winapi",
+ "windows-link",
 ]
 
 [[package]]
@@ -6628,9 +6635,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -6655,27 +6662,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -6685,9 +6692,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -6706,7 +6713,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -6722,8 +6729,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.9",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -6756,12 +6763,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.22",
- "rustls-native-certs 0.8.1",
+ "rustls 0.23.26",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -6770,18 +6777,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "libc",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -6804,16 +6812,17 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -6866,9 +6875,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -6890,9 +6899,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -6911,9 +6920,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -6940,7 +6949,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7054,9 +7063,9 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67aa010c1e3da95bf151bd8b4c059b2ed7e75387cdb969b4f8f2723a43f9941"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -7127,7 +7136,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7162,9 +7171,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -7224,7 +7233,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7287,7 +7296,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7302,7 +7311,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "synstructure 0.13.1",
 ]
 
@@ -7381,9 +7390,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array 0.14.7",
 ]
@@ -7466,7 +7475,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -7480,11 +7489,11 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.0",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -7518,7 +7527,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde-hex-utils",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7526,9 +7535,9 @@ name = "ismp-parachain"
 version = "1.15.3"
 source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
- "cumulus-pallet-parachain-system 0.18.0",
+ "cumulus-pallet-parachain-system 0.18.1",
  "cumulus-primitives-core 0.17.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "hex-literal",
  "ismp",
@@ -7572,7 +7581,7 @@ name = "ismp-parachain-runtime-api"
 version = "1.15.1"
 source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
- "cumulus-pallet-parachain-system 0.18.0",
+ "cumulus-pallet-parachain-system 0.18.1",
  "sp-api 35.0.0",
 ]
 
@@ -7613,23 +7622,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.14"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "jni"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if",
  "combine",
  "jni-sys",
  "log",
  "thiserror 1.0.69",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7640,10 +7684,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -7659,9 +7704,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834af00800e962dee8f7bfc0f60601de215e73e78e5497d733a2919da837d3c8"
+checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -7675,16 +7720,16 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def0fd41e2f53118bd1620478d12305b2c75feef57ea1f93ef70568c98081b7e"
+checksum = "bacb85abf4117092455e1573625e21b8f8ef4dec8aff13361140b2dc266cdff2"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.22",
+ "rustls 0.23.26",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto 0.8.1",
@@ -7698,22 +7743,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76637f6294b04e747d68e69336ef839a3493ca62b35bf488ead525f7da75c5bb"
+checksum = "456196007ca3a14db478346f58c7238028d55ee15c1df15115596e411ff27925"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -7724,25 +7769,25 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcae0c6c159e11541080f1f829873d8f374f81eda0abc67695a13fc8dc1a580"
+checksum = "5e65763c942dfc9358146571911b0cd1c361c2d63e2d2305622d40d36376ca80"
 dependencies = [
  "heck 0.5.0",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7a3df90a1a60c3ed68e7ca63916b53e9afa928e33531e87f61a9c8e9ae87b"
+checksum = "55e363146da18e50ad2b51a0a7925fc423137a0b1371af8235b1c231a0647328"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -7764,11 +7809,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb81adb1a5ae9182df379e374a79e24e992334e7346af4d065ae5b2acb8d4c6"
+checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
 dependencies = [
- "http 1.2.0",
+ "http 1.3.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -7776,11 +7821,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4f3642a292f5b76d8a16af5c88c16a0860f2ccc778104e5c848b28183d9538"
+checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
 dependencies = [
- "http 1.2.0",
+ "http 1.3.1",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -7918,9 +7963,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -7934,9 +7979,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libp2p"
@@ -7948,7 +7993,7 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "instant",
  "libp2p-allow-block-list 0.2.0",
  "libp2p-connection-limits 0.2.1",
@@ -7985,7 +8030,7 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libp2p-allow-block-list 0.4.0",
  "libp2p-connection-limits 0.4.0",
  "libp2p-core 0.42.0",
@@ -8283,7 +8328,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
  "trust-dns-proto 0.22.0",
  "void",
@@ -8304,7 +8349,7 @@ dependencies = [
  "libp2p-swarm 0.45.1",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
  "tracing",
  "void",
@@ -8451,7 +8496,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.16.20",
  "rustls 0.21.12",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -8472,9 +8517,9 @@ dependencies = [
  "parking_lot 0.12.3",
  "quinn 0.11.7",
  "rand 0.8.5",
- "ring 0.17.8",
- "rustls 0.23.22",
- "socket2 0.5.8",
+ "ring 0.17.14",
+ "rustls 0.23.26",
+ "socket2 0.5.9",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -8575,7 +8620,7 @@ dependencies = [
  "proc-macro-warning 0.4.2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8587,7 +8632,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8603,7 +8648,7 @@ dependencies = [
  "libp2p-core 0.40.1",
  "libp2p-identity",
  "log",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
 ]
 
@@ -8619,7 +8664,7 @@ dependencies = [
  "libc",
  "libp2p-core 0.42.0",
  "libp2p-identity",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
  "tracing",
 ]
@@ -8654,8 +8699,8 @@ dependencies = [
  "libp2p-core 0.42.0",
  "libp2p-identity",
  "rcgen 0.11.3",
- "ring 0.17.8",
- "rustls 0.23.22",
+ "ring 0.17.14",
+ "rustls 0.23.26",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.69",
  "x509-parser 0.16.0",
@@ -8726,7 +8771,7 @@ dependencies = [
  "soketto 0.8.1",
  "thiserror 1.0.69",
  "url",
- "webpki-roots 0.25.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -8747,7 +8792,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "url",
- "webpki-roots 0.25.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -8784,9 +8829,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.11",
 ]
 
 [[package]]
@@ -8806,12 +8851,12 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64 0.13.1",
+ "base64 0.22.1",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -8854,9 +8899,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
  "pkg-config",
@@ -8865,9 +8910,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
+checksum = "4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212"
 dependencies = [
  "cc",
 ]
@@ -8889,22 +8934,22 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566336154b9e58a4f055f6dd4cbab62c7dc0826ce3c0a04e63b2d2ecd784cdae"
+checksum = "22d227772b5999ddc0690e733f734f95ca05387e329c4084fe65678c51198ffe"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbe595006d355eaf9ae11db92707d4338cd2384d16866131cc1afdbdd35d8d9"
+checksum = "71a98813fa0073a317ed6a8055dcd4722a49d9b862af828ee68449adb799b6be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8935,6 +8980,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lioness"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8948,9 +8999,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
@@ -8967,7 +9018,7 @@ dependencies = [
  "futures-timer",
  "hex-literal",
  "hickory-resolver",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "libc",
  "mockall 0.13.1",
  "multiaddr 0.17.1",
@@ -8986,8 +9037,8 @@ dependencies = [
  "simple-dns",
  "smallvec",
  "snow",
- "socket2 0.5.8",
- "thiserror 2.0.11",
+ "socket2 0.5.9",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -9015,9 +9066,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
@@ -9088,7 +9139,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9100,7 +9151,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9114,7 +9165,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9125,7 +9176,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9136,14 +9187,8 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -9255,9 +9300,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -9385,7 +9430,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9599,7 +9644,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9644,7 +9689,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -9745,7 +9790,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9857,9 +9902,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -9909,10 +9954,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b1d40dd8f367db3c65bec8d3dd47d4a604ee8874480738f93191bddab4e0e0"
 dependencies = [
  "expander",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itertools 0.11.0",
- "petgraph",
- "proc-macro-crate 3.2.0",
+ "petgraph 0.6.5",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -9979,11 +10024,11 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "21.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "parity-scale-codec",
@@ -10083,11 +10128,11 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-rate"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "18.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "parity-scale-codec",
  "scale-info",
@@ -10269,9 +10314,9 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "pallet-session 39.0.0",
  "parity-scale-codec",
@@ -10315,9 +10360,9 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10366,11 +10411,11 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "39.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "pallet-authorship 39.0.0",
@@ -10475,12 +10520,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "docify",
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "parity-scale-codec",
@@ -10678,11 +10723,11 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bitvec",
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "parity-scale-codec",
@@ -10850,7 +10895,7 @@ checksum = "e35aaa3d7f1dba4ea7b74d7015e6068b753d1f7f63b39a4ce6377de1bc51b476"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10986,12 +11031,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "38.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-benchmarking 39.0.0",
  "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "pallet-election-provider-support-benchmarking 38.0.0",
@@ -11047,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-benchmarking 39.0.0",
  "frame-election-provider-support 39.0.0",
@@ -11112,13 +11157,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "38.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "docify",
  "frame-benchmarking 39.0.0",
  "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "parity-scale-codec",
@@ -11214,12 +11259,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "39.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "enumflags2",
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "parity-scale-codec",
@@ -11328,7 +11373,7 @@ dependencies = [
  "anyhow",
  "fortuples",
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "ismp",
  "log",
@@ -11428,11 +11473,11 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "environmental",
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "parity-scale-codec",
@@ -11525,10 +11570,10 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "parity-scale-codec",
@@ -12070,7 +12115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "895fe6f50f621a69132697b8b43d29d1db4d9ff445eec410bf1fc98cd7e9412c"
 dependencies = [
  "alloy-core",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "environmental",
  "ethabi-decode 2.0.0",
  "ethereum-types 0.15.1",
@@ -12123,7 +12168,7 @@ dependencies = [
  "polkavm-linker 0.21.0",
  "sp-core 36.1.0",
  "sp-io 40.0.0",
- "toml 0.8.19",
+ "toml 0.8.21",
 ]
 
 [[package]]
@@ -12134,7 +12179,7 @@ checksum = "63c2dc2fc6961da23fefc54689ce81a8e006f6988bc465dcc9ab9db905d31766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12228,9 +12273,9 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "impl-trait-for-tuples",
  "log",
@@ -12347,12 +12392,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "39.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "39.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-benchmarking 39.0.0",
  "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "pallet-authorship 39.0.0",
@@ -12395,16 +12440,16 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db5e6b1d8ee9d3f6894c5abd8c3e17737ed738c9854f87bfd16239741b7f4d5d"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "log",
  "sp-arithmetic 26.0.0",
@@ -12534,11 +12579,11 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "docify",
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "parity-scale-codec",
@@ -12608,11 +12653,11 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "39.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "parity-scale-codec",
  "scale-info",
@@ -12704,16 +12749,16 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "38.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "docify",
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 40.0.0",
+ "pallet-balances 40.1.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -12840,11 +12885,11 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "39.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "log",
  "parity-scale-codec",
@@ -13073,7 +13118,7 @@ dependencies = [
  "staging-parachain-info 0.15.0",
  "staging-xcm 14.0.3",
  "staging-xcm-executor 15.0.0",
- "substrate-wasm-builder 23.0.0",
+ "substrate-wasm-builder 23.0.1",
 ]
 
 [[package]]
@@ -13201,10 +13246,10 @@ version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13291,7 +13336,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.11",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -13399,7 +13444,7 @@ dependencies = [
  "staging-xcm 14.0.3",
  "staging-xcm-builder 15.0.0",
  "staging-xcm-executor 15.0.0",
- "substrate-wasm-builder 23.0.0",
+ "substrate-wasm-builder 23.0.1",
  "xcm-runtime-apis 0.2.0",
 ]
 
@@ -13479,20 +13524,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -13500,22 +13545,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -13528,28 +13573,38 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
- "indexmap 2.7.1",
+ "fixedbitset 0.4.2",
+ "indexmap 2.9.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13587,9 +13642,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polkadot-approval-distribution"
@@ -13759,7 +13814,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13788,7 +13843,7 @@ dependencies = [
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "parity-scale-codec",
  "polkadot-node-network-protocol 22.0.0",
  "polkadot-node-primitives 19.0.0",
@@ -13890,7 +13945,7 @@ checksum = "675753ce0f12f89a1c656b35bfd4a1ced2f6942bc71b323fab96dc5a3f7ae3a0"
 dependencies = [
  "async-trait",
  "bitvec",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "futures",
  "futures-timer",
  "itertools 0.11.0",
@@ -14211,17 +14266,17 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "21.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bs58",
  "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives 17.1.0",
  "prioritized-metered-channel",
- "sc-cli 0.50.0",
+ "sc-cli 0.50.1",
  "sc-service 0.49.0",
  "sc-tracing 38.0.0",
  "substrate-prometheus-endpoint 0.17.1",
@@ -14249,22 +14304,22 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
  "bitvec",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fatality",
  "futures",
  "hex",
  "parity-scale-codec",
- "polkadot-node-primitives 17.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-node-primitives 17.0.1",
+ "polkadot-primitives 17.1.0",
  "rand 0.8.5",
  "sc-authority-discovery 0.48.0",
- "sc-network 0.48.0",
- "sc-network-types 0.15.0",
+ "sc-network 0.48.3",
+ "sc-network-types 0.15.2",
  "sp-runtime 40.1.0",
  "strum 0.26.3",
  "thiserror 1.0.69",
@@ -14280,7 +14335,7 @@ dependencies = [
  "async-channel 1.9.0",
  "async-trait",
  "bitvec",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fatality",
  "futures",
  "hex",
@@ -14299,8 +14354,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "17.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -14308,7 +14363,7 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives 17.1.0",
  "sc-keystore 34.0.0",
  "schnorrkel 0.11.4",
  "serde",
@@ -14360,23 +14415,23 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "21.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "bitvec",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fatality",
  "futures",
  "orchestra",
  "polkadot-node-network-protocol 21.0.0",
- "polkadot-node-primitives 17.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-node-primitives 17.0.1",
+ "polkadot-primitives 17.1.0",
  "polkadot-statement-table 17.0.0",
  "sc-client-api 38.0.0",
- "sc-network 0.48.0",
- "sc-network-types 0.15.0",
- "sc-transaction-pool-api 38.0.0",
+ "sc-network 0.48.3",
+ "sc-network-types 0.15.2",
+ "sc-transaction-pool-api 38.1.0",
  "smallvec",
  "sp-api 35.0.0",
  "sp-authority-discovery 35.0.0",
@@ -14394,7 +14449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c49e4a49a9be59cdd68922591e706bd6093d5175277b8417b37982025887a7af"
 dependencies = [
  "async-trait",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fatality",
  "futures",
  "orchestra",
@@ -14450,19 +14505,19 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "21.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "orchestra",
  "parking_lot 0.12.3",
- "polkadot-node-metrics 21.0.0",
+ "polkadot-node-metrics 21.1.0",
  "polkadot-node-network-protocol 21.0.0",
- "polkadot-node-primitives 17.0.0",
- "polkadot-node-subsystem-types 21.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-node-primitives 17.0.1",
+ "polkadot-node-subsystem-types 21.0.1",
+ "polkadot-primitives 17.1.0",
  "sc-client-api 38.0.0",
  "sp-api 35.0.0",
  "sp-core 35.0.0",
@@ -14498,7 +14553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61070d0ff28f596890def0e0d03c231860796130b2a43e293106fa86a50c9a9"
 dependencies = [
  "bounded-collections",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "polkadot-core-primitives 14.0.0",
  "scale-info",
@@ -14512,10 +14567,10 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bounded-collections",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "polkadot-core-primitives 16.0.0",
  "scale-info",
@@ -14532,7 +14587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72943c0948c686b47bacb1a03e59baff63bfba2e16e208d77f0f8615827f8564"
 dependencies = [
  "bounded-collections",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "polkadot-core-primitives 17.1.0",
  "scale-info",
@@ -14572,8 +14627,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "17.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -14715,34 +14770,34 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "18.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bitvec",
  "frame-benchmarking 39.0.0",
  "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
- "pallet-asset-rate 18.0.0",
+ "pallet-asset-rate 18.1.0",
  "pallet-authorship 39.0.0",
- "pallet-balances 40.0.0",
+ "pallet-balances 40.1.0",
  "pallet-broker 0.18.0",
- "pallet-election-provider-multi-phase 38.0.0",
- "pallet-fast-unstake 38.0.0",
- "pallet-identity 39.0.0",
+ "pallet-election-provider-multi-phase 38.1.0",
+ "pallet-fast-unstake 38.1.0",
+ "pallet-identity 39.1.0",
  "pallet-session 39.0.0",
- "pallet-staking 39.0.1",
+ "pallet-staking 39.1.0",
  "pallet-staking-reward-fn 22.0.0",
  "pallet-timestamp 38.0.0",
- "pallet-transaction-payment 39.0.0",
- "pallet-treasury 38.0.0",
- "pallet-vesting 39.0.0",
+ "pallet-transaction-payment 39.1.0",
+ "pallet-treasury 38.1.0",
+ "pallet-vesting 39.1.0",
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
- "polkadot-runtime-parachains 18.0.1",
+ "polkadot-primitives 17.1.0",
+ "polkadot-runtime-parachains 18.1.0",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -14757,9 +14812,9 @@ dependencies = [
  "sp-runtime 40.1.0",
  "sp-session 37.0.0",
  "sp-staking 37.0.0",
- "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
+ "staging-xcm 15.0.3",
+ "staging-xcm-builder 18.1.0",
+ "staging-xcm-executor 18.0.2",
  "static_assertions",
 ]
 
@@ -14846,12 +14901,12 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bs58",
  "frame-benchmarking 39.0.0",
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives 17.1.0",
  "sp-tracing 17.0.1",
 ]
 
@@ -14876,7 +14931,7 @@ checksum = "63f6a36ba61ca8f2c07b7061894f3a947d77189c66e992a2f23109eb01dfa9e0"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "frame-benchmarking 36.0.0",
  "frame-support 36.0.1",
  "frame-system 36.1.0",
@@ -14920,32 +14975,32 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "18.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery 39.0.0",
  "pallet-authorship 39.0.0",
- "pallet-babe 39.0.0",
- "pallet-balances 40.0.0",
+ "pallet-babe 39.1.0",
+ "pallet-balances 40.1.0",
  "pallet-broker 0.18.0",
  "pallet-message-queue 42.0.0",
  "pallet-mmr 39.0.0",
  "pallet-session 39.0.0",
- "pallet-staking 39.0.1",
+ "pallet-staking 39.1.0",
  "pallet-timestamp 38.0.0",
- "pallet-vesting 39.0.0",
+ "pallet-vesting 39.1.0",
  "parity-scale-codec",
  "polkadot-core-primitives 16.0.0",
  "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives 17.1.0",
  "polkadot-runtime-metrics 18.0.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -14962,8 +15017,8 @@ dependencies = [
  "sp-session 37.0.0",
  "sp-staking 37.0.0",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "staging-xcm 15.0.1",
- "staging-xcm-executor 18.0.0",
+ "staging-xcm 15.0.3",
+ "staging-xcm-executor 18.0.2",
 ]
 
 [[package]]
@@ -15179,7 +15234,7 @@ dependencies = [
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "parity-scale-codec",
  "polkadot-node-network-protocol 22.0.0",
  "polkadot-node-primitives 19.0.0",
@@ -15195,10 +15250,10 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives 17.1.0",
  "sp-core 35.0.0",
  "tracing-gum 17.0.0",
 ]
@@ -15346,7 +15401,7 @@ dependencies = [
  "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15358,7 +15413,7 @@ dependencies = [
  "polkavm-common 0.18.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15370,7 +15425,7 @@ dependencies = [
  "polkavm-common 0.21.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15380,7 +15435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15390,7 +15445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
 dependencies = [
  "polkavm-derive-impl 0.18.1",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15400,7 +15455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36837f6b7edfd6f4498f8d25d81da16cf03bd6992c3e56f3d477dfc90f4fefca"
 dependencies = [
  "polkavm-derive-impl 0.21.0",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15530,7 +15585,7 @@ dependencies = [
  "enumflags2",
  "ink",
  "pop-primitives",
- "sp-io 38.0.0",
+ "sp-io 38.0.1",
 ]
 
 [[package]]
@@ -15538,7 +15593,7 @@ name = "pop-api-integration-tests"
 version = "0.1.0"
 dependencies = [
  "contract-build",
- "env_logger 0.11.6",
+ "env_logger 0.11.8",
  "frame-support 40.1.0",
  "frame-system 40.1.0",
  "ismp",
@@ -15566,7 +15621,7 @@ name = "pop-chain-extension"
 version = "0.1.0"
 dependencies = [
  "contract-build",
- "env_logger 0.11.6",
+ "env_logger 0.11.8",
  "frame-support 40.1.0",
  "frame-system 40.1.0",
  "impl-trait-for-tuples",
@@ -15727,7 +15782,7 @@ dependencies = [
  "cumulus-primitives-utility 0.20.0",
  "docify",
  "enumflags2",
- "env_logger 0.11.6",
+ "env_logger 0.11.8",
  "frame-benchmarking 40.0.0",
  "frame-executive 40.0.0",
  "frame-metadata-hash-extension 0.8.0",
@@ -15810,7 +15865,7 @@ dependencies = [
  "cumulus-primitives-utility 0.20.0",
  "docify",
  "enumflags2",
- "env_logger 0.11.6",
+ "env_logger 0.11.8",
  "frame-benchmarking 40.0.0",
  "frame-executive 40.0.0",
  "frame-metadata 18.0.0",
@@ -15891,7 +15946,7 @@ dependencies = [
  "cumulus-primitives-utility 0.20.0",
  "docify",
  "enumflags2",
- "env_logger 0.11.6",
+ "env_logger 0.11.8",
  "frame-benchmarking 40.0.0",
  "frame-executive 40.0.0",
  "frame-metadata 18.0.0",
@@ -15966,9 +16021,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -15978,11 +16042,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -16027,12 +16091,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -16057,7 +16121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
 dependencies = [
  "fixed-hash",
- "impl-codec 0.7.0",
+ "impl-codec 0.7.1",
  "impl-num-traits 0.2.0",
  "impl-rlp 0.4.0",
  "impl-serde 0.5.0",
@@ -16073,7 +16137,7 @@ checksum = "a172e6cc603231f2cf004232eabcecccc0da53ba576ab286ef7baa0cfc7927ad"
 dependencies = [
  "coarsetime",
  "crossbeam-queue",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "futures",
  "futures-timer",
  "nanorand",
@@ -16093,9 +16157,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -16143,7 +16207,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -16154,25 +16218,25 @@ checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "proc-macro-warning"
-version = "1.0.2"
+version = "1.84.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
+checksum = "75eea531cfcd120e0851a3f8aed42c4841f78c889eefafd96339c72677ae42c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -16223,7 +16287,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -16234,7 +16298,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -16258,31 +16322,31 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive 0.13.4",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.7.1",
  "prettyplease",
- "prost 0.13.4",
+ "prost 0.13.5",
  "prost-types",
  "regex",
- "syn 2.0.98",
+ "syn 2.0.101",
  "tempfile",
 ]
 
@@ -16296,36 +16360,36 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost 0.13.4",
+ "prost 0.13.5",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]
@@ -16414,12 +16478,12 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "futures-io",
  "pin-project-lite",
- "quinn-proto 0.11.10",
+ "quinn-proto 0.11.11",
  "quinn-udp 0.5.11",
- "rustc-hash 2.1.0",
- "rustls 0.23.22",
- "socket2 0.5.8",
- "thiserror 2.0.11",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.26",
+ "socket2 0.5.9",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "web-time",
@@ -16444,19 +16508,19 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "rand 0.9.1",
- "ring 0.17.8",
- "rustc-hash 2.1.0",
- "rustls 0.23.22",
+ "ring 0.17.14",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.26",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -16470,7 +16534,7 @@ checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
 dependencies = [
  "bytes",
  "libc",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tracing",
  "windows-sys 0.48.0",
 ]
@@ -16484,19 +16548,25 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tracing",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -16552,7 +16622,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -16561,7 +16631,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -16594,11 +16664,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.3.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6928fa44c097620b706542d428957635951bade7143269085389d42c8a4927e"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -16662,11 +16732,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -16675,7 +16745,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -16686,7 +16756,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87413ebb313323d431e85d0afc5a68222aaed972843537cbfe5f061cf1b4bcab"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fs-err",
  "static_init",
  "thiserror 1.0.69",
@@ -16694,22 +16764,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -16796,12 +16866,11 @@ dependencies = [
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+checksum = "48375394603e3dd4b2d64371f7148fd8c7baa2680e28741f2cb8d23b59e3d4c4"
 dependencies = [
  "hostname",
- "quick-error",
 ]
 
 [[package]]
@@ -16831,15 +16900,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
- "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -17013,13 +17081,13 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rpassword"
-version = "7.3.1"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -17042,12 +17110,12 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -17097,9 +17165,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-hex"
@@ -17122,7 +17190,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.25",
+ "semver 1.0.26",
 ]
 
 [[package]]
@@ -17168,10 +17236,23 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -17193,37 +17274,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring 0.17.14",
  "rustls-webpki 0.101.7",
  "sct",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.8",
+ "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.1",
  "subtle 2.6.1",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -17235,16 +17303,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
+ "security-framework",
 ]
 
 [[package]]
@@ -17258,23 +17317,23 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
+checksum = "4937d110d34408e9e5ad30ba0b0ca3b6a8a390f8db3636db60144ac4fa792750"
 dependencies = [
- "core-foundation 0.9.4",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.22",
- "rustls-native-certs 0.7.3",
+ "rustls 0.23.26",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.102.8",
- "security-framework 2.11.1",
+ "rustls-webpki 0.103.1",
+ "security-framework",
  "security-framework-sys",
- "webpki-roots 0.26.8",
- "winapi",
+ "webpki-root-certs",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -17289,26 +17348,26 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.14",
  "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.14",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rusty-fork"
@@ -17340,7 +17399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
 dependencies = [
  "byteorder",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
 ]
 
 [[package]]
@@ -17356,9 +17415,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe_arch"
@@ -17390,7 +17449,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "log",
  "sp-core 35.0.0",
@@ -17413,7 +17472,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "futures",
@@ -17428,8 +17487,8 @@ dependencies = [
  "prost-build",
  "rand 0.8.5",
  "sc-client-api 38.0.0",
- "sc-network 0.48.0",
- "sc-network-types 0.15.0",
+ "sc-network 0.48.3",
+ "sc-network-types 0.15.2",
  "sp-api 35.0.0",
  "sp-authority-discovery 35.0.0",
  "sp-blockchain 38.0.0",
@@ -17494,7 +17553,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "sp-api 35.0.0",
@@ -17525,7 +17584,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "docify",
@@ -17535,7 +17594,7 @@ dependencies = [
  "sc-chain-spec-derive 12.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sc-client-api 38.0.0",
  "sc-executor 0.41.0",
- "sc-network 0.48.0",
+ "sc-network 0.48.3",
  "sc-telemetry 28.0.0",
  "serde",
  "serde_json",
@@ -17582,27 +17641,27 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b18cef11d2c69703e0d7c3528202ef4ed1cd2b47a6f063e9e17cad8255b1fa94"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sc-cli"
-version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "0.50.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -17619,14 +17678,14 @@ dependencies = [
  "regex",
  "rpassword",
  "sc-client-api 38.0.0",
- "sc-client-db 0.45.0",
+ "sc-client-db 0.45.1",
  "sc-keystore 34.0.0",
  "sc-mixnet 0.18.0",
- "sc-network 0.48.0",
+ "sc-network 0.48.3",
  "sc-service 0.49.0",
  "sc-telemetry 28.0.0",
  "sc-tracing 38.0.0",
- "sc-transaction-pool 38.0.0",
+ "sc-transaction-pool 38.1.0",
  "sc-utils 18.0.0",
  "serde",
  "serde_json",
@@ -17687,7 +17746,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "fnv",
  "futures",
@@ -17695,7 +17754,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "sc-executor 0.41.0",
- "sc-transaction-pool-api 38.0.0",
+ "sc-transaction-pool-api 38.1.0",
  "sc-utils 18.0.0",
  "sp-api 35.0.0",
  "sp-blockchain 38.0.0",
@@ -17740,8 +17799,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "0.45.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -17794,7 +17853,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "futures",
@@ -17802,7 +17861,7 @@ dependencies = [
  "mockall 0.11.4",
  "parking_lot 0.12.3",
  "sc-client-api 38.0.0",
- "sc-network-types 0.15.0",
+ "sc-network-types 0.15.2",
  "sc-utils 18.0.0",
  "serde",
  "sp-api 35.0.0",
@@ -18092,7 +18151,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -18139,7 +18198,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "polkavm 0.9.3",
  "sc-allocator 30.0.0",
@@ -18166,7 +18225,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "log",
  "polkavm 0.9.3",
@@ -18189,7 +18248,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -18224,14 +18283,14 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "console",
  "futures",
  "futures-timer",
  "log",
  "sc-client-api 38.0.0",
- "sc-network 0.48.0",
+ "sc-network 0.48.3",
  "sc-network-common 0.47.0",
  "sc-network-sync 0.47.0",
  "sp-blockchain 38.0.0",
@@ -18258,7 +18317,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -18287,7 +18346,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -18301,9 +18360,9 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "sc-client-api 38.0.0",
- "sc-network 0.48.0",
- "sc-network-types 0.15.0",
- "sc-transaction-pool-api 38.0.0",
+ "sc-network 0.48.3",
+ "sc-network-types 0.15.2",
+ "sc-transaction-pool-api 38.1.0",
  "sp-api 35.0.0",
  "sp-consensus 0.41.0",
  "sp-core 35.0.0",
@@ -18344,8 +18403,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "0.48.3"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -18373,7 +18432,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api 38.0.0",
  "sc-network-common 0.47.0",
- "sc-network-types 0.15.0",
+ "sc-network-types 0.15.2",
  "sc-utils 18.0.0",
  "schnellru",
  "serde",
@@ -18447,7 +18506,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -18456,7 +18515,7 @@ dependencies = [
  "parity-scale-codec",
  "prost-build",
  "sc-consensus 0.47.0",
- "sc-network-types 0.15.0",
+ "sc-network-types 0.15.2",
  "sp-consensus 0.41.0",
  "sp-consensus-grandpa 22.0.0",
  "sp-runtime 40.1.0",
@@ -18496,7 +18555,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -18506,8 +18565,8 @@ dependencies = [
  "prost 0.12.6",
  "prost-build",
  "sc-client-api 38.0.0",
- "sc-network 0.48.0",
- "sc-network-types 0.15.0",
+ "sc-network 0.48.3",
+ "sc-network-types 0.15.2",
  "sp-blockchain 38.0.0",
  "sp-core 35.0.0",
  "sp-runtime 40.1.0",
@@ -18539,7 +18598,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -18554,9 +18613,9 @@ dependencies = [
  "prost-build",
  "sc-client-api 38.0.0",
  "sc-consensus 0.47.0",
- "sc-network 0.48.0",
+ "sc-network 0.48.3",
  "sc-network-common 0.47.0",
- "sc-network-types 0.15.0",
+ "sc-network-types 0.15.2",
  "sc-utils 18.0.0",
  "schnellru",
  "smallvec",
@@ -18611,16 +18670,16 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "futures",
  "log",
  "parity-scale-codec",
- "sc-network 0.48.0",
+ "sc-network 0.48.3",
  "sc-network-common 0.47.0",
  "sc-network-sync 0.47.0",
- "sc-network-types 0.15.0",
+ "sc-network-types 0.15.2",
  "sc-utils 18.0.0",
  "sp-consensus 0.41.0",
  "sp-runtime 40.1.0",
@@ -18649,8 +18708,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "0.15.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -18703,7 +18762,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "rand 0.8.5",
- "rustls 0.23.22",
+ "rustls 0.23.26",
  "sc-client-api 39.0.0",
  "sc-network 0.49.0",
  "sc-network-types 0.15.3",
@@ -18732,7 +18791,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -18745,7 +18804,7 @@ dependencies = [
  "sc-mixnet 0.18.0",
  "sc-rpc-api 0.47.0",
  "sc-tracing 38.0.0",
- "sc-transaction-pool-api 38.0.0",
+ "sc-transaction-pool-api 38.1.0",
  "sc-utils 18.0.0",
  "serde_json",
  "sp-api 35.0.0",
@@ -18797,13 +18856,13 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "sc-chain-spec 41.0.0",
  "sc-mixnet 0.18.0",
- "sc-transaction-pool-api 38.0.0",
+ "sc-transaction-pool-api 38.1.0",
  "scale-info",
  "serde",
  "serde_json",
@@ -18838,13 +18897,13 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
  "futures",
  "governor",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
  "ip_network",
@@ -18869,7 +18928,7 @@ dependencies = [
  "forwarded-header-value",
  "futures",
  "governor",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
  "ip_network",
@@ -18887,7 +18946,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "futures",
@@ -18902,7 +18961,7 @@ dependencies = [
  "sc-chain-spec 41.0.0",
  "sc-client-api 38.0.0",
  "sc-rpc 43.0.0",
- "sc-transaction-pool-api 38.0.0",
+ "sc-transaction-pool-api 38.1.0",
  "schnellru",
  "serde",
  "sp-api 35.0.0",
@@ -18968,7 +19027,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "directories",
@@ -18983,25 +19042,25 @@ dependencies = [
  "rand 0.8.5",
  "sc-chain-spec 41.0.0",
  "sc-client-api 38.0.0",
- "sc-client-db 0.45.0",
+ "sc-client-db 0.45.1",
  "sc-consensus 0.47.0",
  "sc-executor 0.41.0",
  "sc-informant 0.47.0",
  "sc-keystore 34.0.0",
- "sc-network 0.48.0",
+ "sc-network 0.48.3",
  "sc-network-common 0.47.0",
  "sc-network-light 0.47.0",
  "sc-network-sync 0.47.0",
  "sc-network-transactions 0.47.0",
- "sc-network-types 0.15.0",
+ "sc-network-types 0.15.2",
  "sc-rpc 43.0.0",
  "sc-rpc-server 20.0.0",
  "sc-rpc-spec-v2 0.48.0",
  "sc-sysinfo 41.0.0",
  "sc-telemetry 28.0.0",
  "sc-tracing 38.0.0",
- "sc-transaction-pool 38.0.0",
- "sc-transaction-pool-api 38.0.0",
+ "sc-transaction-pool 38.1.0",
+ "sc-transaction-pool-api 38.1.0",
  "sc-utils 18.0.0",
  "schnellru",
  "serde",
@@ -19097,7 +19156,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.37.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -19154,9 +19213,9 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "futures",
  "libc",
  "log",
@@ -19178,7 +19237,7 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beadd799aae2a1ac6eac8edcbcfba533ae4aadbf2c7e8449f530fd98b5be7cd9"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "futures",
  "libc",
  "log",
@@ -19196,7 +19255,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "chrono",
  "futures",
@@ -19205,7 +19264,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "sc-network 0.48.0",
+ "sc-network 0.48.3",
  "sc-utils 18.0.0",
  "serde",
  "serde_json",
@@ -19236,7 +19295,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "chrono",
  "console",
@@ -19296,39 +19355,39 @@ version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151cdf86d79abf22cf2a240a7ca95041c908dbd96c2ae9a818073042aa210964"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "38.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itertools 0.11.0",
  "linked-hash-map",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "sc-client-api 38.0.0",
- "sc-transaction-pool-api 38.0.0",
+ "sc-transaction-pool-api 38.1.0",
  "sc-utils 18.0.0",
  "serde",
  "sp-api 35.0.0",
@@ -19353,7 +19412,7 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itertools 0.11.0",
  "linked-hash-map",
  "log",
@@ -19379,8 +19438,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "38.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "futures",
@@ -19401,7 +19460,7 @@ checksum = "55feca303d4ba839f02261c9a73d40f6b0ac7523882b4008472922b934678729"
 dependencies = [
  "async-trait",
  "futures",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "log",
  "parity-scale-codec",
  "serde",
@@ -19414,7 +19473,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -19468,7 +19527,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc79ba56a1c742f5aeeed1f1801f3edf51f7e818f0a54582cac6f131364ea7b"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "scale-bits 0.5.0",
  "scale-decode-derive 0.11.1",
@@ -19482,7 +19541,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "scale-bits 0.6.0",
  "scale-type-resolver 0.2.0",
@@ -19522,10 +19581,10 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ed9401effa946b493f9f84dc03714cca98119b230497df6f3df6b84a2b03648"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -19534,7 +19593,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628800925a33794fb5387781b883b5e14d130fece9af5a63613867b8de07c5c7"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "scale-encode-derive 0.6.0",
  "scale-type-resolver 0.1.1",
@@ -19575,11 +19634,11 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "102fbc6236de6c53906c0b262f12c7aa69c2bdc604862c12728f5f4d370bc137"
 dependencies = [
- "darling 0.20.10",
- "proc-macro-crate 3.2.0",
+ "darling 0.20.11",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -19603,10 +19662,10 @@ version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -19637,7 +19696,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.98",
+ "syn 2.0.101",
  "thiserror 1.0.69",
 ]
 
@@ -19672,9 +19731,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -19684,14 +19743,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -19748,9 +19807,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scratch"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
+checksum = "9f6280af86e5f559536da57a45ebc84948833b3bee313a7dd25232e09c878a52"
 
 [[package]]
 name = "scrypt"
@@ -19770,7 +19829,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.14",
  "untrusted 0.9.0",
 ]
 
@@ -19874,25 +19933,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.8.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "num-bigint",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -19929,9 +19974,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -19959,9 +20004,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -19987,22 +20032,22 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -20013,14 +20058,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -20030,13 +20075,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -20070,7 +20115,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -20203,9 +20248,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -20239,7 +20284,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -20291,7 +20336,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -20322,9 +20367,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smol"
@@ -20375,7 +20420,7 @@ dependencies = [
  "bs58",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "ed25519-zebra",
  "either",
  "event-listener 2.5.3",
@@ -20429,7 +20474,7 @@ dependencies = [
  "bs58",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "ed25519-zebra",
  "either",
  "event-listener 5.4.0",
@@ -20478,7 +20523,7 @@ dependencies = [
  "async-lock 2.8.0",
  "base64 0.21.7",
  "blake2-rfc",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "either",
  "event-listener 2.5.3",
  "fnv",
@@ -20515,7 +20560,7 @@ dependencies = [
  "base64 0.22.1",
  "blake2-rfc",
  "bs58",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "either",
  "event-listener 5.4.0",
  "fnv",
@@ -20557,7 +20602,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "rand_core 0.6.4",
- "ring 0.17.8",
+ "ring 0.17.14",
  "rustc_version 0.4.1",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -20867,9 +20912,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -20899,7 +20944,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.2.0",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -20932,7 +20977,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "docify",
  "hash-db",
@@ -20983,24 +21028,24 @@ dependencies = [
  "Inflector",
  "blake2 0.10.6",
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -21012,10 +21057,10 @@ dependencies = [
  "Inflector",
  "blake2 0.10.6",
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -21035,7 +21080,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -21060,7 +21105,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -21102,7 +21147,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -21138,7 +21183,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "sp-api 35.0.0",
  "sp-inherents 35.0.0",
@@ -21159,7 +21204,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -21198,7 +21243,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "futures",
@@ -21245,7 +21290,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -21297,7 +21342,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -21394,7 +21439,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -21441,7 +21486,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -21511,7 +21556,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -21619,7 +21664,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -21637,17 +21682,17 @@ checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -21663,7 +21708,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -21677,17 +21722,17 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -21715,7 +21760,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -21738,7 +21783,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -21777,7 +21822,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -21830,9 +21875,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "38.0.0"
+version = "38.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ef7eb561bb4839cc8424ce58c5ea236cbcca83f26fcc0426d8decfe8aa97d4"
+checksum = "a47cb95e32bd5f7e2d8d6cd222a14c207a8da05b3f5ab9699d338e99c791320d"
 dependencies = [
  "bytes",
  "docify",
@@ -21858,7 +21903,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bytes",
  "docify",
@@ -21922,7 +21967,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "sp-core 35.0.0",
  "sp-runtime 40.1.0",
@@ -21955,7 +22000,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -21988,7 +22033,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -22008,7 +22053,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "frame-metadata 18.0.0",
  "parity-scale-codec",
@@ -22029,7 +22074,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -22070,7 +22115,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -22119,7 +22164,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -22157,7 +22202,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "sp-api 35.0.0",
  "sp-core 35.0.0",
@@ -22178,7 +22223,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "backtrace",
  "regex",
@@ -22197,7 +22242,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -22245,7 +22290,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "binary-merkle-tree 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "docify",
@@ -22324,7 +22369,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -22368,23 +22413,23 @@ checksum = "0195f32c628fee3ce1dfbbf2e7e52a30ea85f3589da9fe62a8b816d70fc06294"
 dependencies = [
  "Inflector",
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "Inflector",
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -22405,7 +22450,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -22448,7 +22493,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -22517,7 +22562,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "hash-db",
  "log",
@@ -22558,7 +22603,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -22613,7 +22658,7 @@ checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 
 [[package]]
 name = "sp-storage"
@@ -22644,7 +22689,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -22669,7 +22714,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -22694,7 +22739,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -22727,7 +22772,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "sp-api 35.0.0",
  "sp-runtime 40.1.0",
@@ -22746,7 +22791,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -22823,7 +22868,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
@@ -22886,7 +22931,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -22927,7 +22972,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -22937,22 +22982,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54cabc8279e835cd9c608d70cb00e693bddec94fe8478e9f3104dad1da5f93ca"
 dependencies = [
  "parity-scale-codec",
- "proc-macro-warning 1.0.2",
+ "proc-macro-warning 1.84.1",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "parity-scale-codec",
- "proc-macro-warning 1.0.2",
+ "proc-macro-warning 1.84.1",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -22971,7 +23016,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -22983,7 +23028,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -23153,14 +23198,14 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "15.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "15.0.3"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "array-bytes",
  "bounded-collections",
  "derivative",
  "environmental",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "hex-literal",
  "impl-trait-for-tuples",
  "log",
@@ -23169,7 +23214,7 @@ dependencies = [
  "serde",
  "sp-runtime 40.1.0",
  "sp-weights 31.0.0",
- "xcm-procedural 11.0.0",
+ "xcm-procedural 11.0.1",
 ]
 
 [[package]]
@@ -23219,15 +23264,15 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "18.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "frame-system 39.1.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-asset-conversion 21.0.0",
- "pallet-transaction-payment 39.0.0",
+ "pallet-asset-conversion 21.1.0",
+ "pallet-transaction-payment 39.1.0",
  "parity-scale-codec",
  "polkadot-parachain-primitives 15.0.0",
  "scale-info",
@@ -23235,8 +23280,8 @@ dependencies = [
  "sp-io 39.0.0",
  "sp-runtime 40.1.0",
  "sp-weights 31.0.0",
- "staging-xcm 15.0.1",
- "staging-xcm-executor 18.0.0",
+ "staging-xcm 15.0.3",
+ "staging-xcm-executor 18.0.2",
 ]
 
 [[package]]
@@ -23288,12 +23333,12 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "18.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "environmental",
  "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
@@ -23302,7 +23347,7 @@ dependencies = [
  "sp-io 39.0.0",
  "sp-runtime 40.1.0",
  "sp-weights 31.0.0",
- "staging-xcm 15.0.1",
+ "staging-xcm 15.0.3",
  "tracing",
 ]
 
@@ -23422,7 +23467,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -23441,7 +23486,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -23493,7 +23538,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -23524,7 +23569,7 @@ name = "substrate-state-machine"
 version = "1.15.3"
 source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#99e29f58ab1dfcaa1739641ef594c6061c19ec2d"
 dependencies = [
- "frame-support 39.0.0",
+ "frame-support 39.1.0",
  "hash-db",
  "ismp",
  "pallet-ismp",
@@ -23558,9 +23603,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc993ad871b63fbba60362f3ea86583f5e7e1256e8fdcb3b5b249c9ead354bf"
+checksum = "a52ba794a3eb90856487adbb36a7ef99b3903349cbe2c6391651b183d083f1d1"
 dependencies = [
  "build-helper",
  "cargo_metadata 0.15.4",
@@ -23571,7 +23616,7 @@ dependencies = [
  "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.26.3",
  "tempfile",
- "toml 0.8.19",
+ "toml 0.8.21",
  "walkdir",
  "wasm-opt",
 ]
@@ -23602,7 +23647,7 @@ dependencies = [
  "sp-version 39.0.0",
  "strum 0.26.3",
  "tempfile",
- "toml 0.8.19",
+ "toml 0.8.21",
  "walkdir",
  "wasm-opt",
 ]
@@ -23674,7 +23719,7 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.98",
+ "syn 2.0.101",
  "thiserror 1.0.69",
 ]
 
@@ -23730,14 +23775,14 @@ version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7819c5e09aae0319981ee853869f2fcd1fac4db8babd0d004c17161297aadc05"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.20.11",
  "parity-scale-codec",
  "proc-macro-error2",
  "quote",
  "scale-typegen",
  "subxt-codegen",
  "subxt-utils-fetchmetadata",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -23807,9 +23852,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -23825,7 +23870,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -23848,7 +23893,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -23857,7 +23902,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -23921,15 +23966,14 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand 2.3.0",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix 0.38.44",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -23954,11 +23998,11 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 0.38.44",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -23995,11 +24039,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -24019,7 +24063,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -24030,18 +24074,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -24092,9 +24136,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -24107,15 +24151,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -24142,9 +24186,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -24157,9 +24201,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -24168,7 +24212,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -24181,16 +24225,16 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.22",
+ "rustls 0.23.26",
  "tokio",
 ]
 
@@ -24214,8 +24258,8 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.22",
- "rustls-native-certs 0.8.1",
+ "rustls 0.23.26",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -24224,9 +24268,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -24247,9 +24291,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "900f6c86a685850b1bc9f6223b20125115ee3f31e01207d81655bbcc0aea9231"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -24259,25 +24303,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.23"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
 
 [[package]]
 name = "tower"
@@ -24300,9 +24351,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -24342,7 +24393,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -24368,10 +24419,10 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "coarsetime",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives 17.1.0",
  "tracing",
  "tracing-gum-proc-macro 5.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
 ]
@@ -24395,22 +24446,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f074568687ffdfd0adb6005aa8d1d96840197f2c159f80471285f08694cf0ce"
 dependencies = [
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -24569,14 +24620,14 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.2.0",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.9.1",
- "rustls 0.23.22",
+ "rustls 0.23.26",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "url",
  "utf-8",
 ]
@@ -24601,9 +24652,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -24649,9 +24700,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -24667,12 +24718,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -24802,9 +24847,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3028804c8bbae2a97a15b71ffc0e308c4b01a520994aafa77d56e94e19024"
+checksum = "e6bfb937b3d12077654a9e43e32a4e9c20177dd9fea0f3aba673e7840bb54f32"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -24813,14 +24858,12 @@ dependencies = [
  "ark-serialize 0.4.2",
  "ark-serialize-derive 0.4.2",
  "arrayref",
- "constcat",
  "digest 0.10.7",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -24912,9 +24955,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -24950,7 +24993,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -24985,7 +25028,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -25001,12 +25044,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.220.0"
+version = "0.220.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf48234b389415b226a4daef6562933d38c7b28a8b8f64c5c4130dad1561ab7"
+checksum = "e913f9242315ca39eff82aee0e19ee7a372155717ff0eb082c741e435ce25ed1"
 dependencies = [
  "leb128",
- "wasmparser 0.220.0",
+ "wasmparser 0.220.1",
 ]
 
 [[package]]
@@ -25156,15 +25199,15 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.220.0"
+version = "0.220.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e246c2772ce3ebc83f89a2d4487ac5794cad6c309b2071818a88c7db7c36d87b"
+checksum = "8d07b6a3b550fefa1a914b6d54fc175dd11c3392da11eee604e6ffc759805d25"
 dependencies = [
  "ahash 0.8.11",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
- "semver 1.0.25",
+ "indexmap 2.9.0",
+ "semver 1.0.26",
  "serde",
 ]
 
@@ -25398,8 +25441,17 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.14",
  "untrusted 0.9.0",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180d2741b6115c3d906577e6533ad89472d48d96df00270fccb78233073d77f7"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -25407,15 +25459,6 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
-dependencies = [
- "rustls-pki-types",
-]
 
 [[package]]
 name = "westend-runtime"
@@ -25546,13 +25589,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.1"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 0.38.44",
+ "rustix 1.0.5",
  "winsafe",
 ]
 
@@ -25568,9 +25611,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"
@@ -25615,22 +25658,54 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
 dependencies = [
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.53.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result 0.3.2",
+ "windows-strings",
 ]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
@@ -25639,6 +25714,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -25857,9 +25950,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.1"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
@@ -25882,11 +25975,11 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -25969,7 +26062,7 @@ dependencies = [
  "nom",
  "oid-registry 0.8.1",
  "rusticata-macros",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -26015,7 +26108,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -26027,18 +26120,18 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "xcm-procedural"
-version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
+version = "11.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#8d3ff98476946e06bc8ead3a0bc9c44d24739a52"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -26050,7 +26143,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -26086,9 +26179,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xmltree"
@@ -26171,7 +26264,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "synstructure 0.13.1",
 ]
 
@@ -26181,8 +26274,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -26193,27 +26294,38 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "synstructure 0.13.1",
 ]
 
@@ -26234,7 +26346,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -26256,22 +26368,20 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zip"
-version = "2.2.2"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
- "displaydoc",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "memchr",
- "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -26314,9 +26424,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }
 clap = { version = "4.5.10", features = [ "derive" ] }
-codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.7.4", default-features = false, features = [
 	"derive",
 ] }
 color-print = "0.3.4"

--- a/pallets/api/src/fungibles/mod.rs
+++ b/pallets/api/src/fungibles/mod.rs
@@ -409,7 +409,7 @@ pub mod pallet {
 	}
 
 	/// State reads for the fungibles API with required input.
-	#[derive(Encode, Decode, Debug, MaxEncodedLen)]
+	#[derive(Encode, Decode, DecodeWithMemTracking, Debug, MaxEncodedLen)]
 	#[cfg_attr(feature = "std", derive(PartialEq, Clone))]
 	#[repr(u8)]
 	#[allow(clippy::unnecessary_cast)]

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 
-use codec::{Decode, Encode};
+use codec::{Decode, DecodeWithMemTracking, Encode};
 use frame_support::{
 	dispatch::{DispatchResult, DispatchResultWithPostInfo},
 	pallet_prelude::MaxEncodedLen,
@@ -531,14 +531,16 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-#[derive(Clone, Decode, Debug, Encode, MaxEncodedLen, PartialEq, TypeInfo)]
+#[derive(
+	Clone, Decode, DecodeWithMemTracking, Debug, Encode, MaxEncodedLen, PartialEq, TypeInfo,
+)]
 pub enum Status {
 	Pending,
 	TimedOut,
 	Complete,
 }
 
-#[derive(Encode, Decode, Debug, MaxEncodedLen)]
+#[derive(Encode, Decode, DecodeWithMemTracking, Debug, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(PartialEq, Clone))]
 #[repr(u8)]
 #[allow(clippy::unnecessary_cast)]
@@ -608,7 +610,9 @@ trait CalculateDeposit<Deposit> {
 	fn calculate_deposit(&self) -> Deposit;
 }
 
-#[derive(Clone, Debug, Encode, Eq, Decode, MaxEncodedLen, PartialEq, TypeInfo)]
+#[derive(
+	Clone, Debug, Encode, Eq, Decode, DecodeWithMemTracking, MaxEncodedLen, PartialEq, TypeInfo,
+)]
 #[scale_info(skip_type_params(T))]
 enum Message<T: Config> {
 	Ismp {
@@ -638,7 +642,18 @@ enum Message<T: Config> {
 }
 
 // Message selector and pre-paid weight used as gas limit
-#[derive(Copy, Clone, Debug, Encode, Eq, Decode, MaxEncodedLen, PartialEq, TypeInfo)]
+#[derive(
+	Copy,
+	Clone,
+	Debug,
+	Encode,
+	Eq,
+	Decode,
+	DecodeWithMemTracking,
+	MaxEncodedLen,
+	PartialEq,
+	TypeInfo,
+)]
 pub struct Callback {
 	pub selector: [u8; 4],
 	pub weight: Weight,

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -8,7 +8,7 @@ use ::ismp::{
 	},
 	host::StateMachine,
 };
-use codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{
 	pallet_prelude::Weight, traits::Get as _, CloneNoBound, DebugNoBound, EqNoBound,
 	PartialEqNoBound,
@@ -33,7 +33,16 @@ pub const ID: [u8; 3] = *b"pop";
 
 type DbWeightOf<T> = <T as frame_system::Config>::DbWeight;
 
-#[derive(Encode, EqNoBound, CloneNoBound, DebugNoBound, Decode, PartialEqNoBound, TypeInfo)]
+#[derive(
+	Encode,
+	EqNoBound,
+	CloneNoBound,
+	DebugNoBound,
+	Decode,
+	DecodeWithMemTracking,
+	PartialEqNoBound,
+	TypeInfo,
+)]
 #[scale_info(skip_type_params(T))]
 pub enum Message<T: Config> {
 	Get(Get<T>),
@@ -49,7 +58,16 @@ impl<T: Config> From<Message<T>> for DispatchRequest {
 	}
 }
 
-#[derive(Encode, EqNoBound, CloneNoBound, DebugNoBound, Decode, PartialEqNoBound, TypeInfo)]
+#[derive(
+	Encode,
+	EqNoBound,
+	CloneNoBound,
+	DebugNoBound,
+	Decode,
+	DecodeWithMemTracking,
+	PartialEqNoBound,
+	TypeInfo,
+)]
 #[scale_info(skip_type_params(T))]
 pub struct Get<T: Config> {
 	// TODO: Option<u32> to support relay?
@@ -90,7 +108,16 @@ impl<T: Config> CalculateDeposit<BalanceOf<T>> for Get<T> {
 	}
 }
 
-#[derive(Encode, EqNoBound, CloneNoBound, DebugNoBound, Decode, PartialEqNoBound, TypeInfo)]
+#[derive(
+	Encode,
+	EqNoBound,
+	CloneNoBound,
+	DebugNoBound,
+	Decode,
+	DecodeWithMemTracking,
+	PartialEqNoBound,
+	TypeInfo,
+)]
 #[scale_info(skip_type_params(T))]
 pub struct Post<T: Config> {
 	// TODO: Option<u32> to support relay?

--- a/pallets/api/src/mock.rs
+++ b/pallets/api/src/mock.rs
@@ -102,13 +102,13 @@ impl pallet_assets::Config<AssetsInstance> for Test {
 	type Extra = ();
 	type ForceOrigin = EnsureRoot<u64>;
 	type Freezer = ();
+	type Holder = ();
 	type MetadataDepositBase = ConstU128<1>;
 	type MetadataDepositPerByte = ConstU128<1>;
 	type RemoveItemsLimit = ConstU32<5>;
 	type RuntimeEvent = RuntimeEvent;
 	type StringLimit = ConstU32<50>;
 	type WeightInfo = ();
-	type Holder = ();
 }
 
 impl crate::fungibles::Config for Test {

--- a/pallets/api/src/mock.rs
+++ b/pallets/api/src/mock.rs
@@ -1,4 +1,4 @@
-use codec::{Decode, Encode};
+use codec::{Decode, DecodeWithMemTracking, Encode};
 use frame_support::{
 	derive_impl, parameter_types,
 	traits::{AsEnsureOriginWithArg, ConstU128, ConstU32, ConstU64, Everything},
@@ -108,6 +108,7 @@ impl pallet_assets::Config<AssetsInstance> for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type StringLimit = ConstU32<50>;
 	type WeightInfo = ();
+	type Holder = ();
 }
 
 impl crate::fungibles::Config for Test {
@@ -120,7 +121,7 @@ parameter_types! {
 	pub storage Features: PalletFeatures = PalletFeatures::all_enabled();
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, DecodeWithMemTracking, TypeInfo)]
 pub struct Noop;
 
 impl IdentifyAccount for Noop {
@@ -207,6 +208,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 
 	pallet_balances::GenesisConfig::<Test> {
 		balances: vec![(ALICE, INIT_AMOUNT), (BOB, INIT_AMOUNT), (CHARLIE, INIT_AMOUNT)],
+		..Default::default()
 	}
 	.assimilate_storage(&mut t)
 	.expect("Pallet balances storage can be assimilated");

--- a/pallets/api/src/nonfungibles/mod.rs
+++ b/pallets/api/src/nonfungibles/mod.rs
@@ -531,7 +531,7 @@ pub mod pallet {
 	}
 
 	/// State reads for the non-fungibles API with required input.
-	#[derive(Encode, Decode, Debug, MaxEncodedLen)]
+	#[derive(Encode, Decode, DecodeWithMemTracking, Debug, MaxEncodedLen)]
 	#[cfg_attr(feature = "std", derive(PartialEq, Clone))]
 	#[repr(u8)]
 	#[allow(clippy::unnecessary_cast)]

--- a/pallets/motion/src/mock.rs
+++ b/pallets/motion/src/mock.rs
@@ -88,6 +88,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut ext: sp_io::TestExternalities = RuntimeGenesisConfig {
 		balances: pallet_balances::GenesisConfig::<Test> {
 			balances: vec![(1, 10), (2, 20), (3, 30), (4, 40), (5, 50)],
+			..Default::default()
 		},
 		council: pallet_collective::GenesisConfig {
 			members: vec![1, 2, 3, 4],

--- a/pallets/motion/src/tests.rs
+++ b/pallets/motion/src/tests.rs
@@ -1,4 +1,4 @@
-use codec::Encode;
+use codec::{DecodeWithMemTracking, Encode};
 use frame_support::{assert_ok, dispatch::GetDispatchInfo, weights::Weight};
 use frame_system::{EventRecord, Phase};
 use mock::{RuntimeCall, RuntimeEvent};
@@ -13,13 +13,14 @@ use crate::{mock::*, Event as MotionEvent};
 fn record(event: RuntimeEvent) -> EventRecord<RuntimeEvent, H256> {
 	EventRecord { phase: Phase::Initialization, event, topics: vec![] }
 }
-
+#[derive(DecodeWithMemTracking)]
 struct Proposal {
 	len: u32,
 	weight: Weight,
 	hash: H256,
 }
 
+#[derive(DecodeWithMemTracking)]
 enum MotionType {
 	SimpleMajority,
 	SuperMajority,

--- a/pallets/nfts/src/migration.rs
+++ b/pallets/nfts/src/migration.rs
@@ -28,7 +28,7 @@ pub mod v1 {
 
 	use super::*;
 
-	#[derive(Decode)]
+	#[derive(Decode, DecodeWithMemTracking)]
 	#[allow(missing_docs)]
 	pub struct OldCollectionDetails<AccountId, DepositBalance> {
 		pub owner: AccountId,

--- a/pallets/nfts/src/tests.rs
+++ b/pallets/nfts/src/tests.rs
@@ -1213,7 +1213,7 @@ fn set_collection_system_attributes_should_work() {
 
 		// test typed system attribute
 		let typed_attribute_key = [0u8; 32];
-		#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+		#[derive(Encode, Decode, DecodeWithMemTracking, Clone, PartialEq, Eq, RuntimeDebug)]
 		struct TypedAttributeValue(u32);
 		let typed_attribute_value = TypedAttributeValue(42);
 

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -95,15 +95,15 @@ pub(super) type AccountDepositOf<T, I = ()> =
 
 /// Information about a collection.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub struct CollectionDetails<AccountId, DepositBalance> {
 	/// Collection's owner.
@@ -123,16 +123,16 @@ pub struct CollectionDetails<AccountId, DepositBalance> {
 
 /// Witness data for the destroy transactions.
 #[derive(
-    Copy,
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Copy,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub struct DestroyWitness {
 	/// The total number of items in this collection that have outstanding item metadata.
@@ -158,7 +158,7 @@ impl<AccountId, DepositBalance> CollectionDetails<AccountId, DepositBalance> {
 
 /// Witness data for items mint transactions.
 #[derive(
-    Clone, Encode, Decode, DecodeWithMemTracking, Default, Eq, PartialEq, RuntimeDebug, TypeInfo,
+	Clone, Encode, Decode, DecodeWithMemTracking, Default, Eq, PartialEq, RuntimeDebug, TypeInfo,
 )]
 pub struct MintWitness<ItemId, Balance> {
 	/// Provide the id of the item in a required collection.
@@ -169,16 +169,16 @@ pub struct MintWitness<ItemId, Balance> {
 
 /// Information concerning the ownership of a single unique item.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    Default,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	Default,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub struct ItemDetails<AccountId, Deposit, Approvals> {
 	/// The owner of this item.
@@ -192,15 +192,15 @@ pub struct ItemDetails<AccountId, Deposit, Approvals> {
 
 /// Information about the reserved item deposit.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub struct ItemDeposit<DepositBalance, AccountId> {
 	/// A depositor account.
@@ -211,16 +211,16 @@ pub struct ItemDeposit<DepositBalance, AccountId> {
 
 /// Information about the collection's metadata.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    Default,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	Default,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 #[scale_info(skip_type_params(StringLimit))]
 #[codec(mel_bound(Deposit: MaxEncodedLen))]
@@ -237,16 +237,16 @@ pub struct CollectionMetadata<Deposit, StringLimit: Get<u32>> {
 
 /// Information about the item's metadata.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    Eq,
-    DecodeWithMemTracking,
-    PartialEq,
-    RuntimeDebug,
-    Default,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	Eq,
+	DecodeWithMemTracking,
+	PartialEq,
+	RuntimeDebug,
+	Default,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 #[scale_info(skip_type_params(StringLimit))]
 pub struct ItemMetadata<Deposit, StringLimit: Get<u32>> {
@@ -262,15 +262,15 @@ pub struct ItemMetadata<Deposit, StringLimit: Get<u32>> {
 
 /// Information about the tip.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub struct ItemTip<CollectionId, ItemId, AccountId, Amount> {
 	/// The collection of the item.
@@ -285,16 +285,16 @@ pub struct ItemTip<CollectionId, ItemId, AccountId, Amount> {
 
 /// Information about the pending swap.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    Default,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	Default,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub struct PendingSwap<CollectionId, ItemId, ItemPriceWithDirection, Deadline> {
 	/// The collection that contains the item that the user wants to receive.
@@ -309,15 +309,15 @@ pub struct PendingSwap<CollectionId, ItemId, ItemPriceWithDirection, Deadline> {
 
 /// Information about the reserved attribute deposit.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub struct AttributeDeposit<DepositBalance, AccountId> {
 	/// A depositor account.
@@ -328,15 +328,15 @@ pub struct AttributeDeposit<DepositBalance, AccountId> {
 
 /// Information about the reserved item's metadata deposit.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub struct ItemMetadataDeposit<DepositBalance, AccountId> {
 	/// A depositor account, None means the deposit is collection's owner.
@@ -347,15 +347,15 @@ pub struct ItemMetadataDeposit<DepositBalance, AccountId> {
 
 /// Specifies whether the tokens will be sent or received.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub enum PriceDirection {
 	/// Tokens will be sent.
@@ -366,15 +366,15 @@ pub enum PriceDirection {
 
 /// Holds the details about the price.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub struct PriceWithDirection<Amount> {
 	/// An amount.
@@ -387,16 +387,16 @@ pub struct PriceWithDirection<Amount> {
 #[bitflags]
 #[repr(u64)]
 #[derive(
-    Copy,
-    Clone,
-    RuntimeDebug,
-    PartialEq,
-    Eq,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    MaxEncodedLen,
-    TypeInfo,
+	Copy,
+	Clone,
+	RuntimeDebug,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	MaxEncodedLen,
+	TypeInfo,
 )]
 pub enum CollectionSetting {
 	/// Items in this collection are transferable.
@@ -412,7 +412,7 @@ pub enum CollectionSetting {
 }
 
 /// Wrapper type for `BitFlags<CollectionSetting>` that implements `Codec`.
-#[derive(Clone, Copy, PartialEq, Eq, Default, RuntimeDebug, DecodeWithMemTracking)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, RuntimeDebug)]
 pub struct CollectionSettings(pub BitFlags<CollectionSetting>);
 
 impl CollectionSettings {
@@ -434,21 +434,24 @@ impl CollectionSettings {
 }
 
 impl_codec_bitflags!(CollectionSettings, u64, CollectionSetting);
+// We can implement `DecodeWithMemTracking` for `CollectionSettings`
+// since `u64` also implements `DecodeWithMemTracking`.
+impl DecodeWithMemTracking for CollectionSettings {}
 
 /// Mint type. Can the NFT be create by anyone, or only the creator of the collection,
 /// or only by wallets that already hold an NFT from a certain collection?
 /// The ownership of a privately minted NFT is still publicly visible.
 #[derive(
-    Clone,
-    Copy,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Copy,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub enum MintType<CollectionId> {
 	/// Only an `Issuer` could mint items.
@@ -461,16 +464,16 @@ pub enum MintType<CollectionId> {
 
 /// Holds the information about minting.
 #[derive(
-    Clone,
-    Copy,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Copy,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub struct MintSettings<Price, BlockNumber, CollectionId> {
 	/// Whether anyone can mint or if minters are restricted to some subset.
@@ -499,15 +502,15 @@ impl<Price, BlockNumber, CollectionId> Default for MintSettings<Price, BlockNumb
 
 /// Attribute namespaces for non-fungible tokens.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    scale_info::TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	scale_info::TypeInfo,
+	MaxEncodedLen,
 )]
 pub enum AttributeNamespace<AccountId> {
 	/// An attribute was set by the pallet.
@@ -529,15 +532,15 @@ pub struct CancelAttributesApprovalWitness {
 
 /// A list of possible pallet-level attributes.
 #[derive(
-    Clone,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Eq,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
-    MaxEncodedLen,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 pub enum PalletAttributes<CollectionId> {
 	/// Marks an item as being used in order to claim another item.
@@ -548,16 +551,16 @@ pub enum PalletAttributes<CollectionId> {
 
 /// Collection's configuration.
 #[derive(
-    Clone,
-    Copy,
-    Decode,
-    DecodeWithMemTracking,
-    Default,
-    Encode,
-    MaxEncodedLen,
-    PartialEq,
-    RuntimeDebug,
-    TypeInfo,
+	Clone,
+	Copy,
+	Decode,
+	DecodeWithMemTracking,
+	Default,
+	Encode,
+	MaxEncodedLen,
+	PartialEq,
+	RuntimeDebug,
+	TypeInfo,
 )]
 pub struct CollectionConfig<Price, BlockNumber, CollectionId> {
 	/// Collection's settings.
@@ -590,16 +593,16 @@ impl<Price, BlockNumber, CollectionId> CollectionConfig<Price, BlockNumber, Coll
 #[bitflags]
 #[repr(u64)]
 #[derive(
-    Copy,
-    Clone,
-    RuntimeDebug,
-    PartialEq,
-    Eq,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    MaxEncodedLen,
-    TypeInfo,
+	Copy,
+	Clone,
+	RuntimeDebug,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	MaxEncodedLen,
+	TypeInfo,
 )]
 pub enum ItemSetting {
 	/// This item is transferable.
@@ -611,7 +614,7 @@ pub enum ItemSetting {
 }
 
 /// Wrapper type for `BitFlags<ItemSetting>` that implements `Codec`.
-#[derive(Clone, Copy, PartialEq, Eq, Default, RuntimeDebug, DecodeWithMemTracking)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, RuntimeDebug)]
 pub struct ItemSettings(pub BitFlags<ItemSetting>);
 
 impl ItemSettings {
@@ -633,19 +636,22 @@ impl ItemSettings {
 }
 
 impl_codec_bitflags!(ItemSettings, u64, ItemSetting);
+// We can implement `DecodeWithMemTracking` for `ItemSettings`
+// since `u64` also implements `DecodeWithMemTracking`.
+impl DecodeWithMemTracking for ItemSettings {}
 
 /// Item's configuration.
 #[derive(
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    Default,
-    PartialEq,
-    RuntimeDebug,
-    Clone,
-    Copy,
-    MaxEncodedLen,
-    TypeInfo,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Default,
+	PartialEq,
+	RuntimeDebug,
+	Clone,
+	Copy,
+	MaxEncodedLen,
+	TypeInfo,
 )]
 pub struct ItemConfig {
 	/// Item's settings.
@@ -678,16 +684,16 @@ impl ItemConfig {
 #[bitflags]
 #[repr(u64)]
 #[derive(
-    Copy,
-    Clone,
-    RuntimeDebug,
-    PartialEq,
-    Eq,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    MaxEncodedLen,
-    TypeInfo,
+	Copy,
+	Clone,
+	RuntimeDebug,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	MaxEncodedLen,
+	TypeInfo,
 )]
 pub enum PalletFeature {
 	/// Enable/disable trading operations.
@@ -723,16 +729,16 @@ impl_codec_bitflags!(PalletFeatures, u64, PalletFeature);
 #[bitflags]
 #[repr(u8)]
 #[derive(
-    Copy,
-    Clone,
-    RuntimeDebug,
-    PartialEq,
-    Eq,
-    Encode,
-    Decode,
-    DecodeWithMemTracking,
-    MaxEncodedLen,
-    TypeInfo,
+	Copy,
+	Clone,
+	RuntimeDebug,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	MaxEncodedLen,
+	TypeInfo,
 )]
 pub enum CollectionRole {
 	/// Can mint items.

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -19,7 +19,7 @@
 
 use alloc::{vec, vec::Vec};
 
-use codec::EncodeLike;
+use codec::{DecodeWithMemTracking, EncodeLike};
 use enumflags2::{bitflags, BitFlags};
 use frame_support::{
 	pallet_prelude::{BoundedVec, MaxEncodedLen},
@@ -94,7 +94,17 @@ pub(super) type AccountDepositOf<T, I = ()> =
 	(<T as SystemConfig>::AccountId, DepositBalanceOf<T, I>);
 
 /// Information about a collection.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct CollectionDetails<AccountId, DepositBalance> {
 	/// Collection's owner.
 	pub owner: AccountId,
@@ -112,7 +122,18 @@ pub struct CollectionDetails<AccountId, DepositBalance> {
 }
 
 /// Witness data for the destroy transactions.
-#[derive(Copy, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Copy,
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct DestroyWitness {
 	/// The total number of items in this collection that have outstanding item metadata.
 	#[codec(compact)]
@@ -136,7 +157,9 @@ impl<AccountId, DepositBalance> CollectionDetails<AccountId, DepositBalance> {
 }
 
 /// Witness data for items mint transactions.
-#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, Default, Eq, PartialEq, RuntimeDebug, TypeInfo,
+)]
 pub struct MintWitness<ItemId, Balance> {
 	/// Provide the id of the item in a required collection.
 	pub owned_item: Option<ItemId>,
@@ -145,7 +168,18 @@ pub struct MintWitness<ItemId, Balance> {
 }
 
 /// Information concerning the ownership of a single unique item.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Default, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    Default,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct ItemDetails<AccountId, Deposit, Approvals> {
 	/// The owner of this item.
 	pub(super) owner: AccountId,
@@ -157,7 +191,17 @@ pub struct ItemDetails<AccountId, Deposit, Approvals> {
 }
 
 /// Information about the reserved item deposit.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct ItemDeposit<DepositBalance, AccountId> {
 	/// A depositor account.
 	pub(super) account: AccountId,
@@ -166,7 +210,18 @@ pub struct ItemDeposit<DepositBalance, AccountId> {
 }
 
 /// Information about the collection's metadata.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Default, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    Default,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 #[scale_info(skip_type_params(StringLimit))]
 #[codec(mel_bound(Deposit: MaxEncodedLen))]
 pub struct CollectionMetadata<Deposit, StringLimit: Get<u32>> {
@@ -181,7 +236,18 @@ pub struct CollectionMetadata<Deposit, StringLimit: Get<u32>> {
 }
 
 /// Information about the item's metadata.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Default, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    Eq,
+    DecodeWithMemTracking,
+    PartialEq,
+    RuntimeDebug,
+    Default,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 #[scale_info(skip_type_params(StringLimit))]
 pub struct ItemMetadata<Deposit, StringLimit: Get<u32>> {
 	/// The balance deposited for this metadata.
@@ -195,7 +261,17 @@ pub struct ItemMetadata<Deposit, StringLimit: Get<u32>> {
 }
 
 /// Information about the tip.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct ItemTip<CollectionId, ItemId, AccountId, Amount> {
 	/// The collection of the item.
 	pub(super) collection: CollectionId,
@@ -208,7 +284,18 @@ pub struct ItemTip<CollectionId, ItemId, AccountId, Amount> {
 }
 
 /// Information about the pending swap.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Default, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    Default,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct PendingSwap<CollectionId, ItemId, ItemPriceWithDirection, Deadline> {
 	/// The collection that contains the item that the user wants to receive.
 	pub(super) desired_collection: CollectionId,
@@ -221,7 +308,17 @@ pub struct PendingSwap<CollectionId, ItemId, ItemPriceWithDirection, Deadline> {
 }
 
 /// Information about the reserved attribute deposit.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct AttributeDeposit<DepositBalance, AccountId> {
 	/// A depositor account.
 	pub(super) account: Option<AccountId>,
@@ -230,7 +327,17 @@ pub struct AttributeDeposit<DepositBalance, AccountId> {
 }
 
 /// Information about the reserved item's metadata deposit.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct ItemMetadataDeposit<DepositBalance, AccountId> {
 	/// A depositor account, None means the deposit is collection's owner.
 	pub(super) account: Option<AccountId>,
@@ -239,7 +346,17 @@ pub struct ItemMetadataDeposit<DepositBalance, AccountId> {
 }
 
 /// Specifies whether the tokens will be sent or received.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub enum PriceDirection {
 	/// Tokens will be sent.
 	Send,
@@ -248,7 +365,17 @@ pub enum PriceDirection {
 }
 
 /// Holds the details about the price.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct PriceWithDirection<Amount> {
 	/// An amount.
 	pub(super) amount: Amount,
@@ -259,7 +386,18 @@ pub struct PriceWithDirection<Amount> {
 /// Support for up to 64 user-enabled features on a collection.
 #[bitflags]
 #[repr(u64)]
-#[derive(Copy, Clone, RuntimeDebug, PartialEq, Eq, Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(
+    Copy,
+    Clone,
+    RuntimeDebug,
+    PartialEq,
+    Eq,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    MaxEncodedLen,
+    TypeInfo,
+)]
 pub enum CollectionSetting {
 	/// Items in this collection are transferable.
 	TransferableItems,
@@ -274,7 +412,7 @@ pub enum CollectionSetting {
 }
 
 /// Wrapper type for `BitFlags<CollectionSetting>` that implements `Codec`.
-#[derive(Clone, Copy, PartialEq, Eq, Default, RuntimeDebug)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, RuntimeDebug, DecodeWithMemTracking)]
 pub struct CollectionSettings(pub BitFlags<CollectionSetting>);
 
 impl CollectionSettings {
@@ -300,7 +438,18 @@ impl_codec_bitflags!(CollectionSettings, u64, CollectionSetting);
 /// Mint type. Can the NFT be create by anyone, or only the creator of the collection,
 /// or only by wallets that already hold an NFT from a certain collection?
 /// The ownership of a privately minted NFT is still publicly visible.
-#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Copy,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub enum MintType<CollectionId> {
 	/// Only an `Issuer` could mint items.
 	Issuer,
@@ -311,7 +460,18 @@ pub enum MintType<CollectionId> {
 }
 
 /// Holds the information about minting.
-#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Copy,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct MintSettings<Price, BlockNumber, CollectionId> {
 	/// Whether anyone can mint or if minters are restricted to some subset.
 	pub mint_type: MintType<CollectionId>,
@@ -339,7 +499,15 @@ impl<Price, BlockNumber, CollectionId> Default for MintSettings<Price, BlockNumb
 
 /// Attribute namespaces for non-fungible tokens.
 #[derive(
-	Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, scale_info::TypeInfo, MaxEncodedLen,
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    scale_info::TypeInfo,
+    MaxEncodedLen,
 )]
 pub enum AttributeNamespace<AccountId> {
 	/// An attribute was set by the pallet.
@@ -353,14 +521,24 @@ pub enum AttributeNamespace<AccountId> {
 }
 
 /// A witness data to cancel attributes approval operation.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Clone, Encode, Decode, DecodeWithMemTracking, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct CancelAttributesApprovalWitness {
 	/// An amount of attributes previously created by account.
 	pub account_attributes: u32,
 }
 
 /// A list of possible pallet-level attributes.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Eq,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
 pub enum PalletAttributes<CollectionId> {
 	/// Marks an item as being used in order to claim another item.
 	UsedToClaim(CollectionId),
@@ -370,7 +548,16 @@ pub enum PalletAttributes<CollectionId> {
 
 /// Collection's configuration.
 #[derive(
-	Clone, Copy, Decode, Default, Encode, MaxEncodedLen, PartialEq, RuntimeDebug, TypeInfo,
+    Clone,
+    Copy,
+    Decode,
+    DecodeWithMemTracking,
+    Default,
+    Encode,
+    MaxEncodedLen,
+    PartialEq,
+    RuntimeDebug,
+    TypeInfo,
 )]
 pub struct CollectionConfig<Price, BlockNumber, CollectionId> {
 	/// Collection's settings.
@@ -402,7 +589,18 @@ impl<Price, BlockNumber, CollectionId> CollectionConfig<Price, BlockNumber, Coll
 /// Support for up to 64 user-enabled features on an item.
 #[bitflags]
 #[repr(u64)]
-#[derive(Copy, Clone, RuntimeDebug, PartialEq, Eq, Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(
+    Copy,
+    Clone,
+    RuntimeDebug,
+    PartialEq,
+    Eq,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    MaxEncodedLen,
+    TypeInfo,
+)]
 pub enum ItemSetting {
 	/// This item is transferable.
 	Transferable,
@@ -413,7 +611,7 @@ pub enum ItemSetting {
 }
 
 /// Wrapper type for `BitFlags<ItemSetting>` that implements `Codec`.
-#[derive(Clone, Copy, PartialEq, Eq, Default, RuntimeDebug)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, RuntimeDebug, DecodeWithMemTracking)]
 pub struct ItemSettings(pub BitFlags<ItemSetting>);
 
 impl ItemSettings {
@@ -438,7 +636,16 @@ impl_codec_bitflags!(ItemSettings, u64, ItemSetting);
 
 /// Item's configuration.
 #[derive(
-	Encode, Decode, Default, PartialEq, RuntimeDebug, Clone, Copy, MaxEncodedLen, TypeInfo,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    Default,
+    PartialEq,
+    RuntimeDebug,
+    Clone,
+    Copy,
+    MaxEncodedLen,
+    TypeInfo,
 )]
 pub struct ItemConfig {
 	/// Item's settings.
@@ -470,7 +677,18 @@ impl ItemConfig {
 /// Support for up to 64 system-enabled features on a collection.
 #[bitflags]
 #[repr(u64)]
-#[derive(Copy, Clone, RuntimeDebug, PartialEq, Eq, Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(
+    Copy,
+    Clone,
+    RuntimeDebug,
+    PartialEq,
+    Eq,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    MaxEncodedLen,
+    TypeInfo,
+)]
 pub enum PalletFeature {
 	/// Enable/disable trading operations.
 	Trading,
@@ -504,7 +722,18 @@ impl_codec_bitflags!(PalletFeatures, u64, PalletFeature);
 /// Support for up to 8 different roles for collections.
 #[bitflags]
 #[repr(u8)]
-#[derive(Copy, Clone, RuntimeDebug, PartialEq, Eq, Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(
+    Copy,
+    Clone,
+    RuntimeDebug,
+    PartialEq,
+    Eq,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    MaxEncodedLen,
+    TypeInfo,
+)]
 pub enum CollectionRole {
 	/// Can mint items.
 	Issuer,
@@ -538,7 +767,7 @@ impl CollectionRoles {
 }
 impl_codec_bitflags!(CollectionRoles, u8, CollectionRole);
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, DecodeWithMemTracking, RuntimeDebug, TypeInfo)]
 pub struct PreSignedMint<CollectionId, ItemId, AccountId, Deadline, Balance> {
 	/// A collection of the item to be minted.
 	pub(super) collection: CollectionId,
@@ -556,7 +785,7 @@ pub struct PreSignedMint<CollectionId, ItemId, AccountId, Deadline, Balance> {
 	pub(super) mint_price: Option<Balance>,
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, DecodeWithMemTracking, RuntimeDebug, TypeInfo)]
 pub struct PreSignedAttributes<CollectionId, ItemId, AccountId, Deadline> {
 	/// Collection's ID.
 	pub(super) collection: CollectionId,

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -83,7 +83,7 @@ pub use async_backing_params::*;
 
 /// Proxy commons for Pop runtimes
 pub mod proxy {
-	use codec::{Decode, Encode, MaxEncodedLen};
+	use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 	use frame_support::parameter_types;
 	use sp_runtime::RuntimeDebug;
 
@@ -111,6 +111,7 @@ pub mod proxy {
 		PartialOrd,
 		Encode,
 		Decode,
+		DecodeWithMemTracking,
 		RuntimeDebug,
 		MaxEncodedLen,
 		scale_info::TypeInfo,


### PR DESCRIPTION
As per [polkadot-sdk#7267](https://github.com/paritytech/polkadot-sdk/pull/7627).

This PR derives `DecodeWithMemTracking` for:

- [`ProxyType`](https://github.com/r0gue-io/pop-node/commit/0ffb6b5e1a5fb359090547e161f1ebb49455e868)