### PR TITLE
fix(ci): pin stable-1.86 version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,6 @@
 [toolchain]
-channel = "stable"
+# Release of Rust 1.87.0 introduced issues on CI making tests involving instantiation of wasm smart contracts fail.
+# Pinning version to stable 1.86 until resolved.
+channel = "1.86.0"
 components = [ "clippy", "llvm-tools-preview", "rust-src", "rustfmt" ]
 targets = [ "wasm32v1-none" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Release of Rust 1.87.0 introduced issues on CI making tests involving instantiation of wasm smart contracts fail.
 # Pinning version to stable 1.86 until resolved.
-channel = "1.86.0"
+channel = "1.86"
 components = [ "clippy", "llvm-tools-preview", "rust-src", "rustfmt" ]
 targets = [ "wasm32v1-none" ]


### PR DESCRIPTION
The release of rust 1.87.0 introduced issues on CI making tests involving instantiation of wasm smart contracts fail.
Pinning version to stable 1.86.0 instead of latest stable until resolved.