### PR TITLE
chore: impl `Holder` for `pallet_assets`

### DIFF
--- a/runtime/devnet/src/config/assets.rs
+++ b/runtime/devnet/src/config/assets.rs
@@ -138,6 +138,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type Extra = ();
 	type ForceOrigin = AssetsForceOrigin;
 	type Freezer = ();
+	type Holder = ();
 	type MetadataDepositBase = MetadataDepositBase;
 	type MetadataDepositPerByte = MetadataDepositPerByte;
 	type RemoveItemsLimit = ConstU32<1000>;

--- a/runtime/mainnet/src/config/assets.rs
+++ b/runtime/mainnet/src/config/assets.rs
@@ -48,6 +48,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type Extra = ();
 	type ForceOrigin = AssetsForceOrigin;
 	type Freezer = ();
+	type Holder = ();
 	type MetadataDepositBase = MetadataDepositBase;
 	type MetadataDepositPerByte = MetadataDepositPerByte;
 	type RemoveItemsLimit = ConstU32<1000>;
@@ -255,6 +256,15 @@ mod tests {
 		fn no_extra_data_is_stored() {
 			assert_eq!(
 				TypeId::of::<<Runtime as pallet_assets::Config<TrustBackedAssetsInstance>>::Extra>(
+				),
+				TypeId::of::<()>(),
+			);
+		}
+
+		#[test]
+		fn holder_is_default() {
+			assert_eq!(
+				TypeId::of::<<Runtime as pallet_assets::Config<TrustBackedAssetsInstance>>::Holder>(
 				),
 				TypeId::of::<()>(),
 			);

--- a/runtime/testnet/src/config/assets.rs
+++ b/runtime/testnet/src/config/assets.rs
@@ -45,6 +45,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type Extra = ();
 	type ForceOrigin = AssetsForceOrigin;
 	type Freezer = ();
+	type Holder = ();
 	type MetadataDepositBase = MetadataDepositBase;
 	type MetadataDepositPerByte = MetadataDepositPerByte;
 	type RemoveItemsLimit = ConstU32<1000>;


### PR DESCRIPTION
As per [polkadot-sdk#4530](https://github.com/paritytech/polkadot-sdk/pull/4530).

This PR implements `Holder` for `pallet-assets` in every runtime. `pallet-assets-holder` is not introduced in this PR, hence I've kept `Holder` configured to `()`.