### PR TITLE
refactor(ci): build runtimes using production profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
           chain: ${{ env.RUNTIME }}
           package: "pop-runtime-${{ env.RUNTIME }}"
           runtime_dir: "runtime/${{ env.RUNTIME }}"
+          profile: "production"
 
       - name: Store srtool digest to disk
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
           chain: ${{ env.RUNTIME }}
           package: "pop-runtime-${{ env.RUNTIME }}"
           runtime_dir: "runtime/${{ env.RUNTIME }}"
+          # We use production profile primarily as a way to reduce the resulting wasm size.
           profile: "production"
 
       - name: Store srtool digest to disk


### PR DESCRIPTION
Adds `production` profile to sr-tool runtime build flow in releases.

Aside from other benefits of running building with the production profile the main driver for this change has been pursuing a smaller size in the resulting wasm blob.

The resulting uncompressed runtime should result in a size around `10.1 MB` based on [a prior build](https://github.com/r0gue-io/pop-node/actions/runs/15047519554).