### PR TITLE
fix(contract-example): enable devnet feature for fungibles drink tests

### DIFF
--- a/pop-api/examples/fungibles/Cargo.toml
+++ b/pop-api/examples/fungibles/Cargo.toml
@@ -11,7 +11,7 @@ pop-api = { path = "../../../pop-api", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-drink = { package = "pop-drink", git = "https://github.com/r0gue-io/pop-drink" }
+drink = { package = "pop-drink", git = "https://github.com/r0gue-io/pop-drink", features = [ "devnet" ] }
 env_logger = { version = "0.11.3" }
 serde_json = "1.0.114"
 


### PR DESCRIPTION
Example fungibles contract tests expect the devnet configuration from drink. As per https://github.com/r0gue-io/pop-drink/pull/30 now we enable testnet by default.

This change enables `devnet` such that we keep the same behavior after the linked PR is merged.

NOTE: only merge this after https://github.com/r0gue-io/pop-drink/pull/30 has been merged.