### PR TITLE
refactor(revive): enable unstable host fn

### DIFF
--- a/runtime/devnet/src/config/contracts.rs
+++ b/runtime/devnet/src/config/contracts.rs
@@ -111,8 +111,8 @@ impl pallet_revive::Config for Runtime {
 	// 128 MB. Used in an integrity that verifies the runtime has enough memory.
 	type RuntimeMemory = ConstU32<{ 128 * 1024 * 1024 }>;
 	type Time = Timestamp;
-	// Disables access to unsafe host fns such as xcm_send.
-	type UnsafeUnstableInterface = ConstBool<false>;
+	// Enables access to unsafe host fns such as xcm_send.
+	type UnsafeUnstableInterface = ConstBool<true>;
 	type UploadOrigin = EnsureSigned<Self::AccountId>;
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
 	type WeightPrice = TransactionPayment;

--- a/runtime/testnet/src/config/contracts.rs
+++ b/runtime/testnet/src/config/contracts.rs
@@ -111,8 +111,8 @@ impl pallet_revive::Config for Runtime {
 	// 128 MB. Used in an integrity that verifies the runtime has enough memory.
 	type RuntimeMemory = ConstU32<{ 128 * 1024 * 1024 }>;
 	type Time = Timestamp;
-	// Disables access to unsafe host fns such as xcm_send.
-	type UnsafeUnstableInterface = ConstBool<false>;
+	// Enables access to unsafe host fns such as xcm_send.
+	type UnsafeUnstableInterface = ConstBool<true>;
 	type UploadOrigin = EnsureSigned<Self::AccountId>;
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
 	type WeightPrice = TransactionPayment;


### PR DESCRIPTION
Enables access to unstable host functions for contracts deployed on revive in devnet and testnet.

As an example, this is required for contracts to use fns like `xcm_send`, [which ink! is a user of](https://github.com/use-ink/ink/blob/d71802f482dc129b199c71715f9910e2d7d4e318/crates/env/src/backend.rs#L471).
A complete list of all host functions, stable and unstable, can be found at: https://github.com/paritytech/polkadot-sdk/blob/f73c228b7a1a4a6b7d80ae7917a61df62f2359b8/substrate/frame/revive/uapi/src/host.rs#L24

I was able to deploy an ink! contract with the unstable hostfn feature enabled without issues.

### Notice to users:

While we are making these functions directly accessible to contracts, the general approach within the ecosystem is to expose them through specific pre-compiles. Therefore, this change may be reverted in the future in favor of using the pop-api and built-in pre-compiles. By enabling access to these functions now, ink! users can fully explore the language's features.

As a result, every ink! contract that intends to use this set of functions must be built with the `unstable-hostfn` feature. Like so:

```toml
ink = { version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
```

[Example contract using XCM](https://github.com/use-ink/ink-examples/tree/v6.x/contract-xcm)