### PR TITLE
refactor(devnet): update contracts config

### DIFF
--- a/runtime/devnet/src/config/contracts.rs
+++ b/runtime/devnet/src/config/contracts.rs
@@ -43,7 +43,8 @@ parameter_types! {
 	pub const DepositPerByte: Balance = deposit(0, 1);
 	pub Schedule: pallet_contracts::Schedule<Runtime> = schedule::<Runtime>();
 	pub const DefaultDepositLimit: Balance = deposit(1024, 1024 * 1024);
-	pub const CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);
+	// 30 percent of storage deposit held for using a code hash.
+	pub const CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
 	pub const NativeToEthRatio: u32 = (ETH/UNIT) as u32;
 }
 
@@ -95,7 +96,6 @@ impl pallet_revive::Config for Runtime {
 	type CallFilter = Nothing;
 	type ChainExtension = ();
 	type ChainId = ChainId;
-	// 30 percent of storage deposit held for using a code hash.
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type Currency = Balances;
 	type Debug = ();

--- a/runtime/devnet/src/config/contracts.rs
+++ b/runtime/devnet/src/config/contracts.rs
@@ -38,6 +38,7 @@ impl<T: pallet_contracts::Config> Randomness<T::Hash, BlockNumberFor<T>> for Dum
 const ETH: u128 = 1_000_000_000_000_000_000;
 
 parameter_types! {
+	pub ChainId: u64 = u32::from(crate::genesis::PARA_ID) as u64;
 	pub const DepositPerItem: Balance = deposit(1, 0);
 	pub const DepositPerByte: Balance = deposit(0, 1);
 	pub Schedule: pallet_contracts::Schedule<Runtime> = schedule::<Runtime>();
@@ -93,8 +94,7 @@ impl pallet_revive::Config for Runtime {
 	// No runtime dispatchables are callable from contracts.
 	type CallFilter = Nothing;
 	type ChainExtension = ();
-	// EVM chain id. 3,395 is a unique ID still.
-	type ChainId = ConstU64<3_395>;
+	type ChainId = ChainId;
 	// 30 percent of storage deposit held for using a code hash.
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type Currency = Balances;


### PR DESCRIPTION
Updates the contracts config in the devnet PR to use para id from genesis as chain id, as well as aligns `CodeHashLockupDepositPercent` with the value used in the mainnet runtime.