### PR TITLE
fix(api/nonfungibles): align next_collection_id contract impl with the pallet return type

### DIFF
--- a/pop-api/src/v0/nonfungibles/mod.rs
+++ b/pop-api/src/v0/nonfungibles/mod.rs
@@ -149,9 +149,10 @@ pub fn get_attribute(
 #[inline]
 pub fn next_collection_id() -> Result<CollectionId> {
 	build_read_state(NEXT_COLLECTION_ID)
-		.output::<Result<CollectionId>, true>()
+		.output::<Result<Option<CollectionId>>, true>()
 		.handle_error_code::<StatusCode>()
 		.call(&())
+		.map(|r| r.unwrap_or_default())
 }
 
 /// Returns the metadata of the specified collection `item`.


### PR DESCRIPTION
Resolves the issue with the discrepancy between the pallet return type for a next_collection_id query and the contract library implementation, backed with more robust tests.