### PR TITLE
chore: improve network config files

### DIFF
--- a/networks/devnet.toml
+++ b/networks/devnet.toml
@@ -46,7 +46,7 @@ args = [
 
 [[parachains]]
 id = 1000
-chain = "asset-hub-rococo-local"
+chain = "asset-hub-paseo-local"
 
 [[parachains.collators]]
 name = "asset-hub"

--- a/networks/mainnet.toml
+++ b/networks/mainnet.toml
@@ -37,4 +37,8 @@ balances = [
 [[parachains.collators]]
 name = "pop"
 rpc_port = 9944
-args = ["-lruntime::contracts=debug", "-lpopapi::extension=debug"]
+args = [
+    "-lruntime::revive=trace",
+    "-lruntime::revive::strace=trace",
+    "-lxcm=trace",
+]


### PR DESCRIPTION
Resolves two issues spotted whilst using the network config files for testing:
- asset-hub was using rococo runtime instead of paseo within devnet.toml
- pop args for mainnet were invalid based on functionality available within mainnet runtime