### PR TITLE
fix(api/nonfungibles): fix mint implementation

### DIFF
--- a/pallets/api/src/nonfungibles/mod.rs
+++ b/pallets/api/src/nonfungibles/mod.rs
@@ -90,7 +90,7 @@ pub mod pallet {
 			/// The item transferred (or minted/burned).
 			item: ItemIdOf<T>,
 		},
-		/// Event emitted when a token approve occurs.
+		/// Event emitted when a token approval occurs.
 		// Differing style: event name abides by the PSP34 standard.
 		Approval {
 			/// The owner providing the allowance.
@@ -101,7 +101,7 @@ pub mod pallet {
 			collection: CollectionIdOf<T>,
 			/// The item which is (dis)approved. `None` for all owner's items.
 			item: Option<ItemIdOf<T>>,
-			/// Whether allowance is set or removed.
+			/// Whether an allowance is set or removed.
 			approved: bool,
 		},
 		/// Event emitted when an attribute is set for a token.
@@ -244,7 +244,7 @@ pub mod pallet {
 		/// - `CollectionOwner` namespace could be modified by the `collection` Admin only;
 		/// - `ItemOwner` namespace could be modified by the `item` owner only. `item` should be set
 		///   in that case;
-		/// - `Account(AccountId)` namespace could be modified only when the `origin` was given a
+		/// - `Account(AccountId)` namespace could be modified only when the `origin` was given
 		///   permission to do so;
 		///
 		/// The funds of `origin` are reserved according to the formula:
@@ -253,7 +253,7 @@ pub mod pallet {
 		///
 		/// # Parameters
 		/// - `collection` - The collection.
-		/// - `item` - The optional item whose attribute to set. If `None`, the `collection`'s
+		/// - `item` - The optional item whose attribute is to be set. If `None`, the `collection`'s
 		///   attribute is set.
 		/// - `namespace` - The attribute's namespace.
 		/// - `key` - The key of the attribute.
@@ -284,7 +284,7 @@ pub mod pallet {
 		///
 		/// # Parameters
 		/// - `collection` - The collection.
-		/// - `item` - The optional item whose metadata to clear. If `None`, metadata of the
+		/// - `item` - The optional item whose metadata is to be cleared. If `None`, metadata of the
 		///   `collection` will be cleared.
 		/// - `namespace` - The attribute's namespace.
 		/// - `key` - The key of the attribute.
@@ -377,7 +377,7 @@ pub mod pallet {
 			)
 		}
 
-		/// Cancel the previously provided approval to change item's attributes.
+		/// Cancel the previously provided approval to change an item's attributes.
 		/// All the previously set attributes by the `delegate` will be removed.
 		///
 		/// # Parameters
@@ -422,7 +422,7 @@ pub mod pallet {
 		///
 		/// # Parameters
 		/// - `collection` - The collection.
-		/// - `limit` - The amount of collection approvals that will be cleared.
+		/// - `limit` - The number of collection approvals that will be cleared.
 		#[pallet::call_index(19)]
 		#[pallet::weight(NftsWeightInfoOf::<T>::clear_collection_approvals(*limit))]
 		pub fn clear_collection_approvals(
@@ -530,13 +530,13 @@ pub mod pallet {
 		}
 	}
 
-	/// State reads for the non-fungibles API with required input.
+	/// State reads for the non-fungibles API with required inputs.
 	#[derive(Encode, Decode, Debug, MaxEncodedLen)]
 	#[cfg_attr(feature = "std", derive(PartialEq, Clone))]
 	#[repr(u8)]
 	#[allow(clippy::unnecessary_cast)]
 	pub enum Read<T: Config> {
-		/// Returns the amount of items the owner has within a `collection`.
+		/// Returns the number of items the owner has within a `collection`.
 		#[codec(index = 0)]
 		BalanceOf {
 			/// The collection.
@@ -574,7 +574,7 @@ pub mod pallet {
 		GetAttribute {
 			/// The collection.
 			collection: CollectionIdOf<T>,
-			/// The item. If `None` the attributes for the collection are queried.
+			/// The item. If `None`, the attributes for the collection are queried.
 			item: Option<ItemIdOf<T>>,
 			/// The attribute's namespace.
 			namespace: AttributeNamespaceOf<T>,
@@ -598,17 +598,17 @@ pub mod pallet {
 	#[derive(Debug)]
 	#[cfg_attr(feature = "std", derive(PartialEq, Clone))]
 	pub enum ReadResult<T: Config> {
-		/// Returns the amount of items the owner has within a collection.
+		/// Returns the number of items the owner has within a collection.
 		BalanceOf(u32),
 		/// Returns the owner of an item within a specified collection, if any.
 		OwnerOf(Option<AccountIdOf<T>>),
-		/// Returns whether the operator is approved by the owner to withdraw item. If item is not
-		/// provided, it returns whether the operator is approved to withdraw all owner's items for
-		/// the given collection.
+		/// Returns whether the operator is approved by the owner to withdraw an item. If an item
+		/// is not provided, it returns whether the operator is approved to withdraw all owner's
+		/// items for the given collection.
 		Allowance(bool),
 		/// Returns the total supply of a collection.
 		TotalSupply(u128),
-		/// Returns the attribute value of item for a given key, if any.
+		/// Returns the attribute value of an item for a given key, if any.
 		GetAttribute(Option<Vec<u8>>),
 		/// Returns the next collection identifier, if any.
 		NextCollectionId(Option<CollectionIdOf<T>>),

--- a/pop-api/integration-tests/src/nonfungibles/mod.rs
+++ b/pop-api/integration-tests/src/nonfungibles/mod.rs
@@ -673,16 +673,16 @@ fn mint_works() {
 
 		// Collection does not exist, throws module error `NoConfig`.
 		assert_eq!(
-			mint(&addr, COLLECTION, ALICE, ITEM, None),
+			mint(&addr, ALICE, COLLECTION, ITEM, None),
 			Err(Module { index: 50, error: [31, 0] })
 		);
 		// Successfully mint.
 		let collection = nfts::create_collection(&addr, &addr);
-		assert_ok!(mint(&addr, collection, ALICE, ITEM, None));
+		assert_ok!(mint(&addr, ALICE, collection, ITEM, None));
 		assert_eq!(nfts::balance_of(collection, ALICE), 1);
 		// Minting an existing item ID.
 		assert_eq!(
-			mint(&addr, collection, ALICE, ITEM, None),
+			mint(&addr, ALICE, collection, ITEM, None),
 			Err(Module { index: 50, error: [2, 0] })
 		);
 	});

--- a/pop-api/integration-tests/src/nonfungibles/utils.rs
+++ b/pop-api/integration-tests/src/nonfungibles/utils.rs
@@ -244,12 +244,12 @@ pub(super) fn clear_collection_approvals(
 
 pub(super) fn mint(
 	addr: &AccountId32,
-	collection: CollectionId,
 	to: AccountId32,
+	collection: CollectionId,
 	item: ItemId,
 	witness: Option<MintWitness>,
 ) -> Result<(), Error> {
-	let params = [collection.encode(), to.encode(), item.encode(), witness.encode()].concat();
+	let params = [to.encode(), collection.encode(), item.encode(), witness.encode()].concat();
 	let result = do_bare_call("mint", &addr, params);
 	decoded::<Result<(), Error>>(result.clone())
 		.unwrap_or_else(|_| panic!("Contract reverted: {:?}", result))

--- a/pop-api/src/v0/nonfungibles/mod.rs
+++ b/pop-api/src/v0/nonfungibles/mod.rs
@@ -24,7 +24,7 @@ pub mod events;
 pub mod traits;
 pub mod types;
 
-/// Returns the amount of items the owner has within a collection.
+/// Returns the number of items the owner has within a collection.
 ///
 /// # Parameters
 /// - `collection` - The collection.
@@ -60,7 +60,7 @@ pub fn owner_of(collection: CollectionId, item: ItemId) -> Result<Option<Account
 /// - `collection` - The collection.
 /// - `owner` - The account that owns the item(s).
 /// - `operator` - the account that is allowed to withdraw the item(s).
-/// - `item` - The item. If `None`, it is regarding all owner's items in collection.
+/// - `item` - The item. If `None`, it is all owner's items in the collection.
 #[inline]
 pub fn allowance(
 	collection: CollectionId,
@@ -204,7 +204,7 @@ pub fn destroy(collection: CollectionId, witness: DestroyWitness) -> Result<()> 
 /// - `CollectionOwner` namespace could be modified by the `collection` Admin only;
 /// - `ItemOwner` namespace could be modified by the `item` owner only. `item` should be set in that
 ///   case;
-/// - `Account(AccountId)` namespace could be modified only when the provided account was given a
+/// - `Account(AccountId)` namespace could be modified only when the provided account was given
 ///   permission to do so;
 ///
 /// # Parameters
@@ -303,7 +303,7 @@ pub fn set_max_supply(collection: CollectionId, max_supply: u32) -> Result<()> {
 /// Caller must be the owner of the item.
 ///
 /// # Parameters
-/// - `collection` - The colleciton.
+/// - `collection` - The collection.
 /// - `item` - The item.
 /// - `delegate` - The account to delegate permission to change attributes of the item.
 #[inline]
@@ -319,7 +319,7 @@ pub fn approve_item_attributes(
 		.call(&(collection, item, delegate))
 }
 
-/// Cancel the previously provided approval to change item's attributes.
+/// Cancel the previously provided approval to change the item's attributes.
 /// All the previously set attributes by the `delegate` will be removed.
 ///
 /// # Parameters
@@ -327,7 +327,6 @@ pub fn approve_item_attributes(
 /// - `item` - The item that holds attributes.
 /// - `delegate` - The previously approved account to remove.
 /// - `witness` - A witness data to cancel attributes approval operation.
-/// The account to delegate permission to change attributes of the item.
 #[inline]
 pub fn cancel_item_attributes_approval(
 	collection: CollectionId,
@@ -360,7 +359,7 @@ pub fn clear_all_transfer_approvals(collection: CollectionId, item: ItemId) -> R
 ///
 /// # Parameters
 /// - `collection` - The collection.
-/// - `limit` - The amount of collection approvals that will be cleared.
+/// - `limit` - The number of collection approvals that will be cleared.
 #[inline]
 pub fn clear_collection_approvals(collection: CollectionId, limit: u32) -> Result<()> {
 	build_dispatch(CLEAR_COLLECTION_APPROVALS)
@@ -394,7 +393,7 @@ pub fn mint(
 /// Destroys the specified item. Clearing the corresponding approvals.
 ///
 /// # Parameters
-/// - `collection` - The colleciton.
+/// - `collection` - The collection.
 /// - `item` - The item.
 #[inline]
 pub fn burn(collection: CollectionId, item: ItemId) -> Result<()> {

--- a/pop-api/src/v0/nonfungibles/mod.rs
+++ b/pop-api/src/v0/nonfungibles/mod.rs
@@ -385,10 +385,10 @@ pub fn mint(
 	witness: Option<MintWitness>,
 ) -> Result<()> {
 	build_dispatch(MINT)
-		.input::<(AccountId, CollectionId, ItemId, Option<MintWitness>)>()
+		.input::<(CollectionId, AccountId, ItemId, Option<MintWitness>)>()
 		.output::<Result<()>, true>()
 		.handle_error_code::<StatusCode>()
-		.call(&(to, collection, item, witness))
+		.call(&(collection, to, item, witness))
 }
 
 /// Destroys the specified item. Clearing the corresponding approvals.


### PR DESCRIPTION
The implementation of the `mint` function of the non-fungibles api within the ink! library does not match the `nonfungibles::mint` dispatchable.

Also addresses language and typos highlighted by IDE.