### PR TITLE
fix(proxy): NonTrasnfer Proxy rejects contracts related calls

### DIFF
--- a/runtime/devnet/src/config/proxy.rs
+++ b/runtime/devnet/src/config/proxy.rs
@@ -22,7 +22,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				c,
 				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
 					RuntimeCall::Utility { .. } |
-					RuntimeCall::Multisig { .. }
+					RuntimeCall::Multisig { .. } |
+					RuntimeCall::Revive { .. } |
+					RuntimeCall::Contracts { .. }
 			),
 			ProxyType::Assets => {
 				matches!(

--- a/runtime/mainnet/src/config/proxy.rs
+++ b/runtime/mainnet/src/config/proxy.rs
@@ -11,7 +11,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => !matches!(c, RuntimeCall::Balances { .. }),
+			ProxyType::NonTransfer =>
+				!matches!(c, RuntimeCall::Balances { .. } | RuntimeCall::Revive { .. }),
 			ProxyType::CancelProxy => matches!(
 				c,
 				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }) |

--- a/runtime/testnet/src/config/proxy.rs
+++ b/runtime/testnet/src/config/proxy.rs
@@ -17,7 +17,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				c,
 				RuntimeCall::Balances { .. } |
 					RuntimeCall::Assets { .. } |
-					RuntimeCall::Nfts { .. }
+					RuntimeCall::Nfts { .. } |
+					RuntimeCall::Revive { .. } |
+					RuntimeCall::Contracts { .. }
 			),
 			ProxyType::CancelProxy => matches!(
 				c,


### PR DESCRIPTION
Solved #574 by filtering our contract related calls for `NonTransfer` proxy type.
As contracts are able to transfer funds a call, users of `NonTrasnfer` proxy could have bypassed the purpose of said account prior to this change.