### PR TITLE
ci: enable concurrency controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
 
+concurrency:
+  # Cancel any in-progress jobs for the same pull request
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ensures there is only ever one active workflow running per PR. 

Already implemented at https://github.com/r0gue-io/pop-cli/blob/main/.github/workflows/ci.yml#L13.