### PR TITLE
chore(api/examples/fungible): bump drink version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         working-directory: pop-api
         run: cargo test --release --locked --all-features
 
-  api-examples:
+  api-examples-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -176,15 +176,15 @@ jobs:
       - name: Install `cargo-contract`
         run: cargo install --force --locked cargo-contract
 
-      - name: Check example contracts
+      - name: Test example contracts
         working-directory: pop-api/examples
         shell: bash
         run: |
           set -e
           for example in */ ; do
             if [ -d "$example" ]; then
-              echo "Checking contract in $example"
-              (cd "$example" && cargo contract check)
+              echo "Test contract in $example"
+              (cd "$example" && cargo test --release)
             fi
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,6 @@ jobs:
 
       - uses: "./.github/actions/init"
 
-      - name: Install `cargo-contract`
-        run: cargo install --force --locked cargo-contract
-
       - name: Test example contracts
         working-directory: pop-api/examples
         shell: bash

--- a/pop-api/examples/fungibles/Cargo.toml
+++ b/pop-api/examples/fungibles/Cargo.toml
@@ -11,7 +11,7 @@ pop-api = { path = "../../../pop-api", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-drink = { package = "pop-drink", git = "https://github.com/r0gue-io/pop-drink", branch = "chungquantin/chore-stable2503", features = [ "devnet" ] }
+drink = { package = "pop-drink", git = "https://github.com/r0gue-io/pop-drink", features = [ "devnet" ] }
 env_logger = { version = "0.11.3" }
 serde_json = "1.0.114"
 

--- a/pop-api/examples/fungibles/Cargo.toml
+++ b/pop-api/examples/fungibles/Cargo.toml
@@ -11,7 +11,7 @@ pop-api = { path = "../../../pop-api", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-drink = { package = "pop-drink", git = "https://github.com/r0gue-io/pop-drink" }
+drink = { package = "pop-drink", git = "https://github.com/r0gue-io/pop-drink", branch = "chungquantin/chore-stable2503", features = [ "devnet" ] }
 env_logger = { version = "0.11.3" }
 serde_json = "1.0.114"
 

--- a/pop-api/examples/fungibles/tests.rs
+++ b/pop-api/examples/fungibles/tests.rs
@@ -3,7 +3,7 @@ use drink::{
 	devnet::{
 		account_id_from_slice,
 		error::{
-			v0::{ApiError::*, ArithmeticError::*, Error},
+			v0::{ApiError::*, ArithmeticError::*, Error, TokenError::UnknownAsset},
 			Assets,
 			AssetsError::*,
 		},
@@ -557,7 +557,7 @@ fn mint_fails_with_token_not_live(mut session: Session) {
 	// Token is not live, i.e. frozen or being destroyed.
 	assert_ok!(session.sandbox().start_destroy(&TOKEN));
 	// `pallet-assets` returns `AssetNotLive` error.
-	assert_err!(mint(&mut session, ALICE, AMOUNT), Error::Module(Assets(AssetNotLive)));
+	assert_err!(mint(&mut session, ALICE, AMOUNT), Error::Raw(Token(UnknownAsset)));
 }
 
 #[drink::test(sandbox = Pop)]

--- a/pop-api/examples/fungibles/tests.rs
+++ b/pop-api/examples/fungibles/tests.rs
@@ -556,7 +556,7 @@ fn mint_fails_with_token_not_live(mut session: Session) {
 	session.set_actor(ALICE);
 	// Token is not live, i.e. frozen or being destroyed.
 	assert_ok!(session.sandbox().start_destroy(&TOKEN));
-	// `pallet-assets` returns `AssetNotLive` error.
+	// `pallet-assets` returns `UnknownAsset` error.
 	assert_err!(mint(&mut session, ALICE, AMOUNT), Error::Raw(Token(UnknownAsset)));
 }
 


### PR DESCRIPTION
Update to use the latest version of pop-drink that is bumped to stable2503, compatible with the current codebase of pop-node. Requires https://github.com/r0gue-io/pop-drink/pull/30 to be merged first. 