### PR TITLE
chore: `pop-runtime-testnet` v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14157,7 +14157,7 @@ dependencies = [
 
 [[package]]
 name = "pop-runtime-testnet"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "cumulus-pallet-aura-ext 0.20.0",

--- a/pop-api/examples/fungibles/Cargo.toml
+++ b/pop-api/examples/fungibles/Cargo.toml
@@ -11,7 +11,7 @@ pop-api = { path = "../../../pop-api", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-drink = { package = "pop-drink", git = "https://github.com/r0gue-io/pop-drink", features = [ "devnet" ] }
+drink = { package = "pop-drink", git = "https://github.com/r0gue-io/pop-drink", tag = "stable-2503-4", features = [ "devnet" ] }
 env_logger = { version = "0.11.3" }
 serde_json = "1.0.114"
 

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -6,7 +6,7 @@ homepage.workspace = true
 license = "Unlicense"
 name = "pop-runtime-testnet"
 repository.workspace = true
-version = "0.5.2"
+version = "0.5.3"
 
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -252,7 +252,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: Cow::Borrowed("pop"),
 	authoring_version: 1,
 	#[allow(clippy::zero_prefixed_literal)]
-	spec_version: 00_05_02,
+	spec_version: 00_05_03,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
Bump versions and ready `pop-runtime-testnet` for the release of version 0.5.3.