### PR TITLE
ci: bump rust-cache version to latest

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -25,7 +25,7 @@ runs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
     - name: Rust Cache
-      uses: Swatinem/rust-cache@v2.7.3
+      uses: Swatinem/rust-cache@v2.7.8
       with:
         cache-on-failure: true
         cache-all-crates: true


### PR DESCRIPTION
Rust caching is currently failing due to 'Cache service responded with 422' and 'This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP.'