### PR TITLE
feat(session): implement `DisablingStrategy`

### DIFF
--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -442,6 +442,7 @@ parameter_types! {
 }
 
 impl pallet_session::Config for Runtime {
+	type DisablingStrategy = ();
 	type Keys = SessionKeys;
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
 	type RuntimeEvent = RuntimeEvent;

--- a/runtime/mainnet/src/config/collation.rs
+++ b/runtime/mainnet/src/config/collation.rs
@@ -56,6 +56,7 @@ impl pallet_collator_selection::Config for Runtime {
 impl cumulus_pallet_aura_ext::Config for Runtime {}
 
 impl pallet_session::Config for Runtime {
+	type DisablingStrategy = ();
 	type Keys = SessionKeys;
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
 	type RuntimeEvent = RuntimeEvent;
@@ -254,6 +255,14 @@ mod tests {
 
 	mod session {
 		use super::*;
+
+		#[test]
+		fn ensures_no_disabling_strategy() {
+			assert_eq!(
+				TypeId::of::<<Runtime as pallet_session::Config>::DisablingStrategy>(),
+				TypeId::of::<()>(),
+			);
+		}
 
 		#[test]
 		fn keys_provided_by_aura() {

--- a/runtime/testnet/src/config/collation.rs
+++ b/runtime/testnet/src/config/collation.rs
@@ -58,6 +58,7 @@ parameter_types! {
 }
 
 impl pallet_session::Config for Runtime {
+	type DisablingStrategy = ();
 	type Keys = SessionKeys;
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
 	type RuntimeEvent = RuntimeEvent;


### PR DESCRIPTION
As per [polkadot-sdk#7581](https://github.com/paritytech/polkadot-sdk/pull/7581).

Implement `DisablingStrategy` for `pallet_session` in every runtime.
Note that the migration included upstream is not a requirement for `pop-node`.