### PR TITLE
chore(testnet): v0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14157,7 +14157,7 @@ dependencies = [
 
 [[package]]
 name = "pop-runtime-testnet"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "cumulus-pallet-aura-ext 0.20.0",

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -6,7 +6,7 @@ homepage.workspace = true
 license = "Unlicense"
 name = "pop-runtime-testnet"
 repository.workspace = true
-version = "0.5.3"
+version = "0.5.4"
 
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]

--- a/runtime/testnet/src/config/collation.rs
+++ b/runtime/testnet/src/config/collation.rs
@@ -40,7 +40,7 @@ impl pallet_collator_selection::Config for Runtime {
 	type KickThreshold = Period;
 	type MaxCandidates = ConstU32<100>;
 	type MaxInvulnerables = ConstU32<20>;
-	type MinEligibleCollators = ConstU32<2>;
+	type MinEligibleCollators = ConstU32<1>;
 	type PotId = PotId;
 	type RuntimeEvent = RuntimeEvent;
 	type UpdateOrigin = CollatorSelectionUpdateOrigin;

--- a/runtime/testnet/src/config/collation.rs
+++ b/runtime/testnet/src/config/collation.rs
@@ -40,7 +40,7 @@ impl pallet_collator_selection::Config for Runtime {
 	type KickThreshold = Period;
 	type MaxCandidates = ConstU32<100>;
 	type MaxInvulnerables = ConstU32<20>;
-	type MinEligibleCollators = ConstU32<4>;
+	type MinEligibleCollators = ConstU32<2>;
 	type PotId = PotId;
 	type RuntimeEvent = RuntimeEvent;
 	type UpdateOrigin = CollatorSelectionUpdateOrigin;

--- a/runtime/testnet/src/config/system.rs
+++ b/runtime/testnet/src/config/system.rs
@@ -174,7 +174,7 @@ impl pallet_migrations::Config for Runtime {
 	type MaxServiceWeight = MbmServiceWeight;
 	type MigrationStatusHandler = ();
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Migrations = pallet_migrations::migrations::ResetPallet<Runtime, Revive>;
+	type Migrations = ();
 	// Benchmarks need mocked migrations to guarantee that they succeed.
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = pallet_migrations::mock_helpers::MockedMigrations;

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -159,19 +159,6 @@ pub type UncheckedExtrinsic =
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
 pub type Migrations = (
 	// Note the multi-block migrations configured in pallet_migrations are not present here.
-	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
-	// Unreleased.
-	pallet_assets::migration::next_asset_id::SetNextAssetId<
-		// Higher AssetId on testnet live is `7_045`,
-		// rounded up to 10_000.
-		ConstU32<10_000>,
-		Runtime,
-		TrustBackedAssetsInstance,
-	>,
-	pallet_session::migrations::v1::MigrateV0ToV1<
-		Runtime,
-		pallet_session::migrations::v1::InitOffenceSeverity<Runtime>,
-	>,
 	// Permanent.
 	cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
 	pallet_contracts::Migration<Runtime>,

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -252,7 +252,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: Cow::Borrowed("pop"),
 	authoring_version: 1,
 	#[allow(clippy::zero_prefixed_literal)]
-	spec_version: 00_05_03,
+	spec_version: 00_05_04,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
These changes prepare a new release for pop's testnet runtime.

Mainly lowering `MinEligibleCollators` to `1` and removing the already released migrations.

The reason behind the value of `1` as the minimum amount of eligible collators is that to reduce the number of collators in the set we need the following condition to compute true:

```
ensure!(
	Self::eligible_collators() > T::MinEligibleCollators::get(),
	Error::<T>::TooFewEligibleCollators
);
```

Given no candidates at the moment and only `3` invulnerables. `elegible_collators` (candidates + invulnerables) won't be greater than the current value set for `MinEligibleCollators`.

By setting this value to `1` we will be able to modify the number of collators in the future without blockers if needed.