### PR TITLE
chore: weights for `pallet_multisig::poke_deposit`

### DIFF
--- a/runtime/common/src/weights/pallet_multisig.rs
+++ b/runtime/common/src/weights/pallet_multisig.rs
@@ -143,4 +143,19 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	/// Storage: `Multisig::Multisigs` (r:1 w:1)
+	/// Proof: `Multisig::Multisigs` (`max_values`: None, `max_size`: Some(3346), added: 5821, mode: `MaxEncodedLen`)
+	/// The range of component `s` is `[2, 100]`.
+	fn poke_deposit(s: u32) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `487 + s * (1 ±0)`
+		//  Estimated: `6811`
+		// Minimum execution time: 29_011_000 picoseconds.
+		Weight::from_parts(30_639_580, 0)
+			.saturating_add(Weight::from_parts(0, 6811))
+			// Standard Error: 1_876
+			.saturating_add(Weight::from_parts(164_361, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(1))
+	}
 }


### PR DESCRIPTION
As per [polkadot-sdk#7700](https://github.com/paritytech/polkadot-sdk/pull/7700).

This PR introduces weights for the new extrinsic in pallet-multisig, `poke_deposit`. These weights have been copied from westend runtime upstream and benchmarks should be run before releasing any new runtime version.