### PR TITLE
chore: weights for `pallet_proxy::pole_deposit`

### DIFF
--- a/runtime/common/src/weights/pallet_proxy.rs
+++ b/runtime/common/src/weights/pallet_proxy.rs
@@ -192,4 +192,20 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	/// Storage: `Proxy::Proxies` (r:1 w:1)
+	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(1241), added: 3716, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `Proxy::Announcements` (r:1 w:1)
+	/// Proof: `Proxy::Announcements` (`max_values`: None, `max_size`: Some(2233), added: 4708, mode: `MaxEncodedLen`)
+	fn poke_deposit() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `487`
+		//  Estimated: `5698`
+		// Minimum execution time: 43_822_000 picoseconds.
+		Weight::from_parts(45_419_000, 0)
+			.saturating_add(Weight::from_parts(0, 5698))
+			.saturating_add(T::DbWeight::get().reads(3))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
 }


### PR DESCRIPTION
As per [polkadot-sdk#7801](https://github.com/paritytech/polkadot-sdk/pull/7801).

This PR introduces weights for the new extrinsic in pallet-proxy, `poke_deposit`. These weights have been copied from Westend runtime upstream and benchmarks should be run before releasing any new runtime version.